### PR TITLE
Bluetooth Low Energy Node Discovery

### DIFF
--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -44,6 +44,14 @@
 	<!-- This app require access to the camera to scan QR codes -->
 	<uses-permission android:name="android.permission.CAMERA" />
 
+	<!-- This app requires access to bluetooth to scan for nodes in the background -->
+	<uses-permission android:name="android.permission.BLUETOOTH" />
+	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
+	<!-- This app uses Bluetooth LE for node discovery  -->
+	<uses-feature android:name="android.hardware.bluetooth_le"
+		android:required="false"/>
+
 	<!-- This app uses but not require Wi-Fi direct -->
 	<uses-feature android:name="android.hardware.wifi.direct"
 		android:required="false" />

--- a/android/ibrdtn/res/values-de/strings_ble.xml
+++ b/android/ibrdtn/res/values-de/strings_ble.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="pref_ble_on">An</string>
+    <string name="pref_ble_summary">Verwende Bluetooth LE um Netze zu finden</string>
+    <string name="pref_ble_off">Aus</string>
+    <string name="pref_ble">Bluetooth LE</string>
+    
+</resources>

--- a/android/ibrdtn/res/values/strings_ble.xml
+++ b/android/ibrdtn/res/values/strings_ble.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="pref_ble_on">On</string>
+    <string name="pref_ble_summary">Use Bluetooth LE to discover networks</string>
+    <string name="pref_ble_off">Off</string>
+    <string name="pref_ble">Bluetooth LE</string>
+    
+</resources>

