### PR TITLE
Make push notification of PRoPHET routing optional

### DIFF
--- a/ibrcommon/ibrcommon/Iterator.h
+++ b/ibrcommon/ibrcommon/Iterator.h
@@ -58,6 +58,22 @@ namespace ibrcommon
 			}
 		}
 	};
+
+	template <class map>
+	class key_iterator {
+		typename map::const_iterator iter_;
+	public:
+		key_iterator() {}
+		key_iterator(typename map::iterator iter) :iter_(iter) {}
+		key_iterator(typename map::const_iterator iter) :iter_(iter) {}
+		key_iterator(const key_iterator& b) :iter_(b.iter_) {}
+		key_iterator& operator=(const key_iterator& b) {iter_ = b.iter_; return *this;}
+		key_iterator& operator++() {++iter_; return *this;}
+		key_iterator operator++(int) {return KeyIterator(iter_++);}
+		const typename map::key_type& operator*() {return iter_->first;}
+		bool operator==(const key_iterator& b) {return iter_==b.iter_;}
+		bool operator!=(const key_iterator& b) {return iter_!=b.iter_;}
+	};
 }
 
 #endif /*IBRCOMMON_ITERATOR_H_*/

--- a/ibrdtn/daemon/etc/ibrdtnd.conf
+++ b/ibrdtn/daemon/etc/ibrdtnd.conf
@@ -303,6 +303,8 @@ routing = prophet
 #prophet_forwarding_strategy = GRTR   #The forwarding strategy used GRTR | GTMX
 #prophet_gtmx_nf_max = 30             #Maximum times to forward in the GTMX
                                       #strategy
+#prophet_push_notification = no       #Push notifications to neighbors if new
+                                      #routes are found
 
 #####################################
 # bundle security protocol          #

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -795,6 +795,7 @@ namespace dtn
 				_prophet_config.next_exchange_timeout = conf.read<ibrcommon::Timer::time_t>("prophet_next_exchange_timeout", 600);
 				_prophet_config.forwarding_strategy = conf.read<std::string>("prophet_forwarding_strategy", "GRTR");
 				_prophet_config.gtmx_nf_max = conf.read<unsigned int>("prophet_gtmx_nf_max", 30);
+				_prophet_config.push_notification = (conf.read<std::string>("prophet_push_notification", "no") == "yes");
 			}
 
 			/**

--- a/ibrdtn/daemon/src/Configuration.h
+++ b/ibrdtn/daemon/src/Configuration.h
@@ -288,7 +288,7 @@ namespace dtn
 				public:
 					ProphetConfig()
 					: p_encounter_max(0), p_encounter_first(0), p_first_threshold(0), beta(0), gamma(0), delta(0),
-					  time_unit(0), i_typ(0), next_exchange_timeout(0), forwarding_strategy(), gtmx_nf_max(0)
+					  time_unit(0), i_typ(0), next_exchange_timeout(0), forwarding_strategy(), gtmx_nf_max(0), push_notification(false)
 					{ }
 
 					~ProphetConfig() { }
@@ -304,6 +304,7 @@ namespace dtn
 					ibrcommon::Timer::time_t next_exchange_timeout;
 					std::string forwarding_strategy;
 					unsigned int gtmx_nf_max;
+					bool push_notification;
 				};
 			protected:
 				Network();

--- a/ibrdtn/daemon/src/NativeDaemon.cpp
+++ b/ibrdtn/daemon/src/NativeDaemon.cpp
@@ -1645,7 +1645,8 @@ namespace dtn
 												prophet_config.p_encounter_first, prophet_config.p_first_threshold,
 												prophet_config.beta, prophet_config.gamma, prophet_config.delta,
 												prophet_config.time_unit, prophet_config.i_typ,
-												prophet_config.next_exchange_timeout));
+												prophet_config.next_exchange_timeout,
+												prophet_config.push_notification));
 
 				// add neighbor routing (direct-delivery) extension
 				router.add( new dtn::routing::NeighborRoutingExtension() );

--- a/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.cpp
@@ -340,5 +340,15 @@ namespace dtn
 #endif
 			return hashCode;
 		}
+
+		DeliveryPredictabilityMap::const_iterator DeliveryPredictabilityMap::begin() const
+		{
+			return _predictmap.begin();
+		}
+
+		DeliveryPredictabilityMap::const_iterator DeliveryPredictabilityMap::end() const
+		{
+			return _predictmap.end();
+		}
 	} /* namespace routing */
 } /* namespace dtn */

--- a/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.h
+++ b/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.h
@@ -12,6 +12,7 @@
 #include "routing/NodeHandshake.h"
 #include <ibrdtn/data/EID.h>
 #include <ibrcommon/thread/Mutex.h>
+#include <ibrcommon/Iterator.h>
 #include <map>
 
 namespace dtn
@@ -86,8 +87,16 @@ namespace dtn
 			 */
 			unsigned int hashCode() const;
 
-		private:
+			/**
+			 * Iterator methods and definitions
+			 */
 			typedef std::map<dtn::data::EID, float> predictmap;
+			typedef ibrcommon::key_iterator<predictmap> const_iterator;
+
+			const_iterator begin() const;
+			const_iterator end() const;
+
+		private:
 			predictmap _predictmap;
 
 			float _beta; ///< Weight of the transitive property of prophet.

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.h
@@ -65,7 +65,7 @@ namespace dtn
 			ProphetRoutingExtension(ForwardingStrategy *strategy, float p_encounter_max, float p_encounter_first,
 						float p_first_threshold, float beta, float gamma, float delta,
 						size_t time_unit, size_t i_typ,
-						dtn::data::Timestamp next_exchange_timeout);
+						dtn::data::Timestamp next_exchange_timeout, bool push_notification);
 			virtual ~ProphetRoutingExtension();
 
 			virtual const std::string getTag() const throw ();
@@ -151,6 +151,7 @@ namespace dtn
 			float _p_first_threshold; ///< If the predictability falls below this value, it is erased from the map and _p_encounter_first will be used on the next encounter.
 			float _delta; ///< Maximum predictability is (1-delta).
 			size_t _i_typ; ///< time interval that is characteristic for the network
+			bool _push_notification; ///< true if push notifications should sent
 
 			typedef std::map<dtn::data::EID, dtn::data::Timestamp> age_map;
 			age_map _ageMap; ///< map with time for each neighbor, when the last encounter happened


### PR DESCRIPTION
Push notifications are now only sent if the option is set within the configuration to yes and if new routes found. Disappearing endpoints no longer issue a notification. 