### PR TITLE
daemon: Optimize get() in MemoryBundleStorage

### DIFF
--- a/ibrdtn/daemon/src/storage/MemoryBundleStorage.cpp
+++ b/ibrdtn/daemon/src/storage/MemoryBundleStorage.cpp
@@ -117,6 +117,11 @@ namespace dtn
 				for (bundle_list::const_iterator iter = _bundles.begin(); iter != _bundles.end(); ++iter)
 				{
 					const dtn::data::Bundle &bundle = (*iter);
+
+					// the bundles are sorted, therefore it is possible to optimize
+					// the search for the bundle by skipping all "lower" bundles
+					if (id > bundle) continue;
+
 					if (id == bundle)
 					{
 						if (_faulty) {
@@ -125,6 +130,9 @@ namespace dtn
 
 						return bundle;
 					}
+
+					// stop here, following bundles are "greater"
+					break;
 				}
 			} catch (const dtn::SerializationFailedException &ex) {
 				// bundle loading failed

--- a/ibrdtn/daemon/tests/unittests/BundleStorageTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/BundleStorageTest.cpp
@@ -749,6 +749,40 @@ void BundleStorageTest::testDoubleStore(dtn::storage::BundleStorage &storage)
 	CPPUNIT_ASSERT_EQUAL((dtn::data::Size)1, storage.count());
 }
 
+void BundleStorageTest::testGet()
+{
+	STORAGE_TEST(testGet);
+}
+
+void BundleStorageTest::testGet(dtn::storage::BundleStorage &storage)
+{
+	// create some bundles
+	std::list<dtn::data::Bundle> list;
+
+	for (int i = 0; i < 2000; ++i)
+	{
+		dtn::data::Bundle b;
+		b.lifetime = 1;
+		b.source = dtn::data::EID("dtn://node-two/foo");
+		ibrcommon::BLOB::Reference ref = ibrcommon::BLOB::create();
+		b.push_back(ref);
+
+		(*ref.iostream()) << "Hallo Welt" << std::endl;
+
+		list.push_back(b);
+		storage.store(b);
+	}
+
+	// in parallel we try to retrieve bundles from list1
+	for (std::list<dtn::data::Bundle>::const_reverse_iterator iter = list.rbegin(); iter != list.rend(); ++iter)
+	{
+		const dtn::data::Bundle &b = (*iter);
+		dtn::data::Bundle bundle = storage.get(b);
+	}
+
+	storage.clear();
+}
+
 void BundleStorageTest::testFaultyGet()
 {
 	STORAGE_TEST(testFaultyGet);

--- a/ibrdtn/daemon/tests/unittests/BundleStorageTest.hh
+++ b/ibrdtn/daemon/tests/unittests/BundleStorageTest.hh
@@ -44,6 +44,7 @@ class BundleStorageTest : public CppUnit::TestFixture {
 		void testSelector(dtn::storage::BundleStorage &storage);
 		void testRemoveBloomfilter(dtn::storage::BundleStorage &storage);
 		void testDoubleStore(dtn::storage::BundleStorage &storage);
+		void testGet(dtn::storage::BundleStorage &storage);
 		void testFaultyGet(dtn::storage::BundleStorage &storage);
 		void testFaultyStore(dtn::storage::BundleStorage &storage);
 		void testQueryBloomFilter(dtn::storage::BundleStorage &storage);
@@ -78,6 +79,7 @@ class BundleStorageTest : public CppUnit::TestFixture {
 		void testDistinctDestinations();
 		void testSelector();
 		void testDoubleStore();
+		void testGet();
 		void testFaultyGet();
 		void testFaultyStore();
 		void testQueryBloomFilter();
@@ -113,6 +115,7 @@ class BundleStorageTest : public CppUnit::TestFixture {
 		CPPUNIT_TEST_ALL_STORAGES(testDistinctDestinations);
 		CPPUNIT_TEST_ALL_STORAGES(testSelector);
 		CPPUNIT_TEST_ALL_STORAGES(testDoubleStore);
+		CPPUNIT_TEST_ALL_STORAGES(testGet);
 		CPPUNIT_TEST_ALL_STORAGES(testFaultyGet);
 		CPPUNIT_TEST_ALL_STORAGES(testFaultyStore);
 		CPPUNIT_TEST_ALL_STORAGES(testQueryBloomFilter);


### PR DESCRIPTION
By exploiting the ordered set of bundles, the
search can be aborted earlier if the bundle does not
exist in the storage.