### PR TITLE
daemon: Enable security settings by default

### DIFF
--- a/ibrdtn/daemon/debian/control
+++ b/ibrdtn/daemon/debian/control
@@ -9,7 +9,7 @@ Homepage: http://www.ibr.cs.tu-bs.de/projects/ibr-dtn/
 Package: ibrdtnd
 Architecture: any
 Pre-Depends: debconf, adduser
-Depends: ${shlibs:Depends}, ${misc:Depends}, ibrcommon1, ibrdtn1, libsqlite3-0, libcurl3 (>= 7.18), libdaemon0 (>= 0.12), dtndht1
+Depends: ${shlibs:Depends}, ${misc:Depends}, ibrcommon1, ibrdtn1, libsqlite3-0, libcurl3 (>= 7.18), libdaemon0 (>= 0.12), dtndht1, openssl
 Suggests: logrotate (>= 3.0.0), ibrdtn-tools
 Description: IBR-DTN daemon
 	The implementation of the bundle protocol of the IBR (TU Braunschweig).

--- a/ibrdtn/daemon/debian/ibrdtnd.postinst
+++ b/ibrdtn/daemon/debian/ibrdtnd.postinst
@@ -13,11 +13,20 @@ invoke() {
   fi
 }
 
+gendhparams() {
+  if [ ! -e "/etc/ibrdtn/bpsec/dh_params.pem" ]; then
+    openssl dhparam -out /etc/ibrdtn/bpsec/dh_params.pem 1024
+    chown dtnd.root /etc/ibrdtn/bpsec/dh_params.pem
+    chmod 600 /etc/ibrdtn/bpsec/dh_params.pem
+  fi
+}
+
 # stop the server
 set +e; invoke stop; set -e
 
 case "$1" in
   configure)
+    gendhparams
     invoke start
   ;;
 	

--- a/ibrdtn/daemon/debian/rules
+++ b/ibrdtn/daemon/debian/rules
@@ -4,7 +4,7 @@ include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/autotools.mk
 
 # extra configure flags
-DEB_CONFIGURE_EXTRA_FLAGS := --with-curl --with-sqlite --with-lowpan --with-dtnsec --with-compression --with-tls --sysconfdir=/etc/ibrdtn --enable-docs
+DEB_CONFIGURE_EXTRA_FLAGS := --with-curl --with-sqlite --with-lowpan --with-dtnsec --with-compression --with-tls --sysconfdir=/etc/ibrdtn --enable-docs --without-wifip2p --without-vmime
 
 # debug flags
 DEB_DH_STRIP_ARGS := --dbg-package=ibrdtnd-dbg

--- a/ibrdtn/daemon/etc/ibrdtnd.conf
+++ b/ibrdtn/daemon/etc/ibrdtnd.conf
@@ -334,7 +334,7 @@ routing = prophet
 #
 # key path
 #
-#security_path = /etc/ibrdtn/bpsec/keys
+security_path = /etc/ibrdtn/bpsec
 
 #
 # If set to "yes", the automatic generation of the
@@ -354,7 +354,7 @@ routing = prophet
 #security_key = /etc/ibrdtn/tls/local.key
 
 # path to trusted certificates
-#security_trusted_ca_path = /etc/ibrdtn/tls/
+security_trusted_ca_path = /etc/ibrdtn/certs
 
 # set to 'yes' if tcp connections without TLS are not allowed
 #security_tls_required = yes


### PR DESCRIPTION
The Debian package contains a routine to generate dhparams file during the installation.
This patch solves issue #23.
