### PR TITLE
android-daemon: Disable backup capabilities

### DIFF
--- a/android/ibrdtn/AndroidManifest.xml
+++ b/android/ibrdtn/AndroidManifest.xml
@@ -70,7 +70,7 @@
 
 	<uses-sdk android:minSdkVersion="9" android:targetSdkVersion="20" />
 
-	<application android:allowBackup="true" android:icon="@drawable/ic_launcher"
+	<application android:allowBackup="false" android:icon="@drawable/ic_launcher"
 		android:label="@string/app_name" android:theme="@style/AppTheme">
 		<activity android:name=".daemon.Preferences" android:icon="@drawable/ic_launcher"
 			android:label="@string/app_name" android:uiOptions="splitActionBarWhenNarrow">


### PR DESCRIPTION
Since the private key is stored unencrypted in the private store of the application, it
is better to omit the backup capability in favor of security.
