### PR TITLE
Bluetooth Low Energy Node Discovery

### DIFF
--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -61,7 +61,7 @@
 	<uses-feature android:name="android.hardware.nfc"
 		android:required="false" />
 
-    <!-- This app uses the camera to scan QR codes -->
+	<!-- This app uses the camera to scan QR codes -->
 	<uses-feature android:name="android.hardware.camera"
 		android:required="false" />
 

--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -43,25 +43,25 @@
 
 	<!-- This app require access to the camera to scan QR codes -->
 	<uses-permission android:name="android.permission.CAMERA" />
-	
+
 	<!-- This app requires access to bluetooth and wake locks to scan for nodes in the background -->
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-    	
+	<uses-permission android:name="android.permission.BLUETOOTH" />
+	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
+
 	<!-- This app uses Bluetooth LE for node discovery  -->
 	<uses-feature android:name="android.hardware.bluetooth_le"
-	    android:required="false"/>
-	
-    <!-- This app uses but not require Wi-Fi direct -->
-    <uses-feature android:name="android.hardware.wifi.direct"
-        android:required="false" />
-    
+		android:required="false"/>
+
+	<!-- This app uses but not require Wi-Fi direct -->
+	<uses-feature android:name="android.hardware.wifi.direct"
+		android:required="false" />
+
 	<!-- This app uses NFC if available -->
 	<uses-feature android:name="android.hardware.nfc"
 		android:required="false" />
 
-	<!-- This app uses the camera to scan QR codes -->
+    <!-- This app uses the camera to scan QR codes -->
 	<uses-feature android:name="android.hardware.camera"
 		android:required="false" />
 
@@ -184,14 +184,14 @@
 		</receiver>
 		
 		<service
-            android:name=".discovery.DiscoveryService"
-            android:enabled="true" />
-		
+			android:name=".discovery.DiscoveryService"
+			android:enabled="true" />
+
 		<receiver android:name=".discovery.WakefulDiscoveryReceiver" >
-            <intent-filter>
-                <action android:name="de.tubs.ibr.dtn.Intent.BLE_DISCOVERY" />
-            </intent-filter>
-        </receiver>
+			<intent-filter>
+				<action android:name="de.tubs.ibr.dtn.Intent.BLE_DISCOVERY" />
+			</intent-filter>
+		</receiver>
 
 		<provider
 			android:name=".stats.StatsContentProvider"

--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -43,16 +43,20 @@
 
 	<!-- This app require access to the camera to scan QR codes -->
 	<uses-permission android:name="android.permission.CAMERA" />
-
+	
 	<!-- This app requires access to bluetooth and wake locks to scan for nodes in the background -->
-  <uses-permission android:name="android.permission.BLUETOOTH" />
-  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
-  <uses-permission android:name="android.permission.WAKE_LOCK" />
-
-	<!-- This app uses but not require Wi-Fi direct -->
-	<uses-feature android:name="android.hardware.wifi.direct"
-		android:required="false" />
-
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    	
+	<!-- This app uses Bluetooth LE for node discovery  -->
+	<uses-feature android:name="android.hardware.bluetooth_le"
+	    android:required="false"/>
+	
+    <!-- This app uses but not require Wi-Fi direct -->
+    <uses-feature android:name="android.hardware.wifi.direct"
+        android:required="false" />
+    
 	<!-- This app uses NFC if available -->
 	<uses-feature android:name="android.hardware.nfc"
 		android:required="false" />

--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -44,6 +44,11 @@
 	<!-- This app require access to the camera to scan QR codes -->
 	<uses-permission android:name="android.permission.CAMERA" />
 
+	<!-- This app requires access to bluetooth and wake locks to scan for nodes in the background -->
+  <uses-permission android:name="android.permission.BLUETOOTH" />
+  <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+  <uses-permission android:name="android.permission.WAKE_LOCK" />
+
 	<!-- This app uses but not require Wi-Fi direct -->
 	<uses-feature android:name="android.hardware.wifi.direct"
 		android:required="false" />
@@ -173,6 +178,16 @@
 				<category android:name="android.intent.category.DEFAULT" />
 			</intent-filter>
 		</receiver>
