### PR TITLE
android-daemon: Enforce Holo design on v11 and up

### DIFF
--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -71,7 +71,7 @@
 	<uses-sdk android:minSdkVersion="9" android:targetSdkVersion="20" />
 
 	<application android:allowBackup="true" android:icon="@drawable/ic_launcher"
-		android:label="@string/app_name">
+		android:label="@string/app_name" android:theme="@style/AppTheme">
 		<activity android:name=".daemon.Preferences" android:icon="@drawable/ic_launcher"
 			android:label="@string/app_name" android:uiOptions="splitActionBarWhenNarrow">
 			<intent-filter>

--- a/android/ibrdtn/res/values-v11/styles.xml
+++ b/android/ibrdtn/res/values-v11/styles.xml
@@ -1,0 +1,11 @@
+<resources>
+
+    <!--
+        Base application theme for API 11+. This theme completely replaces
+        AppBaseTheme from res/values/styles.xml on API 11+ devices.
+    -->
+    <style name="AppBaseTheme" parent="android:Theme.Holo">
+        <!-- API 11 theme customizations can go here. -->
+    </style>
+
+</resources>

--- a/android/ibrdtn/res/values/styles.xml
+++ b/android/ibrdtn/res/values/styles.xml
@@ -9,4 +9,21 @@
     </style>
     
     <color name="selected_item_background">#40ffffff</color>
+    
+    <!--
+        Base application theme, dependent on API level. This theme is replaced
+        by AppBaseTheme from res/values-vXX/styles.xml on newer devices.
+    -->
+    <style name="AppBaseTheme" parent="android:Theme">
+        <!--
+            Theme customizations available in newer API levels can go in
+            res/values-vXX/styles.xml, while customizations related to
+            backward-compatibility can go here.
+        -->
+    </style>
+
+    <!-- Application theme. -->
+    <style name="AppTheme" parent="AppBaseTheme">
+        <!-- All customizations that are NOT specific to a particular API-level can go here. -->
+    </style>
 </resources>


### PR DESCRIPTION
Android L applies material design by default. Since that theme does not include a
home button, the ShowcaseView fails. As long as this issue is not solved, we have
to disable material design completely.
