### PR TITLE
ibrdtn: Make non-reference clocks independent from outer clock adjustments

### DIFF
--- a/ibrdtn/ibrdtn/ibrdtn/utils/Clock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/utils/Clock.h
@@ -206,10 +206,14 @@ namespace dtn
 			static dtn::data::Timestamp __getExpireTime(const dtn::data::Timestamp &timestamp, const dtn::data::Number &lifetime);
 
 			static struct timespec __get_monotonic_ts();
+			static struct timeval __get_clock_reference();
+			static struct timeval __initialize_clock();
+
+			static void __monotonic_gettimeofday(struct timeval *tv);
 
 			static struct timeval _offset;
-			static bool _offset_init;
 
+			static struct timeval __clock_reference;
 			static struct timespec _uptime_reference;
 		};
 	}


### PR DESCRIPTION
Before this patch it was possible to disturb the time-synchronization process by
setting the hosts clock individually. Now, a reference is recorded at the start and
adjustments are applied to this value. The current time-stamp is then calculated using
the BOOT_TIME / MONOTONIC_TIME of the host and the previously stored reference.
That way it is not possible change internal clock by setting the host time.
