### PR TITLE
Fix exception handling due to confusing exception naming

### DIFF
--- a/ibrdtn/daemon/src/NativeDaemon.cpp
+++ b/ibrdtn/daemon/src/NativeDaemon.cpp
@@ -610,7 +610,7 @@ namespace dtn
 					nn.type = NativeNode::NODE_P2P;
 					break;
 				}
-			} catch (const NeighborNotAvailableException &ex) {
+			} catch (const NodeNotAvailableException &ex) {
 				throw NativeDaemonException(ex.what());
 			}
 

--- a/ibrdtn/daemon/src/core/Node.cpp
+++ b/ibrdtn/daemon/src/core/Node.cpp
@@ -305,7 +305,7 @@ namespace dtn
 			_attr_list.clear();
 		}
 
-		dtn::data::Size Node::size() const
+		dtn::data::Size Node::size() const throw ()
 		{
 			return _uri_list.size() + _attr_list.size();
 		}
@@ -403,7 +403,7 @@ namespace dtn
 			return ret;
 		}
 
-		const dtn::data::EID& Node::getEID() const
+		const dtn::data::EID& Node::getEID() const throw ()
 		{
 			return _id;
 		}
@@ -523,7 +523,7 @@ namespace dtn
 			_connect_immediately = val;
 		}
 
-		bool Node::hasDialup() const
+		bool Node::hasDialup() const throw ()
 		{
 			for (std::set<Node::URI>::const_iterator iter = _uri_list.begin(); iter != _uri_list.end(); ++iter)
 			{
@@ -534,7 +534,7 @@ namespace dtn
 			return false;
 		}
 
-		bool Node::isAvailable() const
+		bool Node::isAvailable() const throw ()
 		{
 			if (dtn::core::BundleCore::getInstance().isGloballyConnected()) {
 				return !_uri_list.empty();
@@ -557,7 +557,7 @@ namespace dtn
 			return false;
 		}
 
-		bool Node::isAvailable(const Node::URI &uri) const
+		bool Node::isAvailable(const Node::URI &uri) const throw ()
 		{
 			if (dtn::core::BundleCore::getInstance().isGloballyConnected()) {
 				return true;
@@ -582,12 +582,12 @@ namespace dtn
 			}
 		}
 
-		void Node::setAnnounced(bool val)
+		void Node::setAnnounced(bool val) throw ()
 		{
 			_announced_mark = val;
 		}
 
-		bool Node::isAnnounced() const
+		bool Node::isAnnounced() const throw ()
 		{
 			return _announced_mark;
 		}

--- a/ibrdtn/daemon/src/core/Node.h
+++ b/ibrdtn/daemon/src/core/Node.h
@@ -168,7 +168,7 @@ namespace dtn
 			/**
 			 * Get the number of entries (URI + Attributes)
 			 */
-			dtn::data::Size size() const;
+			dtn::data::Size size() const throw ();
 
 			/**
 			 * Returns a list of URIs matching the given protocol
@@ -200,7 +200,7 @@ namespace dtn
 			 * Return the EID of this node.
 			 * @return The EID of this node.
 			 */
-			const dtn::data::EID& getEID() const;
+			const dtn::data::EID& getEID() const throw ();
 
 			/**
 			 * remove expired service descriptors
@@ -229,27 +229,27 @@ namespace dtn
 			/**
 			 * @return true, if there is at least one dial-up connection
 			 */
-			bool hasDialup() const;
+			bool hasDialup() const throw ();
 
 			/**
 			 * @return true, if at least one connection is available
 			 */
-			bool isAvailable() const;
+			bool isAvailable() const throw ();
 
 			/**
 			 * @return true, if this node has been announced before
 			 */
-			bool isAnnounced() const;
+			bool isAnnounced() const throw ();
 
 			/**
 			 * Mark this node as announced or not
 			 */
-			void setAnnounced(bool val);
+			void setAnnounced(bool val) throw ();
 
 			friend std::ostream& operator<<(std::ostream&, const Node&);
 
 		private:
-			bool isAvailable(const Node::URI &uri) const;
+			bool isAvailable(const Node::URI &uri) const throw ();
 
 			bool _connect_immediately;
 			dtn::data::EID _id;

--- a/ibrdtn/daemon/src/net/ConnectionManager.cpp
+++ b/ibrdtn/daemon/src/net/ConnectionManager.cpp
@@ -162,7 +162,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::add(const dtn::core::Node &n)
+		void ConnectionManager::add(const dtn::core::Node &n) throw ()
 		{
 			// If node contains MCL
 			if(n.has(Node::CONN_EMAIL) && !n.getEID().getScheme().compare("mail") == 0)
@@ -224,7 +224,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::remove(const dtn::core::Node &n)
+		void ConnectionManager::remove(const dtn::core::Node &n) throw ()
 		{
 			ibrcommon::MutexLock l(_node_lock);
 			try {
@@ -241,7 +241,7 @@ namespace dtn
 				}
 
 				IBRCOMMON_LOGGER_DEBUG_TAG("ConnectionManager", 56) << "Node attributes removed: " << db << IBRCOMMON_LOGGER_ENDL;
-			} catch (const NeighborNotAvailableException&) { };
+			} catch (const NodeNotAvailableException&) { };
 		}
 
 		void ConnectionManager::add(ConvergenceLayer *cl)
@@ -297,7 +297,7 @@ namespace dtn
 			add(node);
 		}
 
