### PR TITLE
daemon: Reduce pro-active exchange of routing data if PRoPHET routing is active

### DIFF
--- a/ibrdtn/daemon/etc/ibrdtnd.conf
+++ b/ibrdtn/daemon/etc/ibrdtnd.conf
@@ -299,8 +299,6 @@ routing = prophet
 #prophet_time_unit = 1                #time unit in seconds
 #prophet_i_typ = 300                  #typical time interval between two node
                                       #encounters
-#prophet_next_exchange_timeout = 60   #timeout how often handshakes should be
-                                      #executed
 #prophet_forwarding_strategy = GRTR   #The forwarding strategy used GRTR | GTMX
 #prophet_gtmx_nf_max = 30             #Maximum times to forward in the GTMX
                                       #strategy

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -789,7 +789,6 @@ namespace dtn
 				_prophet_config.i_typ = conf.read<ibrcommon::Timer::time_t>("prophet_i_typ", 300);
 				if(_prophet_config.i_typ < 1)
 					_prophet_config.i_typ = 1;
-				_prophet_config.next_exchange_timeout = conf.read<ibrcommon::Timer::time_t>("prophet_next_exchange_timeout", 60);
 				_prophet_config.forwarding_strategy = conf.read<std::string>("prophet_forwarding_strategy", "GRTR");
 				_prophet_config.gtmx_nf_max = conf.read<unsigned int>("prophet_gtmx_nf_max", 30);
 			}

--- a/ibrdtn/daemon/src/Configuration.h
+++ b/ibrdtn/daemon/src/Configuration.h
@@ -285,7 +285,7 @@ namespace dtn
 				public:
 					ProphetConfig()
 					: p_encounter_max(0), p_encounter_first(0), p_first_threshold(0), beta(0), gamma(0), delta(0),
-					  time_unit(0), i_typ(0), next_exchange_timeout(0), forwarding_strategy(), gtmx_nf_max(0)
+					  time_unit(0), i_typ(0), forwarding_strategy(), gtmx_nf_max(0)
 					{ }
 
 					~ProphetConfig() { }
@@ -298,7 +298,6 @@ namespace dtn
 					float delta;
 					ibrcommon::Timer::time_t time_unit;
 					ibrcommon::Timer::time_t i_typ;
-					ibrcommon::Timer::time_t next_exchange_timeout;
 					std::string forwarding_strategy;
 					unsigned int gtmx_nf_max;
 				};

--- a/ibrdtn/daemon/src/NativeDaemon.cpp
+++ b/ibrdtn/daemon/src/NativeDaemon.cpp
@@ -1662,8 +1662,7 @@ namespace dtn
 				router.add( new dtn::routing::ProphetRoutingExtension(forwarding_strategy, prophet_config.p_encounter_max,
 												prophet_config.p_encounter_first, prophet_config.p_first_threshold,
 												prophet_config.beta, prophet_config.gamma, prophet_config.delta,
-												prophet_config.time_unit, prophet_config.i_typ,
-												prophet_config.next_exchange_timeout));
+												prophet_config.time_unit, prophet_config.i_typ));
 
 				// add neighbor routing (direct-delivery) extension
 				router.add( new dtn::routing::NeighborRoutingExtension() );

--- a/ibrdtn/daemon/src/routing/NeighborDatabase.cpp
+++ b/ibrdtn/daemon/src/routing/NeighborDatabase.cpp
@@ -88,6 +88,11 @@ namespace dtn
 			return _summary.has(id);
 		}
 
+		bool NeighborDatabase::NeighborEntry::isFilterValid() const
+		{
+			return (_filter_state == FILTER_AVAILABLE);
+		}
+
 		bool NeighborDatabase::NeighborEntry::isExpired(const dtn::data::Timestamp &timestamp) const
 		{
 			// expired after 15 minutes

--- a/ibrdtn/daemon/src/routing/NeighborDatabase.h
+++ b/ibrdtn/daemon/src/routing/NeighborDatabase.h
@@ -148,6 +148,12 @@ namespace dtn
 				bool isExpired(const dtn::data::Timestamp &timestamp) const;
 
 				/**
+				 * Returns true if the filter has been received before and is
+				 * still not expired.
+				 */
+				bool isFilterValid() const;
+
+				/**
 				 * Returns the last update of this entry
 				 */
 				const dtn::data::Timestamp& getLastUpdate() const;

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -45,10 +45,9 @@ namespace dtn
 		const std::string ProphetRoutingExtension::TAG = "ProphetRoutingExtension";
 
 		ProphetRoutingExtension::ProphetRoutingExtension(ForwardingStrategy *strategy, float p_encounter_max, float p_encounter_first, float p_first_threshold,
-								 float beta, float gamma, float delta, ibrcommon::Timer::time_t time_unit, ibrcommon::Timer::time_t i_typ,
-								 dtn::data::Timestamp next_exchange_timeout)
+								 float beta, float gamma, float delta, ibrcommon::Timer::time_t time_unit, ibrcommon::Timer::time_t i_typ)
 			: _deliveryPredictabilityMap(time_unit, beta, gamma),