+		
+		<service
+            android:name=".discovery.DiscoveryService"
+            android:enabled="true" />
+		
+		<receiver android:name=".discovery.WakefulDiscoveryReceiver" >
+            <intent-filter>
+                <action android:name="de.tubs.ibr.dtn.Intent.BLE_DISCOVERY" />
+            </intent-filter>
+        </receiver>
 
 		<provider
 			android:name=".stats.StatsContentProvider"

--- a/android/ibrdtn/res/values-de/strings_ble.xml
+++ b/android/ibrdtn/res/values-de/strings_ble.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="pref_ble_on">An</string>
+    <string name="pref_ble_summary">Nutze Bluetooth LE zur Node Discovery.</string>
+    <string name="pref_ble_off">Aus</string>
+    <string name="pref_ble">BLE Node Discovery</string>
+    <string name="start_discovery">Start discovery</string>
+    <string name="stop_discovery">Stop discovery</string>
+    
+</resources>

--- a/android/ibrdtn/res/values/strings_ble.xml
+++ b/android/ibrdtn/res/values/strings_ble.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="pref_ble_on">On</string>
+    <string name="pref_ble_summary">Use Bluetooth LE for Node Discovery.</string>
+    <string name="pref_ble_off">Off</string>
+    <string name="pref_ble">BLE Node Discovery</string>
+    <string name="start_discovery">Start discovery</string>
+    <string name="stop_discovery">Stop discovery</string>
+    
+</resources>

--- a/android/ibrdtn/res/xml-v18/preferences.xml
+++ b/android/ibrdtn/res/xml-v18/preferences.xml
@@ -66,7 +66,7 @@
             android:switchTextOff="@string/pref_ble_off"
             android:switchTextOn="@string/pref_ble_on"
             android:title="@string/pref_ble"
-            android:enabled="true" />
+            android:enabled="false" />
     </PreferenceCategory>
     <de.tubs.ibr.dtn.daemon.InterfacePreferenceCategory
         android:key="prefcat_interfaces"