-		bool ConnectionManager::isReachable(const dtn::core::Node &node)
+		bool ConnectionManager::isReachable(const dtn::core::Node &node) throw ()
 		{
 			// if the node has been discovered via an dial-up extension
 			// then this node is always considered as reachable
@@ -517,7 +517,7 @@ namespace dtn
 					// re-throw P2PDialupException
 					throw;
 				}
-			} catch (const dtn::net::NeighborNotAvailableException &ex) {
+			} catch (const dtn::net::NodeNotAvailableException &ex) {
 				// signal interruption of the transfer
 				job.abort(dtn::net::TransferAbortedEvent::REASON_CONNECTION_DOWN);
 			} catch (const dtn::net::ConnectionNotAvailableException &ex) {
@@ -526,7 +526,7 @@ namespace dtn
 			}
 		}
 
-		const ConnectionManager::protocol_list ConnectionManager::getSupportedProtocols()
+		const ConnectionManager::protocol_list ConnectionManager::getSupportedProtocols() throw ()
 		{
 			protocol_list ret;
 
@@ -543,7 +543,7 @@ namespace dtn
 			return ret;
 		}
 
-		const ConnectionManager::protocol_list ConnectionManager::getSupportedProtocols(const dtn::data::EID &peer)
+		const ConnectionManager::protocol_list ConnectionManager::getSupportedProtocols(const dtn::data::EID &peer) throw (NodeNotAvailableException)
 		{
 			protocol_list ret;
 
@@ -587,22 +587,22 @@ namespace dtn
 			return ret;
 		}
 
-		const dtn::core::Node ConnectionManager::getNeighbor(const dtn::data::EID &eid) throw (NeighborNotAvailableException)
+		const dtn::core::Node ConnectionManager::getNeighbor(const dtn::data::EID &eid) throw (NodeNotAvailableException)
 		{
 			ibrcommon::MutexLock l(_node_lock);
 			const Node &n = getNode(eid);
 			if (n.isAvailable() && isReachable(n)) return n;
 
-			throw dtn::net::NeighborNotAvailableException();
+			throw dtn::net::NodeNotAvailableException("Node is not reachable or not available.");
 		}
 
-		bool ConnectionManager::isNeighbor(const dtn::core::Node &node)
+		bool ConnectionManager::isNeighbor(const dtn::core::Node &node) throw ()
 		{
 			try {
 				ibrcommon::MutexLock l(_node_lock);
 				const Node &n = getNode(node.getEID());
 				if (n.isAvailable() && isReachable(n)) return true;
-			} catch (const NeighborNotAvailableException&) { }
+			} catch (const NodeNotAvailableException&) { }
 
 			return false;
 		}
@@ -617,10 +617,10 @@ namespace dtn
 			return "ConnectionManager";
 		}
 
-		dtn::core::Node& ConnectionManager::getNode(const dtn::data::EID &eid) throw (NeighborNotAvailableException)
+		dtn::core::Node& ConnectionManager::getNode(const dtn::data::EID &eid) throw (NodeNotAvailableException)
 		{
 			nodemap::iterator iter = _nodes.find(eid);
-			if (iter == _nodes.end()) throw NeighborNotAvailableException("neighbor not found");
+			if (iter == _nodes.end()) throw NodeNotAvailableException("node not found");
 			return (*iter).second;
 		}
 	}

