### PR TITLE
daemon: Split backroute check in PRoPHET

### DIFF
--- a/ibrdtn/daemon/src/routing/prophet/ForwardingStrategy.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ForwardingStrategy.cpp
@@ -55,12 +55,17 @@ namespace dtn
 		{
 			ibrcommon::MutexLock dpm_lock(_prophet_router->_deliveryPredictabilityMap);
 
-			// if this is a non-singleton, check if we or the peer know a way to the source
+			// check if we know a way to the source
 			try {
-				return ((_prophet_router->_deliveryPredictabilityMap.get(source.getNode()) > 0.0) || (neighbor_dpm.get(source.getNode()) > 0.0));
-			} catch (const dtn::routing::DeliveryPredictabilityMap::ValueNotFoundException&) {
-				return false;
-			}
+				if (_prophet_router->_deliveryPredictabilityMap.get(source.getNode()) > 0.0) return true;
+			} catch (const dtn::routing::DeliveryPredictabilityMap::ValueNotFoundException&) { }
+
+			// check if the peer know a way to the source
+			try {
+				if (neighbor_dpm.get(source.getNode()) > 0.0) return true;
+			} catch (const dtn::routing::DeliveryPredictabilityMap::ValueNotFoundException&) { }
+
+			return false;
 		}
 
 		void ForwardingStrategy::setProphetRouter(ProphetRoutingExtension *router)


### PR DESCRIPTION
The previous version of the check combined the local with the peer
check. If the local check failed due to an exception the peer check
was not performed. Now the peer check if performed even if the local
check fails.