--- a/android/ibrdtn/res/xml-v18/preferences.xml
+++ b/android/ibrdtn/res/xml-v18/preferences.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <PreferenceCategory
+        android:key="prefcat_general"
+        android:title="@string/general" >
+        <de.tubs.ibr.dtn.daemon.EndpointListPreference
+            android:defaultValue="dtn"
+            android:key="endpoint_id"
+            android:entries="@array/endpoint_scheme_names"
+            android:entryValues="@array/endpoint_scheme_values"
+            android:summary="@string/eid_description"
+            android:title="@string/endpoint_id">
+        </de.tubs.ibr.dtn.daemon.EndpointListPreference>
+
+        <ListPreference
+            android:defaultValue="prophet"
+            android:entries="@array/routing_scheme_names"
+            android:entryValues="@array/routing_scheme_values"
+            android:key="routing"
+            android:summary="@string/routing_description"
+            android:title="@string/routing" >
+        </ListPreference>
+        
+        <ListPreference
+            android:defaultValue="disk-persistent"
+            android:entries="@array/storage_modes_names"
+            android:entryValues="@array/storage_modes_values"
+            android:key="storage_mode"
+            android:summary="@string/pref_storage_description"
+            android:title="@string/pref_storage" >
+        </ListPreference>
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:key="prefcat_connection"
+        android:title="@string/pref_connection" >
+        <ListPreference
+            android:defaultValue="smart"
+            android:entries="@array/discovery_modes_names"
+            android:entryValues="@array/discovery_modes_values"
+            android:key="discovery_mode"
+            android:title="@string/pref_discovery_title" >
+        </ListPreference>
+        <ListPreference
+            android:defaultValue="off"
+            android:entries="@array/uplink_modes_names"
+            android:entryValues="@array/uplink_modes_values"
+            android:key="uplink_mode"
+            android:summary="@string/pref_uplink_summary"
+            android:title="@string/pref_uplink_title" >
+        </ListPreference>
+        <SwitchPreference
+            android:defaultValue="false"
+            android:disableDependentsState="false"
+            android:key="p2p_enabled"
+            android:summary="@string/pref_p2p_summary"
+            android:switchTextOff="@string/pref_p2p_off"
+            android:switchTextOn="@string/pref_p2p_on"
+            android:title="@string/pref_p2p"
+            android:enabled="false" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:disableDependentsState="false"
+            android:key="ble_enabled"
+            android:summary="@string/pref_ble_summary"
+            android:switchTextOff="@string/pref_ble_off"
+            android:switchTextOn="@string/pref_ble_on"
+            android:title="@string/pref_ble"
+            android:enabled="true" />
+    </PreferenceCategory>
+    <de.tubs.ibr.dtn.daemon.InterfacePreferenceCategory
+        android:key="prefcat_interfaces"
+        android:title="@string/interfaces" >
+    </de.tubs.ibr.dtn.daemon.InterfacePreferenceCategory>
+    <PreferenceCategory
+        android:key="prefcat_security"
+        android:title="@string/security" >
+        <ListPreference
+            android:defaultValue="disabled"
+            android:entries="@array/security_modes_names"
+            android:entryValues="@array/security_modes_values"
+            android:key="security_mode"
+            android:summary="@string/pref_security_mode_desc"
+            android:title="@string/pref_security_mode" />
+
+        <EditTextPreference
+            android:key="security_bab_key"
+            android:summary="@string/pref_bab_key_desc"
+            android:title="@string/pref_bab_key"
+            android:singleLine="true" />
+    </PreferenceCategory>
+    
+    <PreferenceCategory
+        android:key="prefcat_timesync"
+        android:title="@string/timesync" >
+        <ListPreference
+            android:defaultValue="disabled"
+            android:entries="@array/timesync_modes_names"
+            android:entryValues="@array/timesync_modes_values"
+            android:key="timesync_mode"
+            android:summary="@string/pref_timesync_mode_desc"
+            android:title="@string/pref_timesync_mode" />
+
+    </PreferenceCategory>
+    
+    <PreferenceCategory
+        android:key="prefcat_logging"
+        android:title="@string/pref_logging" >
+        <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/log_options_names"
+            android:entryValues="@array/log_options_values"
+            android:key="log_options"
+            android:summary="@string/pref_log_options_desc"
+            android:title="@string/pref_log_options" />
+
+        <EditTextPreference
+            android:defaultValue="99"
+            android:key="log_debug_verbosity"
+            android:summary="@string/pref_log_debug_verbosity_desc"
+            android:title="@string/pref_log_debug_verbosity"
+            android:inputType="number"
+            android:singleLine="true" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="log_enable_file"
+            android:summary="@string/pref_log_enable_file_desc"
+            android:title="@string/pref_log_enable_file" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_system" >
+        <CheckBoxPreference
+            android:key="collect_stats"
+            android:summary="@string/pref_collect_stats_desc"
+            android:title="@string/pref_collect_stats" />
+
+        <Preference
+            android:key="system_version"
+            android:title="@string/system_version" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/daemon/Preferences.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/daemon/Preferences.java
@@ -134,8 +134,8 @@ public class Preferences extends PreferenceActivity {
 	
 	private BluetoothManager mBluetoothManager;
 	private BluetoothAdapter mBluetoothAdapter;
-    private AlarmManager mAlarmManager;
-    private PendingIntent mBleDiscoveryIntent;
+	private AlarmManager mAlarmManager;
+	private PendingIntent mBleDiscoveryIntent;
 
 	private ServiceConnection mConnection = new ServiceConnection() {
 		@SuppressLint("NewApi")

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/discovery/DiscoveryService.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/discovery/DiscoveryService.java
@@ -1,0 +1,173 @@
+package de.tubs.ibr.dtn.discovery;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
+import android.content.Intent;
+import android.net.wifi.WifiConfiguration;
+import android.net.wifi.WifiManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.IBinder;
+import android.os.SystemClock;
+import android.preference.PreferenceManager;
+import android.support.v4.content.WakefulBroadcastReceiver;
+import android.util.Log;
+import android.util.SparseArray;
+
+import de.tubs.ibr.dtn.daemon.Preferences;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class DiscoveryService extends Service {
+
+    public static final String TAG = DiscoveryService.class.getSimpleName();
+
+    /**
+     * Prefix used in the name of a bluetooth device that announces a DTN node
+     */
+    public static final String DTN_DISCOVERY_PREFIX = "DTN:";
+    
+    public static final String ACTION_BLE_NODE_DISCOVERED = "de.tubs.ibr.dtn.Intent.BLE_NODE_DISCOVERED";
+    public static final String EXTRA_BLE_NODE = "de.tubs.ibr.dtn.Intent.BLE_NODE";
+
+    private Handler mHandler = new Handler();
+    private BluetoothManager mBluetoothManager;
+    private BluetoothAdapter mBluetoothAdapter;
+    private WifiManager mWifiManager;
+    private AlarmManager mAlarmManager;
+    private Intent mWakefulIntent;
+    private SparseArray<Long> mDiscoveredDtnNodes;
+
+    private BluetoothAdapter.LeScanCallback mLeScanCallback =
+            new BluetoothAdapter.LeScanCallback() {
+                @Override
+                public void onLeScan(final BluetoothDevice device, int rssi, byte[] scanRecord) {
+                    Log.i(TAG, "onLeScan: " + device.getAddress() + " (rssi=" + rssi + ")");
+                    if (device.getName().startsWith(DTN_DISCOVERY_PREFIX)) {
+                        onDtnNodeDiscovered(device.getAddress());
+                    }
+                }
+            };
+
+    private void onDtnNodeDiscovered(String address) {
+
+        // throttle announcements to once per minute
+        int nodeHash = address.hashCode();
+        Long lastDiscoveryTime = mDiscoveredDtnNodes.get(nodeHash);
+        if (lastDiscoveryTime != null && System.currentTimeMillis() < lastDiscoveryTime + 60*1000 ) {
+            return;
+        }
+        mDiscoveredDtnNodes.put(nodeHash, System.currentTimeMillis());
+
+        Log.d(TAG, "found DTN node with address: " + address);
+        String ssid = DTN_DISCOVERY_PREFIX + "//" + address;
+
+        WifiConfiguration wifiConfig = new WifiConfiguration();
+        wifiConfig.SSID = String.format("\"%s\"", ssid);
+        wifiConfig.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
+
+        int networkId = mWifiManager.addNetwork(wifiConfig);
+        mWifiManager.disconnect();
+        mWifiManager.enableNetwork(networkId, true);
+        mWifiManager.reconnect();
+
+        // TODO announce endpoint to IBR-DTN (EID == SSID)
+        Intent discoveredIntent = new Intent(ACTION_BLE_NODE_DISCOVERED);
+        discoveredIntent.putExtra(EXTRA_BLE_NODE, ssid);
+        sendBroadcast(discoveredIntent);
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        initialize();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        mWakefulIntent = intent;
+        startScan();
+        return super.onStartCommand(intent, flags, startId);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    /**
+     * Initializes a reference to the local Bluetooth adapter.
+     *
+     * @return Return true if the initialization is successful.
+     */
+    @TargetApi(18)
+    public boolean initialize() {
+
+        if (Build.VERSION.SDK_INT < 18) {
+          // Bluetooth Low Energy is not supported
+          return false;
+        }
+
+        // For API level 18 and above, get a reference to BluetoothAdapter through
+        // BluetoothManager.
+        if (mBluetoothManager == null) {
+            mBluetoothManager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
+            if (mBluetoothManager == null) {
+                Log.e(TAG, "Unable to initialize BluetoothManager.");
+                return false;
+            }
+        }
+
+        mBluetoothAdapter = mBluetoothManager.getAdapter();
+        if (mBluetoothAdapter == null) {
+            Log.e(TAG, "Unable to obtain a BluetoothAdapter.");
+            return false;
+        }
+
+        mAlarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+
+        mWifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
+        mDiscoveredDtnNodes = new SparseArray<Long>();
+
+        return true;
+    }
+
+    @SuppressLint("NewApi")
+	private void startScan() {
+      // TODO set proper values for scan duration and delay
+        final int duration = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString(Preferences.KEY_SCAN_DURATION, "2200"));
+        final int delay = Integer.parseInt(PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getString(Preferences.KEY_SCAN_DELAY, "2200"));
+
+        if (duration <= 0) {
+            Log.i(TAG, "scan duration invalid: " + duration + " ms");
+            return;
+        }
+        Log.i(TAG, "scanning for " + duration + " ms");
+        mBluetoothAdapter.startLeScan(mLeScanCallback);
+        mHandler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                mBluetoothAdapter.stopLeScan(mLeScanCallback);
+                if (!PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean(Preferences.KEY_BLE_ENABLED, false))
+                    return;
+                Log.i(TAG, "scanning again in " + delay + " ms");
+                // TODO schedule new scan with AlarmManager
+                PendingIntent intent = PendingIntent.getBroadcast(getApplicationContext(), 0, new Intent(WakefulDiscoveryReceiver.ACTION_BLE_DISCOVERY), 0);
+                if (Build.VERSION.SDK_INT >= 19) {
+                    mAlarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + delay, intent);
+                } else {
+                    mAlarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + delay, intent);
+                }
+                // release wakelock after scan has finished
+                WakefulBroadcastReceiver.completeWakefulIntent(mWakefulIntent);
+            }
+        }, duration);
+    }
+
+}

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/discovery/WakefulDiscoveryReceiver.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/discovery/WakefulDiscoveryReceiver.java
@@ -1,0 +1,18 @@
+package de.tubs.ibr.dtn.discovery;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.WakefulBroadcastReceiver;
+
+public class WakefulDiscoveryReceiver extends WakefulBroadcastReceiver {
+
+    public static final String ACTION_BLE_DISCOVERY = "de.tubs.ibr.dtn.Intent.BLE_DISCOVERY";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+
+        Intent service = new Intent(context, DiscoveryService.class);
+        // Start the service, keeping the device awake while it is launching.
+        startWakefulService(context, service);
+    }
+}

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/BleManager.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/BleManager.java
@@ -26,6 +26,11 @@ public class BleManager extends NativeP2pManager {
 		mService.registerReceiver(mBleEventReceiver, ble_filter);
 	}
 
