### PR TITLE
android-daemon: Store bundles in private storage

### DIFF
--- a/android/ibrdtn/res/values-de/strings.xml
+++ b/android/ibrdtn/res/values-de/strings.xml
@@ -50,7 +50,7 @@
     <string name="pref_log_debug_verbosity">Debug Verbosity Level</string>
     <string name="pref_log_debug_verbosity_desc">Benötigt Log Level DEBUG</string>
     <string name="pref_log_enable_file">Speichere Log als Datei</string>
-    <string name="pref_log_enable_file_desc">Speichert das Log als Datei in ibrdtn/logs/ auf dem externen Speicher.</string>
+    <string name="pref_log_enable_file_desc">Speichert das Log als Datei in Download/logs/ auf dem externen Speicher.</string>
     <string name="pref_debugging">Entwickler Modus</string>
     <string name="pref_debugging_desc">Entwickleroptionen einschalten.</string>
     <string name="list_no_log">Keine Einträge gefunden.</string>

--- a/android/ibrdtn/res/values/strings.xml
+++ b/android/ibrdtn/res/values/strings.xml
@@ -50,7 +50,7 @@
     <string name="pref_log_debug_verbosity">Debug Verbosity Level</string>
     <string name="pref_log_debug_verbosity_desc">Requires logging level DEBUG</string>
     <string name="pref_log_enable_file">Log to File</string>
-    <string name="pref_log_enable_file_desc">Also log into files in ibrdtn/logs/ on your external storage.</string>
+    <string name="pref_log_enable_file_desc">Also log into files in Download/logs/ on your external storage.</string>
     <string name="pref_debugging">Developer Mode</string>
     <string name="pref_debugging_desc">Enable debugging options.</string>
     <string name="list_no_log">No logs found.</string>

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/daemon/Preferences.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/daemon/Preferences.java
@@ -709,6 +709,8 @@ public class Preferences extends PreferenceActivity {
 
 						logFilePath = logPath.getPath() + File.separatorChar + "ibrdtn_" + time
 								+ ".log";
+					} else {
+						Log.e(TAG, "External media for logging is not mounted");
 					}
 				}
 				
@@ -913,6 +915,8 @@ public class Preferences extends PreferenceActivity {
 				File blobPath = DaemonStorageUtils.getBlobPath(context);
 				if (blobPath != null) {
 					p.println("blob_path = " + blobPath.getPath());
+				} else {
+					Log.e(TAG, "Internal cache directory is not available");
 				}
 			}
 
@@ -921,6 +925,8 @@ public class Preferences extends PreferenceActivity {
 				if (bundlePath != null) {
 					p.println("storage_path = " + bundlePath.getPath());
 					p.println("use_persistent_bundlesets = yes");
+				} else {
+					Log.e(TAG, "External media to store bundles is not mounted");
 				}
 			}
 

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/DaemonProcess.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/DaemonProcess.java
@@ -280,6 +280,8 @@ public class DaemonProcess {
                         + cal.get(Calendar.HOUR) + cal.get(Calendar.MINUTE) + cal.get(Calendar.SECOND);
                 
                 logFilePath = logPath.getPath() + File.separatorChar + "ibrdtn_" + time + ".log";
+            } else {
+                Log.e(TAG, "External media for logging is not mounted");
             }
         }
 

--- a/android/ibrdtn/src/de/tubs/ibr/dtn/service/DaemonStorageUtils.java
+++ b/android/ibrdtn/src/de/tubs/ibr/dtn/service/DaemonStorageUtils.java
@@ -52,8 +52,8 @@ public class DaemonStorageUtils {
 	{
 		if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED))
 		{
-			File externalStorage = Environment.getExternalStorageDirectory();
-			return new File(externalStorage.getPath() + File.separatorChar + "ibrdtn" + File.separatorChar + "storage");
+			File externalStorage = context.getExternalFilesDir(null);
+			return new File(externalStorage.getPath() + File.separatorChar + "storage");
 		}
 
 		return null;
@@ -63,8 +63,8 @@ public class DaemonStorageUtils {
 	{
 		if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED))
 		{
-			File externalStorage = Environment.getExternalStorageDirectory();
-			return new File(externalStorage.getPath() + File.separatorChar + "ibrdtn" + File.separatorChar + "logs");
+			File externalStorage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+			return new File(externalStorage.getPath() + File.separatorChar + "logs");
 		}
 
 		return null;


### PR DESCRIPTION
The logfile, bundles, and temporary files are no longer
stored in "/sdcard/ibrdtn". Instead the logfiles are stored
in the Download directory on the external media. Bundles
are placed within the private folder on the external
media and temporary files (BLOBs) are stored in the
internal app cache directory.