### PR TITLE
Regex endpoints

### DIFF
--- a/ibrdtn/daemon/src/api/Registration.cpp
+++ b/ibrdtn/daemon/src/api/Registration.cpp
@@ -226,7 +226,7 @@ namespace dtn
 #endif
 			{
 			public:
-				BundleFilter(const std::set<dtn::data::EID> endpoints, const RegistrationQueue &queue, bool loopback, bool fragment_filter)
+				BundleFilter(const std::set<dtn::data::EID> &endpoints, const RegistrationQueue &queue, bool loopback, bool fragment_filter)
 				 : _endpoints(endpoints), _queue(queue), _loopback(loopback), _fragment_filter(fragment_filter)
 				{};
 
@@ -307,7 +307,7 @@ namespace dtn
 #endif
 
 			private:
-				const std::set<dtn::data::EID> _endpoints;
+				const std::set<dtn::data::EID> &_endpoints;
 				const RegistrationQueue &_queue;
 				const bool _loopback;
 				const bool _fragment_filter;

--- a/ibrdtn/ibrdtn/configure.ac
+++ b/ibrdtn/ibrdtn/configure.ac
@@ -112,6 +112,10 @@ ANDROID_AC_BUILD([
 	ZLIB_LIBS="-lz"
 	AC_SUBST(ZLIB_LIBS)
 	with_compression="yes"
+	
+	# REGEX
+	AC_DEFINE(HAVE_REGEX_H, [1] ["Define to 1 if you have the <regex.h> header file."])
+	have_regex="yes"
 ],[
 #ANDROID else begin
 	AC_CHECK_HEADERS([netinet/in.h])
@@ -268,6 +272,15 @@ ANDROID_AC_BUILD([
 		])
 	],[
 		with_compression="no"
+	])
+	
+	dnl -----------------------------------------------
+	dnl check for regex capabilities
+	dnl -----------------------------------------------
+	AC_CHECK_HEADERS([regex.h], [
+		have_regex="yes"
+	], [
+		have_regex="no"
 	])
 #ANDROID else end
 ])

--- a/ibrdtn/ibrdtn/ibrdtn/data/EID.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/EID.h
@@ -123,6 +123,21 @@ namespace dtn
 			typedef std::pair<Number, Number> Compressed;
 			Compressed getCompressed() const;
 
+			/**
+			 * Prepares an internal regular expression structure for matching
+			 * against another EID. If the compilation of the structure
+			 * fails an exception is throw.
+			 */
+			void prepare() throw (ibrcommon::Exception);
+
+			/**
+			 * Matches this EID against another EID by interpreting the result
+			 * of getString() as regular expression. This method need a preceding
+			 * call of prepare() otherwise the string is matched using the
+			 * standard compare operators.
+			 */
+			bool match(const dtn::data::EID &other) const;
+
 		private:
 			/**
 			 * private constructor to create a modified EID
@@ -151,6 +166,9 @@ namespace dtn
 			// CBHE scheme
 			Number _cbhe_node;
 			Number _cbhe_application;
+
+			// regex structure
+			void *_regex;
 
 			// well-known CBHE numbers
 			typedef std::map<std::string, Number> cbhe_map;


### PR DESCRIPTION
The match() support of EIDs allows to use regular expressions as endpoint identifiers.
Using this capability applications are able to match wildcard endpoints. E.g. an application
registered to "app/\(.*\)" can receive bundles address to dtn://node/app/foo as well as
dtn://node/app/bar.