### PR TITLE
Add grow-able Bloom-filters

### DIFF
--- a/ibrcommon/ibrcommon/data/BloomFilter.cpp
+++ b/ibrcommon/ibrcommon/data/BloomFilter.cpp
@@ -291,13 +291,16 @@ namespace ibrcommon
 
 	void BloomFilter::load(const cell_type* data, size_t len)
 	{
-		if (len < table_size_)
+		if (len == (table_size_ / bits_per_char))
 		{
 			std::copy(data, data + len, bit_table_);
 		}
 		else
 		{
-			std::copy(data, data + table_size_, bit_table_);
+			table_size_ = len * bits_per_char;
+			delete[] bit_table_;
+			bit_table_ = new cell_type[len];
+			std::copy(data, data + len, bit_table_);
 		}
 
 		_itemcount = 0;

--- a/ibrcommon/ibrcommon/data/BloomFilter.cpp
+++ b/ibrcommon/ibrcommon/data/BloomFilter.cpp
@@ -137,11 +137,12 @@ namespace ibrcommon
 														 };
 
 	BloomFilter::BloomFilter(std::size_t table_size, std::size_t salt_count)
-	 : _hashp(salt_count), table_size_(table_size), _itemcount(0), salt_count_(salt_count)
+	 : _hashp(salt_count), table_size_(table_size), initial_table_size_(table_size), _itemcount(0), salt_count_(salt_count)
 	{
 		// check if table_size_ is multiple of 8
-		if (table_size_ % bits_per_char != 0) {
-			table_size_ += bits_per_char - (table_size_ % bits_per_char);
+		if (initial_table_size_ % bits_per_char != 0) {
+			initial_table_size_ += bits_per_char - (initial_table_size_ % bits_per_char);
+			table_size_ = initial_table_size_;
 		}
 
 		bit_table_ = new cell_type[table_size_ / bits_per_char];
@@ -149,7 +150,7 @@ namespace ibrcommon
 	}
 
 	BloomFilter::BloomFilter(const BloomFilter& filter)
-	 : _hashp(filter._hashp), table_size_(filter.table_size_), _itemcount(filter._itemcount), salt_count_(filter.salt_count_)
+	 : _hashp(filter._hashp), table_size_(filter.table_size_), initial_table_size_(filter.initial_table_size_), _itemcount(filter._itemcount), salt_count_(filter.salt_count_)
 	{
 		bit_table_ = new cell_type[table_size_ / bits_per_char];
 		std::copy(filter.bit_table_, filter.bit_table_ + (table_size_ / bits_per_char), bit_table_);
@@ -177,6 +178,13 @@ namespace ibrcommon
 
 	void BloomFilter::clear()
 	{
+		// shrink Bloom-filter to initial size
+		if (table_size_ > initial_table_size_) {
+			table_size_ = initial_table_size_;
+			delete[] bit_table_;
+			bit_table_ = new cell_type[table_size_ / bits_per_char];
+		}
+
 		std::fill_n(bit_table_,(table_size_ / bits_per_char),0x00);
 		_itemcount = 0;
 	}
@@ -306,6 +314,38 @@ namespace ibrcommon
 		_itemcount = 0;
 	}
 
+	bool BloomFilter::grow(size_t num)
+	{
+		// estimate allocation
+		double alloc = estimateAllocation(num, table_size_);
+
+		// return true, if the allocation is acceptable
+		if (alloc < 0.01) return false;
+
+		size_t nalloc = initial_table_size_ * 2;
+
+		// double maximum of 8 times
+		for (int i = 0; i < 8; ++i)
+		{
+			if (estimateAllocation(num, nalloc) < 0.01) break;
+			nalloc *= 2;
+		}
+
+		if (table_size_ >= nalloc) return false;
+
+		table_size_ = nalloc;
+
+		// create a new table
+		delete[] bit_table_;
+		bit_table_ = new cell_type[table_size_ / bits_per_char];
+
+		std::fill_n(bit_table_,(table_size_ / bits_per_char),0x00);
+		_itemcount = 0;
+
+		// return true to indicate that the filter should get re-filled
+		return true;
+	}
+
 	const cell_type* BloomFilter::table() const
 	{
 		return bit_table_;
@@ -317,12 +357,16 @@ namespace ibrcommon
 		bit = bit_index % bits_per_char;
 	}
 
+	double BloomFilter::estimateAllocation(size_t items, size_t table_size) const
+	{
+		double n = static_cast<double>(items);
+		double k = static_cast<double>(salt_count_);
+		double s = static_cast<double>(table_size);
+		return pow(1 - pow(1 - (1 / s), k * n), k);
+	}
+
 	double BloomFilter::getAllocation() const
 	{
-		double m = static_cast<double>(table_size_);
-		double n = static_cast<double>(_itemcount);
-		double k = static_cast<double>(salt_count_);
-
-		return pow(1 - pow(1 - (1 / m), k * n), k);
+		return estimateAllocation(_itemcount, table_size_);
 	}
 }