--- a/android/ibrdtn/res/xml-v18/preferences.xml
+++ b/android/ibrdtn/res/xml-v18/preferences.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <PreferenceCategory
+        android:key="prefcat_general"
+        android:title="@string/general" >
+        <de.tubs.ibr.dtn.daemon.EndpointListPreference
+            android:defaultValue="dtn"
+            android:key="endpoint_id"
+            android:entries="@array/endpoint_scheme_names"
+            android:entryValues="@array/endpoint_scheme_values"
+            android:summary="@string/eid_description"
+            android:title="@string/endpoint_id">
+        </de.tubs.ibr.dtn.daemon.EndpointListPreference>
+
+        <ListPreference
+            android:defaultValue="prophet"
+            android:entries="@array/routing_scheme_names"
+            android:entryValues="@array/routing_scheme_values"
+            android:key="routing"
+            android:summary="@string/routing_description"
+            android:title="@string/routing" >
+        </ListPreference>
+        
+        <ListPreference
+            android:defaultValue="disk-persistent"
+            android:entries="@array/storage_modes_names"
+            android:entryValues="@array/storage_modes_values"
+            android:key="storage_mode"
+            android:summary="@string/pref_storage_description"
+            android:title="@string/pref_storage" >
+        </ListPreference>
+    </PreferenceCategory>
+    <PreferenceCategory
+        android:key="prefcat_connection"
+        android:title="@string/pref_connection" >
+        <ListPreference
+            android:defaultValue="smart"
+            android:entries="@array/discovery_modes_names"
+            android:entryValues="@array/discovery_modes_values"
+            android:key="discovery_mode"
+            android:title="@string/pref_discovery_title" >
+        </ListPreference>
+        <ListPreference
+            android:defaultValue="off"
+            android:entries="@array/uplink_modes_names"
+            android:entryValues="@array/uplink_modes_values"
+            android:key="uplink_mode"
+            android:summary="@string/pref_uplink_summary"
+            android:title="@string/pref_uplink_title" >
+        </ListPreference>
+        <SwitchPreference
+            android:defaultValue="false"
+            android:disableDependentsState="false"
+            android:key="p2p_enabled"
+            android:summary="@string/pref_p2p_summary"
+            android:switchTextOff="@string/pref_p2p_off"
+            android:switchTextOn="@string/pref_p2p_on"
+            android:title="@string/pref_p2p"
+            android:enabled="false" />
+        <SwitchPreference
+            android:defaultValue="false"
+            android:disableDependentsState="false"
+            android:key="ble_enabled"
+            android:summary="@string/pref_ble_summary"
+            android:switchTextOff="@string/pref_ble_off"
+            android:switchTextOn="@string/pref_ble_on"
+            android:title="@string/pref_ble"
+            android:enabled="false" />
+    </PreferenceCategory>
+    <de.tubs.ibr.dtn.daemon.InterfacePreferenceCategory
+        android:key="prefcat_interfaces"
+        android:title="@string/interfaces" >
+    </de.tubs.ibr.dtn.daemon.InterfacePreferenceCategory>
+    <PreferenceCategory
+        android:key="prefcat_security"
+        android:title="@string/security" >
+        <ListPreference
+            android:defaultValue="disabled"
+            android:entries="@array/security_modes_names"
+            android:entryValues="@array/security_modes_values"
+            android:key="security_mode"
+            android:summary="@string/pref_security_mode_desc"
+            android:title="@string/pref_security_mode" />
+
+        <EditTextPreference
+            android:key="security_bab_key"
+            android:summary="@string/pref_bab_key_desc"
+            android:title="@string/pref_bab_key"
+            android:singleLine="true" />
+    </PreferenceCategory>
+    
+    <PreferenceCategory
+        android:key="prefcat_timesync"
+        android:title="@string/timesync" >
+        <ListPreference
+            android:defaultValue="disabled"
+            android:entries="@array/timesync_modes_names"
+            android:entryValues="@array/timesync_modes_values"
+            android:key="timesync_mode"
+            android:summary="@string/pref_timesync_mode_desc"
+            android:title="@string/pref_timesync_mode" />
+
+    </PreferenceCategory>
+    
+    <PreferenceCategory
+        android:key="prefcat_logging"
+        android:title="@string/pref_logging" >
+        <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/log_options_names"
+            android:entryValues="@array/log_options_values"
+            android:key="log_options"
+            android:summary="@string/pref_log_options_desc"
+            android:title="@string/pref_log_options" />
+
+        <EditTextPreference
+            android:defaultValue="99"
+            android:key="log_debug_verbosity"
+            android:summary="@string/pref_log_debug_verbosity_desc"
+            android:title="@string/pref_log_debug_verbosity"
+            android:inputType="number"
+            android:singleLine="true" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="log_enable_file"
+            android:summary="@string/pref_log_enable_file_desc"
+            android:title="@string/pref_log_enable_file" />
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_system" >
+        <CheckBoxPreference
+            android:key="collect_stats"
+            android:summary="@string/pref_collect_stats_desc"
+            android:title="@string/pref_collect_stats" />
+
+        <Preference
+            android:key="system_version"
+            android:title="@string/system_version" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/BleManager.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/BleManager.java
@@ -1,0 +1,267 @@
+
+package de.tubs.ibr.dtn.service;
+
+import java.util.Locale;
+
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.wifi.WifiConfiguration;
+import android.net.wifi.WifiInfo;
+import android.net.wifi.WifiManager;
+import android.os.Build;
+import android.util.Log;
+import android.util.SparseArray;
+import de.tubs.ibr.dtn.swig.EID;
+import de.tubs.ibr.dtn.swig.NativeP2pManager;
+
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class BleManager extends NativeP2pManager {
+
+	private final static String TAG = "BleManager";
+	
+	public static final String INTENT_BLE_STATE_CHANGED = "de.tubs.ibr.dtn.ble.action.STATE_CHANGED";
+	public static final String EXTRA_BLE_STATE = "de.tubs.ibr.dtn.ble.action.EXTRA_STATE";
+	
+	/**
+	 * Prefix used in the name of a Bluetooth device that announces a DTN node
+	 */
+	public static final String DTN_DISCOVERY_PREFIX = "dtn:";
+
+	private BluetoothManager mBluetoothManager = null;
+	private BluetoothAdapter mBluetoothAdapter = null;
+	
+	private SparseArray<Long> mDiscoveredDtnNodes = null;
+
+	private DaemonService mService = null;
+	
+	private boolean mServiceEnabled = false;
+	private boolean mDiscoveryEnabled = false;
+	
+	private enum ManagerState {
+		UNINITIALIZED,
+		INACTIVE,
+		ACTIVE
+	};
+
+	private ManagerState mManagerState = ManagerState.UNINITIALIZED;
+
+	public BleManager(DaemonService service) {
+		super("P2P:BT");
+		this.mService = service;
+	}
+	
+	public synchronized boolean isActive() {
+		return ManagerState.ACTIVE.equals(mManagerState);
+	}
+	
+	public synchronized void setEnabled(boolean enabled) {
+		// allow BT-LE scanning
+		mServiceEnabled = enabled;
+
+		if (enabled && mDiscoveryEnabled) {
+			// start discovery on enable if discovery is active
+			startDiscovery();
+		}
+		else if (!enabled && mDiscoveryEnabled) {
+			// stop discovery on disable
+			stopDiscovery();
+			mDiscoveryEnabled = true;
+		}
+	}
+	
+	private void setState(ManagerState state) {
+		// new state debug
+		Log.d(TAG, "state transition: " + mManagerState.toString() + " -> " + state.toString());
+		
+		// change state
+		mManagerState = state;
+
+		// generate intent
+		Intent i = new Intent(INTENT_BLE_STATE_CHANGED);
+		i.putExtra(EXTRA_BLE_STATE, ManagerState.ACTIVE.equals(state));
+		mService.sendBroadcast(i);
+	}
+	
+	/**
+	 * Initializes a reference to the local Bluetooth adapter.
+	 *
+	 * @return Return true if the initialization is successful.
+	 */
+	public synchronized void create() {
+		// allowed transition from UNINITIALIZED
+		if (ManagerState.UNINITIALIZED.equals(mManagerState)) {
+			onCreate();
+		}
+	}
+	
+	public synchronized void destroy() {
+		if (ManagerState.ACTIVE.equals(mManagerState)) {
+			onBleDisabled();
+		}
+		
+		// allowed transition from ACTIVE and INACTIVE
+		if (ManagerState.INACTIVE.equals(mManagerState)) {
+			onDestroy();
+		}
+	}
+	
+	private synchronized void onCreate() {
+		// initialize data-structures
+		mDiscoveredDtnNodes = new SparseArray<Long>();
+		
+		// For API level 18 and above, get a reference to BluetoothAdapter through
+		// BluetoothManager.
+		mBluetoothManager = (BluetoothManager) mService.getSystemService(Context.BLUETOOTH_SERVICE);
+
+		// set the current state
+		setState(ManagerState.INACTIVE);
+		
+		// enable blue-tooth
+		onBleEnabled();
+	}
+	
+	/**
+	 * This method is called if the BT-LE has been initialized
+	 */
+	private synchronized void onBleEnabled() {
+		// transition only from INACTIVE state
+		if (!ManagerState.INACTIVE.equals(mManagerState)) return;
+		
+		// stop here if BT-LE is not supported
+		if (!mService.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return;
+
+		if (mBluetoothManager == null) return;
+
+		// get the blue-tooth adapter
+		mBluetoothAdapter = mBluetoothManager.getAdapter();
+		
+		if (mBluetoothAdapter == null) {
+			Log.e(TAG, "Unable to obtain a BluetoothAdapter.");
+			return;
+		}
+		
+		// set the current state
+		setState(ManagerState.ACTIVE);
+		
+		// restart discovery
+		if (mDiscoveryEnabled) {
+			startDiscovery();
+		}
+	}
+	
+	private synchronized void onBleDisabled() {
+		// transition only from ACTIVE state
+		if (!ManagerState.ACTIVE.equals(mManagerState)) return;
+		
+		// stop scanning
+		stopDiscovery();
+		
+		// reset adapter
+		mBluetoothAdapter = null;
+		
+		// set the current state
+		setState(ManagerState.INACTIVE);
+	}
+	
+	private synchronized void onDestroy() {
+		mDiscoveredDtnNodes = null;
+		mBluetoothManager = null;
+
+		// set the current state
+		setState(ManagerState.UNINITIALIZED);
+	}
+
+	@Override
+	public synchronized void connect(String identifier) {
+		// check if service is enabled
+		if (!mServiceEnabled) return;
+		
+		// check if stack is active
+		if (!ManagerState.ACTIVE.equals(mManagerState)) return;
+		
+		String ssid = DTN_DISCOVERY_PREFIX + "//" + identifier;
+		
+		WifiManager wifiManager = (WifiManager) mService.getSystemService(Context.WIFI_SERVICE);
+		
+		// connect to network with matching SSID if not already connected
+		WifiInfo wifiInfo = wifiManager.getConnectionInfo();
+		
+		if (!wifiInfo.getSSID().equals(String.format("\"%s\"", ssid))) {
+			Log.d(TAG, "connecting to SSID " + ssid);
+			WifiConfiguration wifiConfig = new WifiConfiguration();
+			wifiConfig.SSID = String.format("\"%s\"", ssid);
+			wifiConfig.allowedKeyManagement.set(WifiConfiguration.KeyMgmt.NONE);
+
+			int networkId = wifiManager.addNetwork(wifiConfig);
+			wifiManager.disconnect();
+			wifiManager.enableNetwork(networkId, true);
+			wifiManager.reconnect();
+		}
+	}
+	
+	@Override
+	public void disconnect(String data) {
+		// check if stack is active
+		if (!ManagerState.ACTIVE.equals(mManagerState)) return;
+
+		// disconnect from the peer identified by "data"
+		Log.i(TAG, "disconnect request: " + data);
+	}
+	
+	public synchronized void startDiscovery() {
+		// set disco marker
+		mDiscoveryEnabled = true;
+		
+		// check if service is enabled
+		if (!mServiceEnabled) return;
+
+		// check if stack is active
+		if (!ManagerState.ACTIVE.equals(mManagerState)) return;
+		
+		mBluetoothAdapter.startLeScan(mLeScanCallback);
+	}
+	
+	public synchronized void stopDiscovery() {
+		// set disco marker
+		mDiscoveryEnabled = false;
+		
+		// check if stack is active
+		if (!ManagerState.ACTIVE.equals(mManagerState)) return;
+
+		mBluetoothAdapter.stopLeScan(mLeScanCallback);
+	}
+
+	private BluetoothAdapter.LeScanCallback mLeScanCallback = new BluetoothAdapter.LeScanCallback() {
+		@Override
+		public void onLeScan(final BluetoothDevice device, int rssi, byte[] scanRecord) {
+			// check if service is enabled
+			if (!mServiceEnabled) return;
+			
+			Log.i(TAG, "onLeScan: " + device.getAddress() + " (rssi=" + rssi + ")");
+			
+			if (device.getName().toLowerCase(Locale.US).startsWith(DTN_DISCOVERY_PREFIX)) {
+				// transform address to proper format
+				String nodeAddress = device.getAddress().toLowerCase(Locale.US).replace(":", "");
+
+				// throttle announcements to once per minute
+				int nodeHash = nodeAddress.hashCode();
+				Long lastDiscoveryTime = mDiscoveredDtnNodes.get(nodeHash);
+				if (lastDiscoveryTime != null && System.currentTimeMillis() < lastDiscoveryTime + 60*1000 ) {
+					return;
+				}
+				mDiscoveredDtnNodes.put(nodeHash, System.currentTimeMillis());
+
+				Log.d(TAG, "found DTN node with address: " + nodeAddress);
+				String ssid = DTN_DISCOVERY_PREFIX + "//" + nodeAddress;
+
+				// announce endpoint to IBR-DTN daemon
+				fireDiscovered(new EID(ssid + ".dtn"), nodeAddress, 90, 10);
+			}
+		}
+	};
+}

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/ControlService.aidl
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/ControlService.aidl
@@ -33,6 +33,16 @@ interface ControlService {
 	void setP2pEnabled(boolean val);
 	
 	/**
+	 * Returns whether BT LE is active or not
+	 */
+	boolean isBleActive();
+	
+	/**
+	 * Enable / disable BT LE extension
+	 */
+	void setBleEnabled(boolean val);
+	
+	/**
 	 * Get the version of the daemon
 	 * @returns A array with the version at position 0 and the build number at position 1
 	 */


### PR DESCRIPTION
Public DTN nodes announce their presence via BLE advertisements. The access point SSID and the endpoint identifier are derived from the MAC address of the Bluetooth Beacon.