### PR TITLE
Missing cast from reference to pointer

### DIFF
--- a/ibrcommon/ibrcommon/Logger.cpp
+++ b/ibrcommon/ibrcommon/Logger.cpp
@@ -166,7 +166,7 @@ namespace ibrcommon
 		{
 			const LoggerOutput &output = (*iter);
 
-			if ((void*)stream == (void*)output._stream)
+			if ((void*)&stream == (void*)(&(output._stream)))
 			{
 				iter = _logger.erase(iter);
 			}


### PR DESCRIPTION
OS X/clang build failed with 

Logger.cpp:169:8: error: cannot cast from type 'std::ostream' (aka 'basic_ostream<char>') to pointer type 'void _'
                        if ((void_)stream == (void_)output._stream)
                            ^~~~~~~~~~~~~
Logger.cpp:169:25: error: cannot cast from type 'std::ostream' (aka 'basic_ostream<char>') to pointer type 'void *'
                        if ((void_)stream == (void*)output._stream)
                                             ^~~~~~~~~~~~~~~~~~~~~

because stream and LoggerOutput._stream are references. Need an & operator before casting
