### PR TITLE
ibrdtn: Fixing patch "Do not modify time if clock rating is equal to 1.0"

### DIFF
--- a/ibrdtn/ibrdtn/ibrdtn/utils/Clock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/utils/Clock.cpp
@@ -187,7 +187,7 @@ namespace dtn
 		void Clock::setOffset(const struct timeval &tv)
 		{
 			// do not modify time on reference nodes
-			if (Clock::getRating() < 1.0) return;
+			if (Clock::getRating() == 1.0) return;
 
 			if (!Clock::shouldModifyClock())
 			{
@@ -216,7 +216,7 @@ namespace dtn
 			struct timezone tz;
 
 			// do not modify time on reference nodes
-			if (Clock::getRating() < 1.0) return;
+			if (Clock::getRating() == 1.0) return;
 
 			if (!Clock::shouldModifyClock())
 			{


### PR DESCRIPTION
The return has to happen if the rating is 1.0 and not if it is below that value.