-			  _forwardingStrategy(strategy), _next_exchange_timeout(next_exchange_timeout), _next_exchange_timestamp(0),
+			  _forwardingStrategy(strategy),
 			  _p_encounter_max(p_encounter_max), _p_encounter_first(p_encounter_first),
 			  _p_first_threshold(p_first_threshold), _delta(delta), _i_typ(i_typ)
 		{
@@ -57,9 +56,6 @@ namespace dtn
 
 			// set value for local EID to 1.0
 			_deliveryPredictabilityMap.set(core::BundleCore::local, 1.0);
-
-			// define the first exchange timestamp
-			_next_exchange_timestamp = dtn::utils::Clock::getMonotonicTimestamp() + _next_exchange_timeout;
 
 			try {
 				// set file to store prophet data
@@ -250,17 +246,6 @@ namespace dtn
 				// store persistent data to disk
 				if (_persistent_file.isValid()) store(_persistent_file);
 			}
-
-			ibrcommon::MutexLock l(_next_exchange_mutex);
-			const dtn::data::Timestamp now = dtn::utils::Clock::getMonotonicTimestamp();
-
-			if ((_next_exchange_timestamp > 0) && (_next_exchange_timestamp < now))
-			{
-				_taskqueue.push( new NextExchangeTask() );
-
-				// define the next exchange timestamp
-				_next_exchange_timestamp = now + _next_exchange_timeout;
-			}
 		}
 
 		void ProphetRoutingExtension::raiseEvent(const NodeHandshakeEvent &handshake) throw ()
@@ -392,9 +377,15 @@ namespace dtn
 						{
 							return false;
 						}
+
+						// check if the neighbor data is up-to-date
+						if (!_entry.isFilterValid()) throw dtn::storage::BundleSelectorException();
 					}
 					else
 					{
+						// check if the neighbor data is up-to-date
+						if (!_entry.isFilterValid()) throw dtn::storage::BundleSelectorException();
+
 						// if this is a non-singleton, check if the peer knows a way to the source
 						try {
 							if (_dpm.get(meta.source.getNode()) <= 0.0) return false;
@@ -509,24 +500,6 @@ namespace dtn
 						} catch (const dtn::storage::NoBundleFoundException &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(ProphetRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 						} catch (const std::bad_cast&) { }
-
-						/**
-						 * NextExchangeTask is a timer based event, that triggers
-						 * a new dp_map exchange for every connected node
-						 */
-						try {
-							dynamic_cast<NextExchangeTask&>(*t);
-
-							std::set<dtn::core::Node> neighbors = dtn::core::BundleCore::getInstance().getConnectionManager().getNeighbors();
-							std::set<dtn::core::Node>::const_iterator it;
-							for(it = neighbors.begin(); it != neighbors.end(); ++it)
-							{
-								try{
-									(**this).doHandshake(it->getEID());
-								} catch (const ibrcommon::Exception &ex) { }
-							}
-						} catch (const std::bad_cast&) { }
-
 					} catch (const ibrcommon::Exception &ex) {
 						IBRCOMMON_LOGGER_DEBUG_TAG(ProphetRoutingExtension::TAG, 20) << "task failed: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 					}
@@ -725,19 +698,6 @@ namespace dtn
 		std::string ProphetRoutingExtension::SearchNextBundleTask::toString() const
 		{
 			return "SearchNextBundleTask: " + eid.getString();
-		}
-
-		ProphetRoutingExtension::NextExchangeTask::NextExchangeTask()
-		{
-		}
-
-		ProphetRoutingExtension::NextExchangeTask::~NextExchangeTask()
-		{
-		}
-
-		std::string ProphetRoutingExtension::NextExchangeTask::toString() const
-		{
-			return "NextExchangeTask";
 		}
 
 		ProphetRoutingExtension::GRTR_Strategy::GRTR_Strategy()

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.h
@@ -64,8 +64,7 @@ namespace dtn
 		public:
 			ProphetRoutingExtension(ForwardingStrategy *strategy, float p_encounter_max, float p_encounter_first,
 						float p_first_threshold, float beta, float gamma, float delta,
-						size_t time_unit, size_t i_typ,
-						dtn::data::Timestamp next_exchange_timeout);
+						size_t time_unit, size_t i_typ);
 			virtual ~ProphetRoutingExtension();
 
 			/* virtual methods from BaseRouter::Extension */
@@ -133,10 +132,6 @@ namespace dtn
 			ForwardingStrategy *_forwardingStrategy;
 			AcknowledgementSet _acknowledgementSet;
 
-			ibrcommon::Mutex _next_exchange_mutex; ///< Mutex for the _next_exchange_timestamp.
-			dtn::data::Timestamp _next_exchange_timeout; ///< Interval in seconds how often Handshakes should be executed on longer connections.
-			dtn::data::Timestamp _next_exchange_timestamp; ///< Unix timestamp, when the next handshake is due.
-
 			/*!
 			 * Calculates the p_encounter that rises linearly with the time since the encounter, up to p_encounter_max.
 			 */
@@ -169,15 +164,6 @@ namespace dtn
 				virtual std::string toString() const;
 
 				const dtn::data::EID eid;
-			};
-
-			class NextExchangeTask : public Task
-			{
-			public:
-				NextExchangeTask();
-				virtual ~NextExchangeTask();
-
-				virtual std::string toString() const;
 			};
 
 			ibrcommon::Queue<Task* > _taskqueue;


### PR DESCRIPTION
Prior to this patch, the PRoPHET routing implementation exchanges routing data with all
neighbors in a configurable interval. This pro-active behavior is removed now and replaces
through a reactive approach. Every time more recent PRoPHET routing data is necessary,
the routing module will trigger the handshake.