+	@Override
+	public void connect(String identifier) {
+		// Connection is handled within the Bluetooth LE Discovery Service
+	}
+
 	private BroadcastReceiver mBleEventReceiver = new BroadcastReceiver() {
 
 		@Override

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/BleManager.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/BleManager.java
@@ -1,0 +1,45 @@
+
+package de.tubs.ibr.dtn.service;
+
+import android.annotation.TargetApi;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.util.Log;
+import de.tubs.ibr.dtn.discovery.DiscoveryService;
+import de.tubs.ibr.dtn.swig.EID;
+import de.tubs.ibr.dtn.swig.NativeP2pManager;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class BleManager extends NativeP2pManager {
+
+	private final static String TAG = "BleManager";
+
+	private DaemonService mService = null;
+
+	public BleManager(DaemonService service) {
+		super("P2P:BT");
+		this.mService = service;
+		IntentFilter ble_filter = new IntentFilter(DiscoveryService.ACTION_BLE_NODE_DISCOVERED);
+		mService.registerReceiver(mBleEventReceiver, ble_filter);
+	}
+
+	private BroadcastReceiver mBleEventReceiver = new BroadcastReceiver() {
+
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			Log.d(TAG, "BLE action: " + intent);
+
+			String action = intent.getAction();
+
+			if (DiscoveryService.ACTION_BLE_NODE_DISCOVERED.equals(action)) {
+				String eid = intent.getExtras().getString(DiscoveryService.EXTRA_BLE_NODE, "");
+				Log.d(TAG, "announcing EID: " + eid);
+				fireDiscovered(new EID(eid), eid, 90, 10);
+			}
+		}
+	};
+
+}

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/DaemonService.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/DaemonService.java
@@ -122,6 +122,9 @@ public class DaemonService extends Service {
 
 	// the P2P manager used for wifi direct control
 	private P2pManager mP2pManager = null;
+	
+	// the BLE manager used for node discovery
+	private BleManager mBleManager = null;
 
 	// the daemon process
 	private DaemonProcess mDaemonProcess = null;
@@ -726,6 +729,11 @@ public class DaemonService extends Service {
 			mP2pManager = new P2pManager(this);
 			mP2pManager.create();
 		}
+		
+		// create BLE Manager
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+					mBleManager = new BleManager(this);
+				}
 
 		// start initialization of the daemon process
 		final Intent intent = new Intent(this, DaemonService.class);


### PR DESCRIPTION
Public DTN nodes announce their presence via BLE advertisements. The access point SSID and the endpoint identifier are derived from the MAC address of the Bluetooth Beacon. 