### PR TITLE
ibrcommon: Improved error checking on RWMutex locking.

### DIFF
--- a/ibrcommon/ibrcommon/thread/RWMutex.cpp
+++ b/ibrcommon/ibrcommon/thread/RWMutex.cpp
@@ -44,6 +44,11 @@ namespace ibrcommon
 		case EBUSY:
 			throw MutexException("The mutex could not be acquired because it was already locked.");
 			break;
+		case EDEADLK:
+			throw MutexException("The mutex could not be acquired because the current thread already locked it.");
+			break;
+		default:
+			throw MutexException("The mutex could not be acquired. Reason unknown.");
 		}
 	}
 
@@ -67,6 +72,11 @@ namespace ibrcommon
 		case EBUSY:
 			throw MutexException("The mutex could not be acquired because it was already locked.");
 			break;
+		case EDEADLK:
+			throw MutexException("The mutex could not be acquired because the current thread already locked it.");
+			break;
+		default:
+			throw MutexException("The mutex could not be acquired. Reason unknown.");
 		}
 	}
 


### PR DESCRIPTION
ibrcommon unit tests on OS X failed:

thread/MutexTests.cpp:116: Assertion
Test name: MutexTests::rwmutex_test_readwrite
expected exception not thrown
- Expected: ibrcommon::MutexException

RWMutex did not check all error conditions. Explicitly added the condition flagged by OS X during the unit tests and added a default case always throwing an exception when the locking does not succeed.
