### PR TITLE
daemon: Fix wrong string concatenation in NativeDaemon.cpp

### DIFF
--- a/ibrdtn/daemon/src/NativeDaemon.cpp
+++ b/ibrdtn/daemon/src/NativeDaemon.cpp
@@ -266,7 +266,9 @@ namespace dtn
 			{
 				// add fragmentation values
 				data.push_back("Fragmentoffset: " + b.fragmentoffset.toString());
-				data.push_back("Fragmentpayload: " + b.getPayloadLength());
+				std::stringstream fpll;
+				fpll << "Fragmentpayload: " << b.getPayloadLength();
+				data.push_back(fpll.str());
 			}
 		}
 


### PR DESCRIPTION
A bit ugly. std::to_string() is nicer, but it is only supported since C++11, and I guess we might support older stuff.