--- a/ibrcommon/ibrcommon/data/BloomFilter.h
+++ b/ibrcommon/ibrcommon/data/BloomFilter.h
@@ -164,7 +164,16 @@ namespace ibrcommon
 
 		const cell_type* table() const;
 
+		/**
+		 * Returns the allocation
+		 */
 		double getAllocation() const;
+
+		/**
+		 * Increase the Bloom-filter table by the initial size
+		 * This operation also clears all elements
+		 */
+		bool grow(size_t num);
 
 	protected:
 		virtual void compute_indices(const bloom_type& hash, std::size_t& bit_index, std::size_t& bit) const;
@@ -172,9 +181,17 @@ namespace ibrcommon
 
 		unsigned char*          bit_table_;
 		std::size_t             table_size_;
+		std::size_t             initial_table_size_;
 
 		unsigned int _itemcount;
 		std::size_t salt_count_;
+
+	private:
+		/**
+		 * Returns the allocation under the assumption that the given number
+		 * of items is stored within the filter
+		 */
+		double estimateAllocation(size_t items, size_t table_size) const;
 	};
 }
 

--- a/ibrcommon/tests/unittests/BloomFilterTest.cpp
+++ b/ibrcommon/tests/unittests/BloomFilterTest.cpp
@@ -118,23 +118,15 @@ void BloomFilterTest::testLoad()
 	ibrcommon::BloomFilter Filter(8196,2);
 	const ibrcommon::cell_type* cad1;
 	const ibrcommon::cell_type* cad2;
-	cad1 = (const ibrcommon::cell_type*)"Hello World";
-	Filter.load(cad1, sizeof(cad1));
+	cad1 = (const ibrcommon::cell_type*)"Hello World\0";
+	Filter.load(cad1, 12);
 	cad2 = Filter.table();
 	int i = 0;
 	bool dif;
 	while (cad1[i] != 0 && cad2[i] != 0)
 	{
-		if (cad1[i] == cad2[i])
-		{
-			dif = true ;
-		}
-		else
-		{
-			dif= false;
-		}
-	i++;
-	CPPUNIT_ASSERT_EQUAL(true,dif);
+		i++;
+		CPPUNIT_ASSERT_EQUAL(cad1[i], cad2[i]);
 	}
 }
 

--- a/ibrcommon/tests/unittests/BloomFilterTest.cpp
+++ b/ibrcommon/tests/unittests/BloomFilterTest.cpp
@@ -516,7 +516,7 @@ void BloomFilterTest::testMemory()
 	Filter1.insert("test");
 	CPPUNIT_ASSERT(Filter1.contains("test"));
 	Filter1.clear();
-	CPPUNIT_ASSERT_EQUAL(false, Filter1.contains("test"));
+	CPPUNIT_ASSERT(!Filter1.contains("test"));
 
 }
 /*=== END   tests for class 'BloomFilter' ===*/

--- a/ibrdtn/daemon/tests/unittests/BundleSetTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/BundleSetTest.cpp
@@ -282,6 +282,25 @@ void BundleSetTest::persistanceTest()
 	CPPUNIT_ASSERT_EQUAL(num_bundles,size_after);
 }
 
+void BundleSetTest::sizeTest()
+{
+	BundleSet src(NULL, 12000);
+	genbundles(src,100,10,15);
+
+	BundleSet dst;
+	genbundles(dst,100,10,15);
+
+	CPPUNIT_ASSERT(src.getBloomFilter().size() != dst.getBloomFilter().size());
+
+	std::stringstream ss;
+	ss << src;
+	ss.clear();
+
+	ss >> dst;
+
+	CPPUNIT_ASSERT_EQUAL(src.getBloomFilter().size(), dst.getBloomFilter().size());
+}
+
 void BundleSetTest::genbundles(dtn::data::BundleSet &l, int number, int offset, int max)
 {
 	int range = max - offset;

--- a/ibrdtn/daemon/tests/unittests/BundleSetTest.hh
+++ b/ibrdtn/daemon/tests/unittests/BundleSetTest.hh
@@ -67,6 +67,7 @@ class BundleSetTest : public CppUnit::TestFixture {
 		void namingTest();
 		void performanceTest();
 		void persistanceTest();
+		void sizeTest();
 
 		void setUp();
 		void tearDown();
@@ -84,6 +85,7 @@ class BundleSetTest : public CppUnit::TestFixture {
 		CPPUNIT_TEST_ALL_STORAGES(namingTest);
 		CPPUNIT_TEST_ALL_STORAGES(performanceTest);
 		CPPUNIT_TEST_ALL_STORAGES(persistanceTest);
+		CPPUNIT_TEST_ALL_STORAGES(sizeTest);
 		CPPUNIT_TEST_SUITE_END();
 
 		static size_t testCounter;


### PR DESCRIPTION
This patch-set solves #142 but may also break downward compatibility since there is a bug in version 1.0.0 that may crash the daemon on receiving a Bloom-filter with a different size.