### PR TITLE
RWMutex initialisation fix & improved logging 

### DIFF
--- a/ibrcommon/ibrcommon/thread/RWMutex.cpp
+++ b/ibrcommon/ibrcommon/thread/RWMutex.cpp
@@ -21,11 +21,14 @@
 
 #include "ibrcommon/thread/RWMutex.h"
 #include <errno.h>
+#include <cstring>
 
 namespace ibrcommon
 {
 	RWMutex::RWMutex()
 	{
+		std::memset(&_rwlock,0,sizeof(pthread_rwlock_t));
+		
 		switch(pthread_rwlock_init(&_rwlock, NULL))
 		{
 			case 0:

--- a/ibrcommon/ibrcommon/thread/RWMutex.cpp
+++ b/ibrcommon/ibrcommon/thread/RWMutex.cpp
@@ -26,12 +26,50 @@ namespace ibrcommon
 {
 	RWMutex::RWMutex()
 	{
-		pthread_rwlock_init(&_rwlock, NULL);
+		switch(pthread_rwlock_init(&_rwlock, NULL))
+		{
+			case 0:
+				break;
+			
+			case EAGAIN:
+				throw MutexException("The mutex could not be initialized because the system lacked the necessary resources (EAGAIN).");
+				break;
+			case ENOMEM:
+				throw MutexException("The mutex could not be initialized because insufficient memory exists  (ENOMEM).");
+				break;
+			case EPERM:
+				throw MutexException("The mutex could not be initialized because the caller does not have sufficient privileges (EPERM).");
+				break;
+			case EBUSY:
+				throw MutexException("The mutex could not be initialized because the system has detected an attempt to re-initialize a previously initialized but not yet destroyed read/write lock (EBUSY).");
+				break;
+			case EINVAL:
+				throw MutexException("The mutex could not be initialized because a paramter is invalid (EINVAL).");
+				break;
+			default:
+				throw MutexException("The mutex could not be initialized. Reason unknown.");
+		}
 	}
 
 	RWMutex::~RWMutex()
 	{
-		pthread_rwlock_destroy(&_rwlock);
+		switch(pthread_rwlock_destroy(&_rwlock))
+		{
+			case 0:
+				break;
+				
+			case EPERM:
+				throw MutexException("The mutex could not be destroyed because the caller does not have sufficient privileges (EPERM).");
+				break;	
+			case EBUSY:
+				throw MutexException("The mutex could not be destroyed because it is still locked (EBUSY).");
+				break;
+			case EINVAL:
+				throw MutexException("The mutex could not be destroyed because a paramter is invalid (EINVAL).");
+				break;
+			default:
+				throw MutexException("The mutex could not be destroyed. Reason unknown.");			
+		}
 	}
 
 	void RWMutex::trylock() throw (MutexException)

--- a/ibrcommon/tests/thread/MutexTests.cpp
+++ b/ibrcommon/tests/thread/MutexTests.cpp
@@ -103,6 +103,9 @@ void MutexTests::rwmutex_test_readonly()
 
 	// try to lock the mutex for a read-write access (should fail)
 	CPPUNIT_ASSERT_THROW(rwm.trylock_wr(), ibrcommon::MutexException);
+	
+	//Release original lock
+	CPPUNIT_ASSERT_NO_THROW(rwm.leave());
 }
 
 void MutexTests::rwmutex_test_readwrite()


### PR DESCRIPTION
RWMutex tests failed on OS X if the memory used by "pthread_rwlock_t" used in pthread_rwlock_init looks like a locked pthread_rwlock_t structure.

This is fixed by initialising the lock structure using memset. PTHREAD_RWLOCK_INITIALIZER seems to be implemented differently on different systems, and therefore cannot be used on Linux and OS X in the same way (also not libcs might support it yet).