--- a/ibrdtn/daemon/src/net/ConnectionManager.h
+++ b/ibrdtn/daemon/src/net/ConnectionManager.h
@@ -43,10 +43,10 @@ namespace dtn
 {
 	namespace net
 	{
-		class NeighborNotAvailableException : public ibrcommon::Exception
+		class NodeNotAvailableException : public ibrcommon::Exception
 		{
 		public:
-			NeighborNotAvailableException(string what = "The requested neighbor is not available.") throw() : ibrcommon::Exception(what)
+			NodeNotAvailableException(string what = "The requested node is not a neighbor.") throw() : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -67,8 +67,8 @@ namespace dtn
 			ConnectionManager();
 			virtual ~ConnectionManager();
 
-			void add(const dtn::core::Node &n);
-			void remove(const dtn::core::Node &n);
+			void add(const dtn::core::Node &n) throw ();
+			void remove(const dtn::core::Node &n) throw ();
 
 			/**
 			 * Add a convergence layer
@@ -118,12 +118,12 @@ namespace dtn
 			/**
 			 * Returns a list of all supported protocols
 			 */
-			const protocol_list getSupportedProtocols();
+			const protocol_list getSupportedProtocols() throw ();
 
 			/**
 			 * Returns a list of protocol supported by both, local BPA and the peer
 			 */
-			const protocol_list getSupportedProtocols(const dtn::data::EID &peer);
+			const protocol_list getSupportedProtocols(const dtn::data::EID &eid) throw (NodeNotAvailableException);
 
 			/**
 			 * get a set with all neighbors
@@ -136,15 +136,15 @@ namespace dtn
 			 * @param
 			 * @return
 			 */
-			bool isNeighbor(const dtn::core::Node&);
+			bool isNeighbor(const dtn::core::Node&) throw ();
 
 			/**
 			 * Get the neighbor with the given EID.
-			 * @throw dtn::net::NeighborNotAvailableException if the neighbor is not available.
+			 * @throw dtn::net::NodeNotAvailableException if the node is not a neighbor.
 			 * @param eid The EID of the neighbor.
 			 * @return A node object with all neighbor data.
 			 */
-			const dtn::core::Node getNeighbor(const dtn::data::EID &eid) throw (NeighborNotAvailableException);
+			const dtn::core::Node getNeighbor(const dtn::data::EID &eid) throw (NodeNotAvailableException);
 
 			/**
 			 * Add collected data about a neighbor to the neighbor database.
@@ -202,12 +202,12 @@ namespace dtn
 			/**
 			 * check if the node is reachable by any convergence-layer
 			 */
-			bool isReachable(const dtn::core::Node &node);
+			bool isReachable(const dtn::core::Node &node) throw ();
 
 			/**
 			 * get node
 			 */
-			dtn::core::Node& getNode(const dtn::data::EID &eid) throw (NeighborNotAvailableException);
+			dtn::core::Node& getNode(const dtn::data::EID &eid) throw (NodeNotAvailableException);
 
 			// mutex for the list of convergence layers
 			ibrcommon::Mutex _cl_lock;

--- a/ibrdtn/daemon/src/routing/BaseRouter.cpp
+++ b/ibrdtn/daemon/src/routing/BaseRouter.cpp
@@ -249,7 +249,7 @@ namespace dtn
 
 				// add the bundle to the summary vector of the neighbor
 				entry.add(event.getBundle());
-			} catch (const NeighborDatabase::NeighborNotAvailableException&) { };
+			} catch (const NeighborDatabase::EntryNotFoundException&) { };
 
 			// trigger all routing modules to search for bundles to forward
 			__eventTransferCompleted(event.getPeer(), event.getBundle());
@@ -316,7 +316,7 @@ namespace dtn
 
 						// add the bundle to the summary vector of the neighbor
 						_neighbor_database.get(event.peer).add(m);
-					} catch (const NeighborDatabase::NeighborNotAvailableException&) { };
+					} catch (const NeighborDatabase::EntryNotFoundException&) { };
 
 					// store the bundle into a storage module
 					getStorage().store(bundle);
@@ -383,7 +383,7 @@ namespace dtn
 					// add the bundle to the bloomfilter of the receiver to avoid further retries
 					entry.add(meta);
 				}
-			} catch (const NeighborDatabase::NeighborNotAvailableException&) {
+			} catch (const NeighborDatabase::EntryNotFoundException&) {
 			} catch (const dtn::storage::NoBundleFoundException&) { };
 
 			// trigger all routing modules to search for bundles to forward
@@ -414,7 +414,7 @@ namespace dtn
 				try {
 					ibrcommon::MutexLock l(_neighbor_database);
 					_neighbor_database.get( event.getNode().getEID() ).reset();
-				} catch (const NeighborDatabase::NeighborNotAvailableException&) { };
+				} catch (const NeighborDatabase::EntryNotFoundException&) { };
 
 				// new bundles trigger a re-check for all neighbors
 				const std::set<dtn::core::Node> nl = dtn::core::BundleCore::getInstance().getConnectionManager().getNeighbors();
