### PR TITLE
Fix unittests for BundleSet if sqlite supported is not included in the build

### DIFF
--- a/ibrdtn/daemon/tests/unittests/BundleSetTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/BundleSetTest.cpp
@@ -49,6 +49,8 @@ void BundleSetTest::setUp()
 		_storage = new dtn::storage::MemoryBundleStorage();
 
 		ibrcommon::File path("/tmp/memory-bundleset-test");
+		if (path.exists()) path.remove(true);
+
 		MemoryBundleSet::setPath(path);
 		break;
 	}


### PR DESCRIPTION
These patches fixes #47.
