### PR TITLE
ibrdtn: Do not modify time if clock rating is equal to 1.0

### DIFF
--- a/ibrdtn/ibrdtn/ibrdtn/utils/Clock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/utils/Clock.cpp
@@ -186,6 +186,9 @@ namespace dtn
 
 		void Clock::setOffset(const struct timeval &tv)
 		{
+			// do not modify time on reference nodes
+			if (Clock::getRating() < 1.0) return;
+
 			if (!Clock::shouldModifyClock())
 			{
 				timeradd(&Clock::_offset, &tv, &Clock::_offset);
@@ -211,6 +214,9 @@ namespace dtn
 		{
 			struct timeval now;
 			struct timezone tz;
+
+			// do not modify time on reference nodes
+			if (Clock::getRating() < 1.0) return;
 
 			if (!Clock::shouldModifyClock())
 			{
@@ -239,7 +245,7 @@ namespace dtn
 
 		void Clock::gettimeofday(struct timeval *tv)
 		{
-			if (!Clock::shouldModifyClock() && Clock::_rating < 1.0)
+			if (!Clock::shouldModifyClock() && Clock::getRating() < 1.0)
 			{
 				// get the monotonic time of day
 				__monotonic_gettimeofday(tv);


### PR DESCRIPTION
Clock with a rating of 1.0 are considered as reference node and should never
change their value by data received through the DTN. Instead external syncronization
approached should adjust the local clock.
