### PR TITLE
Whisper: Fix crash on disconnect from 0.12 router

### DIFF
--- a/android/Whisper/src/de/tubs/ibr/dtn/chat/MeFragment.java
+++ b/android/Whisper/src/de/tubs/ibr/dtn/chat/MeFragment.java
@@ -36,6 +36,7 @@ public class MeFragment extends Fragment implements View.OnClickListener {
 	
 	// Security API provided by IBR-DTN
 	private SecurityService mSecurityService = null;
+	private boolean mSecurityBound = false;
 	
 	// Security action item
 	private MenuItem mItemKeyInfo = null;
@@ -117,6 +118,7 @@ public class MeFragment extends Fragment implements View.OnClickListener {
 		// Establish a connection with the security service
 		try {
 			Services.SERVICE_SECURITY.bind(getActivity(), mSecurityConnection, Context.BIND_AUTO_CREATE);
+			mSecurityBound = true;
 		} catch (ServiceNotAvailableException e) {
 			// Security API not available
 		}
@@ -124,7 +126,10 @@ public class MeFragment extends Fragment implements View.OnClickListener {
 
 	@Override
 	public void onStop() {
-		getActivity().unbindService(mSecurityConnection);
+		if (mSecurityBound) {
+		    getActivity().unbindService(mSecurityConnection);
+		    mSecurityBound = false;
+		}
 		
 		super.onStop();
 	}

--- a/android/Whisper/src/de/tubs/ibr/dtn/chat/MessageFragment.java
+++ b/android/Whisper/src/de/tubs/ibr/dtn/chat/MessageFragment.java
@@ -46,6 +46,7 @@ public class MessageFragment extends Fragment {
 	
 	// Security API provided by IBR-DTN
 	private SecurityService mSecurityService = null;
+	private boolean mSecurityBound = false;
 	
 	private ServiceConnection mSecurityConnection = new ServiceConnection() {
 		public void onServiceConnected(ComponentName name, IBinder service) {
@@ -246,6 +247,7 @@ public class MessageFragment extends Fragment {
 		// Establish a connection with the security service
 		try {
 			Services.SERVICE_SECURITY.bind(getActivity(), mSecurityConnection, Context.BIND_AUTO_CREATE);
+			mSecurityBound = true;
 		} catch (ServiceNotAvailableException e) {
 			// Security API not available
 		}
@@ -271,7 +273,10 @@ public class MessageFragment extends Fragment {
 
 	@Override
 	public void onStop() {
-		getActivity().unbindService(mSecurityConnection);
+		if (mSecurityBound) {
+		    getActivity().unbindService(mSecurityConnection);
+		    mSecurityBound = false;
+		}
 		
 		super.onStop();
 	}


### PR DESCRIPTION
When trunk Whisper is run with 0.12 IBR-DTN router, it crashes when the
contact list or message list windows are closed. This is because
binding the security connection fails. The bind exception is caught,
but then attempting to unbind it causes an unrecoverable error. Track
the connection bind status so Whisper does not attempt to unbind an
unbound connection.