@@ -487,7 +487,7 @@ namespace dtn
 					for (std::set<dtn::core::Node>::const_iterator it = neighbors.begin(); it != neighbors.end(); ++it) {
 						try {
 							_neighbor_database.get( (*it).getEID() );
-						} catch (const NeighborDatabase::NeighborNotAvailableException&) { };
+						} catch (const NeighborDatabase::EntryNotFoundException&) { };
 					}
 
 					// check all neighbor entries for expiration

--- a/ibrdtn/daemon/src/routing/NeighborDatabase.cpp
+++ b/ibrdtn/daemon/src/routing/NeighborDatabase.cpp
@@ -220,15 +220,15 @@ namespace dtn
 			return *(*iter).second;
 		}
 
-		NeighborDatabase::NeighborEntry& NeighborDatabase::get(const dtn::data::EID &eid, bool noCached) throw (NeighborNotAvailableException)
+		NeighborDatabase::NeighborEntry& NeighborDatabase::get(const dtn::data::EID &eid, bool noCached) throw (EntryNotFoundException)
 		{
 			if (noCached && !dtn::core::BundleCore::getInstance().getConnectionManager().isNeighbor(eid))
-				throw NeighborDatabase::NeighborNotAvailableException();
+				throw NeighborDatabase::EntryNotFoundException();
 
 			neighbor_map::iterator iter = _entries.find(eid);
 			if (iter == _entries.end())
 			{
-				throw NeighborNotAvailableException();
+				throw EntryNotFoundException();
 			}
 
 			// set last update timestamp

--- a/ibrdtn/daemon/src/routing/NeighborDatabase.h
+++ b/ibrdtn/daemon/src/routing/NeighborDatabase.h
@@ -77,11 +77,11 @@ namespace dtn
 				virtual ~AlreadyInTransitException() throw () { };
 			};
 
-			class NeighborNotAvailableException : public ibrcommon::Exception
+			class EntryNotFoundException : public ibrcommon::Exception
 			{
 			public:
-				NeighborNotAvailableException() : ibrcommon::Exception("Entry for this neighbor not found.") { };
-				virtual ~NeighborNotAvailableException() throw () { };
+				EntryNotFoundException() : ibrcommon::Exception("Entry for this neighbor not found.") { };
+				virtual ~EntryNotFoundException() throw () { };
 			};
 
 			class DatasetNotAvailableException : public ibrcommon::Exception
@@ -237,7 +237,7 @@ namespace dtn
 			 * @param noCached Only returns an entry if the neighbor is available
 			 * @return The neighbor entry reference.
 			 */
