### PR TITLE
daemon: PRoPHET broadcast routing optimization

### DIFF
--- a/ibrdtn/daemon/src/routing/prophet/ForwardingStrategy.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ForwardingStrategy.cpp
@@ -51,6 +51,18 @@ namespace dtn
 			return false;
 		}
 
+		bool ForwardingStrategy::isBackrouteValid(const DeliveryPredictabilityMap& neighbor_dpm, const dtn::data::EID& source) const
+		{
+			ibrcommon::MutexLock dpm_lock(_prophet_router->_deliveryPredictabilityMap);
+
+			// if this is a non-singleton, check if we or the peer know a way to the source
+			try {
+				return ((_prophet_router->_deliveryPredictabilityMap.get(source.getNode()) > 0.0) || (neighbor_dpm.get(source.getNode()) > 0.0));
+			} catch (const dtn::routing::DeliveryPredictabilityMap::ValueNotFoundException&) {
+				return false;
+			}
+		}
+
 		void ForwardingStrategy::setProphetRouter(ProphetRoutingExtension *router)
 		{
 			_prophet_router = router;

--- a/ibrdtn/daemon/src/routing/prophet/ForwardingStrategy.h
+++ b/ibrdtn/daemon/src/routing/prophet/ForwardingStrategy.h
@@ -26,6 +26,7 @@ namespace dtn
 		public:
 			ForwardingStrategy();
 			virtual ~ForwardingStrategy() = 0;
+
 			/*!
 			 * The prophetRoutingExtension calls this function for every bundle that can be forwarded to a neighbor
 			 * and forwards it depending on the return value.
@@ -35,10 +36,16 @@ namespace dtn
 			 * \return true if the bundle should be forwarded
 			 */
 			virtual bool shallForward(const DeliveryPredictabilityMap& neighbor_dpm, const dtn::data::MetaBundle& bundle) const = 0;
+
 			/*!
 			 * checks if the deliveryPredictability of the neighbor is higher than that of the destination of the bundle.
 			 */
 			bool neighborDPIsGreater(const DeliveryPredictabilityMap& neighbor_dpm, const dtn::data::EID& destination) const;
+
+			/*!
+			 * checks if a backwards route exists to the source
+			 */
+			bool isBackrouteValid(const DeliveryPredictabilityMap& neighbor_dpm, const dtn::data::EID& source) const;
 
 			/**
 			 * Set back-reference to the prophet router

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -397,22 +397,10 @@ namespace dtn
 						{
 							return false;
 						}
-
-						// check if the neighbor data is up-to-date
-						if (!_entry.isFilterValid()) throw dtn::storage::BundleSelectorException();
 					}
-					else
-					{
-						// check if the neighbor data is up-to-date
-						if (!_entry.isFilterValid()) throw dtn::storage::BundleSelectorException();
 
-						// if this is a non-singleton, check if the peer knows a way to the source
-						try {
-							if (_dpm.get(meta.source.getNode()) <= 0.0) return false;
-						} catch (const dtn::routing::DeliveryPredictabilityMap::ValueNotFoundException&) {
-							return false;
-						}
-					}
+					// check if the neighbor data is up-to-date
+					if (!_entry.isFilterValid()) throw dtn::storage::BundleSelectorException();
 
 					// do not forward bundles already known by the destination
 					// throws BloomfilterNotAvailableException if no filter is available or it is expired
@@ -813,6 +801,10 @@ namespace dtn
 
 		bool ProphetRoutingExtension::GRTR_Strategy::shallForward(const DeliveryPredictabilityMap& neighbor_dpm, const dtn::data::MetaBundle& bundle) const
 		{
+			if (bundle.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON)) {
+				return isBackrouteValid(neighbor_dpm, bundle.source);
+			}
+
 			return neighborDPIsGreater(neighbor_dpm, bundle.destination);
 		}
 
@@ -838,6 +830,10 @@ namespace dtn
 
 		bool ProphetRoutingExtension::GTMX_Strategy::shallForward(const DeliveryPredictabilityMap& neighbor_dpm, const dtn::data::MetaBundle& bundle) const
 		{
+			if (bundle.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON)) {
+				return isBackrouteValid(neighbor_dpm, bundle.source);
+			}
+
 			unsigned int NF = 0;
 
 			nf_map::const_iterator nf_it = _NF_map.find(bundle);


### PR DESCRIPTION
Now PRoPHET routing forwards a broadcast packet if the backwards route
is known by the peer OR at least the local routing knows a backwards
route.