### PR TITLE
Android remove separate app folder

### DIFF
--- a/android/ShareBox/src/de/tubs/ibr/dtn/sharebox/data/Utils.java
+++ b/android/ShareBox/src/de/tubs/ibr/dtn/sharebox/data/Utils.java
@@ -75,10 +75,10 @@ public class Utils {
     {
         if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED))
         {
-            File externalStorage = Environment.getExternalStorageDirectory();
+            File externalStorage = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
             
             // create working directory
-            File sharefolder = new File(externalStorage.getPath() + File.separatorChar + "sharebox");
+            File sharefolder = new File(externalStorage.getPath() + File.separatorChar + "ShareBox");
             if (!sharefolder.exists())
             {
                     sharefolder.mkdir();

--- a/android/Talkie/src/de/tubs/ibr/dtn/dtalkie/service/RecorderService.java
+++ b/android/Talkie/src/de/tubs/ibr/dtn/dtalkie/service/RecorderService.java
@@ -225,12 +225,8 @@ public class RecorderService extends Service {
             
             Log.i(TAG, "start recording audio for " + mDestination.toString());
             
-            File path = Utils.getStoragePath();
+            File path = Utils.getStoragePath(this);
             
-            if (path == null) {
-                Log.e(TAG, "no storage path available");
-            }
-
             try {
                 Log.i(TAG, "create temporary file in " + path.getAbsolutePath());
 

--- a/android/Talkie/src/de/tubs/ibr/dtn/dtalkie/service/TalkieService.java
+++ b/android/Talkie/src/de/tubs/ibr/dtn/dtalkie/service/TalkieService.java
@@ -169,7 +169,7 @@ public class TalkieService extends DTNIntentService {
 		public TransferMode startBlock(Block block) {
 			if ((block.type == 1) && (file == null))
 			{
-				File folder = Utils.getStoragePath();
+				File folder = Utils.getStoragePath(TalkieService.this);
 				
 				// create a new temporary file
 				try {

--- a/android/Talkie/src/de/tubs/ibr/dtn/dtalkie/service/Utils.java
+++ b/android/Talkie/src/de/tubs/ibr/dtn/dtalkie/service/Utils.java
@@ -80,35 +80,20 @@ public class Utils {
 		builder.show();
 	}
 	
-    public static File getStoragePath()
-    {
-        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED))
-        {
-            File externalStorage = Environment.getExternalStorageDirectory();
-            
-            // create working directory
-            File sharefolder = new File(externalStorage.getPath() + File.separatorChar + "dtalkie");
-            if (!sharefolder.exists())
-            {
-                    sharefolder.mkdir();
-            }
-            
-            // add gallery hide file
-            File hideFile = new File(sharefolder.getPath() + File.separatorChar + ".nomedia");
-            if (!hideFile.exists()) {
-                try {
-                    hideFile.createNewFile();
-                } catch (IOException e) {
-                    Log.e(TAG, null, e);
-                }
-            }
-            
-            return sharefolder;
-        }
-        
-        return null;
-    }
-    
+	public static File getStoragePath(Context context)
+	{
+		File externalStorage = context.getFilesDir();
+
+		// create working directory
+		File sharefolder = new File(externalStorage.getPath() + File.separatorChar + "audio");
+		if (!sharefolder.exists())
+		{
+			sharefolder.mkdir();
+		}
+
+		return sharefolder;
+	}
+
     public static void lockScreenOrientation(Activity activity) {
         int orientation = activity.getResources().getConfiguration().orientation;
         activity.setRequestedOrientation(orientation);


### PR DESCRIPTION
Talkie now used the internal app storage to store audio files.
ShareBox now stores its files in the public download folder on
the external media.