-			NeighborDatabase::NeighborEntry& get(const dtn::data::EID &eid, bool noCached = false) throw (NeighborNotAvailableException);
+			NeighborDatabase::NeighborEntry& get(const dtn::data::EID &eid, bool noCached = false) throw (EntryNotFoundException);
 
 			/**
 			 * Query a neighbor entry of the database. If the entry does not

--- a/ibrdtn/daemon/src/routing/NeighborRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/NeighborRoutingExtension.cpp
@@ -166,11 +166,13 @@ namespace dtn
 							} catch (const NeighborDatabase::AlreadyInTransitException&) { };
 						}
 					} catch (const NeighborDatabase::NoMoreTransfersAvailable &ex) {
-						IBRCOMMON_LOGGER_DEBUG_TAG(NeighborRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-					} catch (const NeighborDatabase::NeighborNotAvailableException &ex) {
-						IBRCOMMON_LOGGER_DEBUG_TAG(NeighborRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+					} catch (const NeighborDatabase::EntryNotFoundException &ex) {
+						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+					} catch (const NodeNotAvailableException &ex) {
+						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 					} catch (const dtn::storage::NoBundleFoundException &ex) {
-						IBRCOMMON_LOGGER_DEBUG_TAG(NeighborRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 					} catch (const std::bad_cast&) { };
 
 					/**
@@ -202,7 +204,9 @@ namespace dtn
 						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 					} catch (const NeighborDatabase::NoMoreTransfersAvailable &ex) {
 						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-					} catch (const NeighborDatabase::NeighborNotAvailableException &ex) {
+					} catch (const NeighborDatabase::EntryNotFoundException &ex) {
+						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+					} catch (const NodeNotAvailableException &ex) {
 						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 					} catch (const NeighborDatabase::NoRouteKnownException &ex) {
 						// nothing to do here.

--- a/ibrdtn/daemon/src/routing/RoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/RoutingExtension.cpp
@@ -90,7 +90,7 @@ namespace dtn
 				IBRCOMMON_LOGGER_DEBUG_TAG(RoutingExtension::TAG, 20) << "bundle " << meta.toString() << " queued for " << destination.getString() << " via protocol " << dtn::core::Node::toString(p) << IBRCOMMON_LOGGER_ENDL;
 			} catch (const dtn::core::P2PDialupException&) {
 				// the bundle transfer queues the bundle for retransmission, thus abort the query here
-				throw NeighborDatabase::NeighborNotAvailableException();
+				throw NeighborDatabase::EntryNotFoundException();
 			} catch (const ibrcommon::Exception &e) {
 				// ignore any other error
 			}

--- a/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
@@ -238,7 +238,9 @@ namespace dtn
 						}
 					} catch (const NeighborDatabase::NoMoreTransfersAvailable &ex) {
 						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-					} catch (const NeighborDatabase::NeighborNotAvailableException &ex) {
+					} catch (const NeighborDatabase::EntryNotFoundException &ex) {
+						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+					} catch (const NodeNotAvailableException &ex) {
 						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 					} catch (const dtn::storage::NoBundleFoundException &ex) {
 						IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
@@ -295,10 +297,13 @@ namespace dtn
 										}
 									}
 								}
-							} catch (const NeighborDatabase::NeighborNotAvailableException&) {
-								// neighbor is not available, can not forward this bundle
+							} catch (const NeighborDatabase::EntryNotFoundException&) {
+								// neighbor is not in the database, can not forward this bundle
 							} catch (const NeighborDatabase::NoMoreTransfersAvailable&) {
-							} catch (const NeighborDatabase::AlreadyInTransitException&) { };
+							} catch (const NeighborDatabase::AlreadyInTransitException&) {
+							} catch (const NodeNotAvailableException &ex) {
+								// node is not available as neighbor
+							};
 						}
 					} catch (const std::bad_cast&) { };
 

--- a/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
@@ -315,7 +315,9 @@ namespace dtn
 							}
 						} catch (const NeighborDatabase::NoMoreTransfersAvailable &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-						} catch (const NeighborDatabase::NeighborNotAvailableException &ex) {
+						} catch (const NeighborDatabase::EntryNotFoundException &ex) {
+							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+						} catch (const NodeNotAvailableException &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 						} catch (const dtn::storage::NoBundleFoundException &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;

--- a/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
@@ -280,7 +280,9 @@ namespace dtn
 							}
 						} catch (const NeighborDatabase::NoMoreTransfersAvailable &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-						} catch (const NeighborDatabase::NeighborNotAvailableException &ex) {
+						} catch (const NeighborDatabase::EntryNotFoundException &ex) {
+							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+						} catch (const NodeNotAvailableException &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 						} catch (const dtn::storage::NoBundleFoundException &ex) {
 							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -129,7 +129,7 @@ namespace dtn
 
 					ibrcommon::MutexLock l(db);
 					db.get(neighbor_node).putDataset(ds);
-				} catch (const NeighborNotAvailableException&) { };
+				} catch (const NeighborDatabase::EntryNotFoundException&) { };
 
 				/* update predictability for this neighbor */
 				updateNeighbor(neighbor_node, neighbor_dp_map);
@@ -546,11 +546,13 @@ namespace dtn
 								} catch (const NeighborDatabase::AlreadyInTransitException&) { };
 							}
 						} catch (const NeighborDatabase::NoMoreTransfersAvailable &ex) {
-							IBRCOMMON_LOGGER_DEBUG_TAG(ProphetRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-						} catch (const NeighborDatabase::NeighborNotAvailableException &ex) {
-							IBRCOMMON_LOGGER_DEBUG_TAG(ProphetRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+						} catch (const NeighborDatabase::EntryNotFoundException &ex) {
+							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+						} catch (const NodeNotAvailableException &ex) {
+							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 						} catch (const dtn::storage::NoBundleFoundException &ex) {
-							IBRCOMMON_LOGGER_DEBUG_TAG(ProphetRoutingExtension::TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
+							IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "task " << t->toString() << " aborted: " << ex.what() << IBRCOMMON_LOGGER_ENDL;
 						} catch (const std::bad_cast&) { }
 
 						/**


### PR DESCRIPTION
There exist two exception classes with the same name. Due to that confusing
construct one of these exceptions was not handled properly. This patch re-organizes
these exceptions and rename both to avoid future confusion.
