### PR TITLE
daemon: Add missing lock for the retransmission set

### DIFF
--- a/ibrdtn/daemon/src/routing/RetransmissionExtension.cpp
+++ b/ibrdtn/daemon/src/routing/RetransmissionExtension.cpp
@@ -62,6 +62,8 @@ namespace dtn
 		{
 			// remove the bundleid in our list
 			RetransmissionData data(meta, peer);
+
+			ibrcommon::MutexLock l(_mutex);
 			_set.erase(data);
 		}
 
@@ -106,6 +108,8 @@ namespace dtn
 		{
 			// remove the bundleid in our list
 			RetransmissionData data(aborted.getBundleID(), aborted.getPeer());
+
+			ibrcommon::MutexLock l(_mutex);
 			_set.erase(data);
 		}
 


### PR DESCRIPTION
Prior this patch there exist erase operations without locking. Since
these operations are triggered by events, a lock is required to not
collide with concurrent operations.