### PR TITLE
Fix handling of semaphore for file resources

### DIFF
--- a/ibrcommon/ibrcommon/data/BLOB.cpp
+++ b/ibrcommon/ibrcommon/data/BLOB.cpp
@@ -307,6 +307,9 @@ namespace ibrcommon
 
 		if (!_filestream.is_open())
 		{
+			// Release semaphore on failed file open
+			ibrcommon::BLOB::_filelimit.post();
+
 			throw ibrcommon::CanNotOpenFileException(_file);
 		}
 	}
@@ -359,6 +362,9 @@ namespace ibrcommon
 
 		if (!_filestream.is_open())
 		{
+			// Release semaphore on failed file open
+			ibrcommon::BLOB::_filelimit.post();
+
 			IBRCOMMON_LOGGER_TAG("TmpFileBLOB::open", error) << "can not open temporary file " << _tmpfile.getPath() << IBRCOMMON_LOGGER_ENDL;
 			throw ibrcommon::CanNotOpenFileException(_tmpfile);
 		}

--- a/ibrdtn/daemon/src/storage/SQLiteBundleStorage.cpp
+++ b/ibrdtn/daemon/src/storage/SQLiteBundleStorage.cpp
@@ -84,6 +84,9 @@ namespace dtn
 
 			if (!_filestream.is_open())
 			{
+				// Release semaphore on failed file open
+				ibrcommon::BLOB::_filelimit.post();
+
 				IBRCOMMON_LOGGER_TAG(SQLiteBundleStorage::TAG, error) << "can not open temporary file " << _file.getPath() << IBRCOMMON_LOGGER_ENDL;
 				throw ibrcommon::CanNotOpenFileException(_file);
 			}


### PR DESCRIPTION
If the open() method of file-based BLOBs fails, the resources allocated within the semaphore is never released. This patch fixes this issue.