### PR TITLE
Routing Limitations

### DIFF
--- a/ibrdtn/daemon/etc/ibrdtnd.conf
+++ b/ibrdtn/daemon/etc/ibrdtnd.conf
@@ -233,6 +233,11 @@ routing = prophet
 #routing_forwarding = yes
 
 #
+# accept non-singleton bundles
+#
+#routing_accept_nonsingleton = yes
+
+#
 # forward singleton bundles directly if the destination is a neighbor
 #
 #routing_prefer_direct = yes

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -704,7 +704,7 @@ namespace dtn
 			{
 				const dtn::data::EID node_eid( conf.read<std::string>(prefix + "uri", "dtn:none") );
 
-				// create a address URI
+				// create an address URI
 				std::stringstream ss;
 				ss << "ip=" << conf.read<std::string>(prefix + "address", "127.0.0.1") << ";port=" << conf.read<unsigned int>(prefix + "port", 4556) << ";";
 

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -93,7 +93,7 @@ namespace dtn
 		 : _quiet(false), _options(0), _timestamps(false), _verbose(false) {}
 
 		Configuration::Network::Network()
-		 : _routing("default"), _forwarding(true), _prefer_direct(true), _tcp_nodelay(true), _tcp_chunksize(4096), _tcp_idle_timeout(0), _keepalive_timeout(60), _default_net("lo"), _use_default_net(false), _auto_connect(0), _fragmentation(false), _scheduling(false), _link_request_interval(5000)
+		 : _routing("default"), _forwarding(true), _prefer_direct(true), _tcp_nodelay(true), _tcp_chunksize(4096), _tcp_idle_timeout(0), _keepalive_timeout(60), _default_net("lo"), _use_default_net(false), _auto_connect(0), _fragmentation(false), _scheduling(false), _managed_connectivity(false), _link_request_interval(5000)
 		{}
 
 		Configuration::Security::Security()

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -93,7 +93,7 @@ namespace dtn
 		 : _quiet(false), _options(0), _timestamps(false), _verbose(false) {}
 
 		Configuration::Network::Network()
-		 : _routing("default"), _forwarding(true), _prefer_direct(true), _tcp_nodelay(true), _tcp_chunksize(4096), _tcp_idle_timeout(0), _keepalive_timeout(60), _default_net("lo"), _use_default_net(false), _auto_connect(0), _fragmentation(false), _scheduling(false), _managed_connectivity(false), _link_request_interval(5000)
+		 : _routing("default"), _forwarding(true), _accept_nonsingleton(true), _prefer_direct(true), _tcp_nodelay(true), _tcp_chunksize(4096), _tcp_idle_timeout(0), _keepalive_timeout(60), _default_net("lo"), _use_default_net(false), _auto_connect(0), _fragmentation(false), _scheduling(false), _managed_connectivity(false), _link_request_interval(5000)
 		{}
 
 		Configuration::Security::Security()
@@ -799,9 +799,10 @@ namespace dtn
 			}
 
 			/**
-			 * get the routing extension
+			 * get the routing parameters
 			 */
 			_forwarding = (conf.read<std::string>("routing_forwarding", "yes") == "yes");
+			_accept_nonsingleton = (conf.read<std::string>("routing_accept_nonsingleton", "yes") == "yes");
 
 			/**
 			 * prefer direct routes
@@ -999,6 +1000,11 @@ namespace dtn
 		bool Configuration::Network::doForwarding() const
 		{
 			return _forwarding;
+		}
+
+		bool Configuration::Network::doAcceptNonSingleton() const
+		{
+			return _accept_nonsingleton;
 		}
 
 		bool Configuration::Network::doPreferDirect() const

--- a/ibrdtn/daemon/src/Configuration.h
+++ b/ibrdtn/daemon/src/Configuration.h
@@ -316,6 +316,7 @@ namespace dtn
 				std::list<NetConfig> _interfaces;
 				std::string _routing;
 				bool _forwarding;
+				bool _accept_nonsingleton;
 				bool _prefer_direct;
 				bool _tcp_nodelay;
 				dtn::data::Length _tcp_chunksize;
@@ -357,6 +358,11 @@ namespace dtn
 				 * @return True, if forwarding is enabled.
 				 */
 				bool doForwarding() const;
+
+				/**
+				 * Define if non-singleton bundles are accepted or not.
+				 */
+				bool doAcceptNonSingleton() const;
 
 				/**
 				 * Define if direct routes are preferred instead of spreading bundles to all

--- a/ibrdtn/daemon/src/core/BundleCore.cpp
+++ b/ibrdtn/daemon/src/core/BundleCore.cpp
@@ -193,6 +193,18 @@ namespace dtn
 				BundleCore::forwarding = false;
 			}
 
+			// accept or reject non-singleton bundles
+			if (config.getNetwork().doAcceptNonSingleton())
+			{
+				IBRCOMMON_LOGGER_TAG(BundleCore::TAG, info) << "Non-singleton bundles are accepted." << IBRCOMMON_LOGGER_ENDL;
+				BundleCore::singleton_only = false;
+			}
+			else
+			{
+				IBRCOMMON_LOGGER_TAG(BundleCore::TAG, info) << "Non-singleton bundles are rejected." << IBRCOMMON_LOGGER_ENDL;
+				BundleCore::singleton_only = true;
+			}
+
 			const std::set<ibrcommon::vinterface> &global_nets = config.getNetwork().getInternetDevices();
 
 			// remove myself from all listeners

--- a/ibrdtn/daemon/src/core/BundleCore.cpp
+++ b/ibrdtn/daemon/src/core/BundleCore.cpp
@@ -458,6 +458,14 @@ namespace dtn
 				throw dtn::data::Validator::RejectedException("bundle is expired");
 			}
 
+			// if we do not accept non-singleton bundles
+			if (BundleCore::singleton_only && !p.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+			{
+				// ... we reject all non-singleton bundles.
+				IBRCOMMON_LOGGER_TAG("BundleCore", warning) << "non-singleton bundle rejected: " << p.toString() << IBRCOMMON_LOGGER_ENDL;
+				throw dtn::data::Validator::RejectedException("bundle is not addressed to a singleton endpoint");
+			}
+
 			// if we do not forward bundles
 			if (!BundleCore::forwarding)
 			{

--- a/ibrdtn/daemon/src/core/BundleCore.cpp
+++ b/ibrdtn/daemon/src/core/BundleCore.cpp
@@ -467,7 +467,7 @@ namespace dtn
 			}
 
 			// if we do not forward bundles
-			if (!BundleCore::forwarding)
+			if (!BundleCore::forwarding && p.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 			{
 				if (!p.destination.sameHost(BundleCore::local))
 				{

--- a/ibrdtn/daemon/src/core/BundleCore.cpp
+++ b/ibrdtn/daemon/src/core/BundleCore.cpp
@@ -79,6 +79,7 @@ namespace dtn
 		dtn::data::Size BundleCore::max_bundles_in_transit = 5;
 
 		bool BundleCore::forwarding = true;
+		bool BundleCore::singleton_only = false;
 
 		BundleCore& BundleCore::getInstance()
 		{

--- a/ibrdtn/daemon/src/core/BundleCore.h
+++ b/ibrdtn/daemon/src/core/BundleCore.h
@@ -174,6 +174,11 @@ namespace dtn
 			static bool forwarding;
 
 			/**
+			 * Define if non-singleton bundles accepted for routing
+			 */
+			static bool singleton_only;
+
+			/**
 			 * Defines how many bundles should be in transit at once
 			 */
 			static dtn::data::Size max_bundles_in_transit;

--- a/ibrdtn/daemon/src/routing/NeighborRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/NeighborRoutingExtension.cpp
@@ -243,6 +243,18 @@ namespace dtn
 				{
 					return make_pair(false, dtn::core::Node::CONN_UNDEFINED);
 				}
+
+				// request limits from neighbor database
+				try {
+					const RoutingLimitations &limits = n.getDataset<RoutingLimitations>();
+
+					// check if the payload is too large for the neighbor
+					if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
+						((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength()))
+					{
+						return make_pair(false, dtn::core::Node::CONN_UNDEFINED);
+					}
+				} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
 			}
 			else
 			{

--- a/ibrdtn/daemon/src/routing/NodeHandshake.cpp
+++ b/ibrdtn/daemon/src/routing/NodeHandshake.cpp
@@ -390,5 +390,84 @@ namespace dtn
 
 		const dtn::data::Number BloomFilterPurgeVector::identifier = NodeHandshakeItem::BLOOM_FILTER_PURGE_VECTOR;
 
+		RoutingLimitations::RoutingLimitations()
+		 : NeighborDataSetImpl(RoutingLimitations::identifier)
+		{
+		}
+
+		RoutingLimitations::~RoutingLimitations()
+		{
+		}
+
+		const dtn::data::Number& RoutingLimitations::getIdentifier() const
+		{
+			return identifier;
+		}
+
+		dtn::data::Length RoutingLimitations::getLength() const
+		{
+			dtn::data::Length ret = 0;
+
+			// number of elements
+			ret += dtn::data::Number(_limits.size()).getLength();
+
+			for (std::map<size_t, ssize_t>::const_iterator it = _limits.begin(); it != _limits.end(); ++it)
+			{
+				ret += dtn::data::Number((*it).first).getLength();
+				ret += dtn::data::SDNV<ssize_t>((*it).second).getLength();
+			}
+
+			return ret;
+		}
+
+		void RoutingLimitations::setLimit(LimitIndex index, ssize_t value)
+		{
+			_limits[index] = value;
+		}
+
+		ssize_t RoutingLimitations::getLimit(LimitIndex index) const
+		{
+			std::map<size_t, ssize_t>::const_iterator it = _limits.find(index);
+			if (it == _limits.end()) return 0;
+			return (*it).second;
+		}
+
+		std::ostream& RoutingLimitations::serialize(std::ostream &stream) const
+		{
+			// number of elements
+			stream << dtn::data::Number(_limits.size());
+
+			for (std::map<size_t, ssize_t>::const_iterator it = _limits.begin(); it != _limits.end(); ++it)
+			{
+				stream << dtn::data::Number((*it).first);
+				stream << dtn::data::SDNV<ssize_t>((*it).second);
+			}
+
+			return stream;
+		}
+
+		std::istream& RoutingLimitations::deserialize(std::istream &stream)
+		{
+			dtn::data::Number elements, first;
+			dtn::data::SDNV<ssize_t> second;
+
+			// clear all elements
+			_limits.clear();
+
+			// get number of elements
+			stream >> elements;
+
+			for (size_t i = 0; i < elements.get<size_t>(); ++i)
+			{
+				stream >> first;
+				stream >> second;
+				_limits[first.get<size_t>()] = second.get<ssize_t>();
+			}
+
+			return stream;
+		}
+
+		const dtn::data::Number RoutingLimitations::identifier = NodeHandshakeItem::ROUTING_LIMITATIONS;
+
 	} /* namespace routing */
 } /* namespace dtn */

--- a/ibrdtn/daemon/src/routing/NodeHandshake.h
+++ b/ibrdtn/daemon/src/routing/NodeHandshake.h
@@ -22,6 +22,7 @@
 #ifndef NODEHANDSHAKE_H_
 #define NODEHANDSHAKE_H_
 
+#include "routing/NeighborDataset.h"
 #include <ibrdtn/data/BundleSet.h>
 #include <ibrdtn/data/SDNV.h>
 #include <iostream>
@@ -43,7 +44,8 @@ namespace dtn
 				BLOOM_FILTER_SUMMARY_VECTOR = 1,
 				BLOOM_FILTER_PURGE_VECTOR = 2,
 				DELIVERY_PREDICTABILITY_MAP = 3,
-				PROPHET_ACKNOWLEDGEMENT_SET = 4
+				PROPHET_ACKNOWLEDGEMENT_SET = 4,
+				ROUTING_LIMITATIONS = 5
 			};
 
 			virtual ~NodeHandshakeItem() { };
@@ -87,6 +89,30 @@ namespace dtn
 
 		private:
 			dtn::data::BundleSet _vector;
+		};
+
+		class RoutingLimitations : public NeighborDataSetImpl, public NodeHandshakeItem
+		{
+		public:
+			RoutingLimitations();
+			virtual ~RoutingLimitations();
+			const dtn::data::Number& getIdentifier() const;
+			dtn::data::Length getLength() const;
+			std::ostream& serialize(std::ostream&) const;
+			std::istream& deserialize(std::istream&);
+			static const dtn::data::Number identifier;
+
+			enum LimitIndex {
+				LIMIT_BLOCKSIZE = 0,
+				LIMIT_SINGLETON_ONLY = 1,
+				LIMIT_LOCAL_ONLY = 2
+			};
+
+			void setLimit(LimitIndex index, ssize_t value);
+			ssize_t getLimit(LimitIndex index) const;
+
+		private:
+			std::map<size_t, ssize_t> _limits;
 		};
 
 		class NodeHandshake

--- a/ibrdtn/daemon/src/routing/NodeHandshake.h
+++ b/ibrdtn/daemon/src/routing/NodeHandshake.h
@@ -104,8 +104,9 @@ namespace dtn
 
 			enum LimitIndex {
 				LIMIT_BLOCKSIZE = 0,
-				LIMIT_SINGLETON_ONLY = 1,
-				LIMIT_LOCAL_ONLY = 2
+				LIMIT_FOREIGN_BLOCKSIZE = 1,
+				LIMIT_SINGLETON_ONLY = 2,
+				LIMIT_LOCAL_ONLY = 3
 			};
 
 			void setLimit(LimitIndex index, ssize_t value);

--- a/ibrdtn/daemon/src/routing/NodeHandshakeExtension.cpp
+++ b/ibrdtn/daemon/src/routing/NodeHandshakeExtension.cpp
@@ -89,7 +89,8 @@ namespace dtn
 				RoutingLimitations *limits = new RoutingLimitations();
 
 				// add limitations
-				limits->setLimit(RoutingLimitations::LIMIT_BLOCKSIZE, dtn::core::BundleCore::foreign_blocksizelimit);
+				limits->setLimit(RoutingLimitations::LIMIT_BLOCKSIZE, dtn::core::BundleCore::blocksizelimit);
+				limits->setLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE, dtn::core::BundleCore::foreign_blocksizelimit);
 				limits->setLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY, dtn::core::BundleCore::singleton_only ? 1 : 0);
 				limits->setLimit(RoutingLimitations::LIMIT_LOCAL_ONLY, dtn::core::BundleCore::forwarding ? 0 : 1);
 

--- a/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
@@ -111,18 +111,20 @@ namespace dtn
 					try {
 						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
 
-						// check if the peer accepts bundles for other nodes
-						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
-
-						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
-
-						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if the peer accepts bundles for other nodes
+							if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+						}
+						else
 						{
 							// check if destination permits non-singleton bundles
 							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
 						}
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
 
 					// do not forward bundles already known by the destination

--- a/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
@@ -115,8 +115,8 @@ namespace dtn
 						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
 
 						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 
 						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 						{

--- a/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
@@ -107,6 +107,24 @@ namespace dtn
 						return false;
 					}
 
+					// request limits from neighbor database
+					try {
+						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
+
+						// check if the peer accepts bundles for other nodes
+						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+
+						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if destination permits non-singleton bundles
+							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
+						}
+					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
+
 					// do not forward bundles already known by the destination
 					if (_entry.has(meta))
 					{

--- a/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
@@ -201,18 +201,20 @@ namespace dtn
 					try {
 						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
 
-						// check if the peer accepts bundles for other nodes
-						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
-
-						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
-
-						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if the peer accepts bundles for other nodes
+							if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+						}
+						else
 						{
 							// check if destination permits non-singleton bundles
 							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
 						}
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
 
 					// if this is a singleton bundle ...

--- a/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
@@ -197,6 +197,24 @@ namespace dtn
 						return false;
 					}
 
+					// request limits from neighbor database
+					try {
+						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
+
+						// check if the peer accepts bundles for other nodes
+						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+
+						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if destination permits non-singleton bundles
+							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
+						}
+					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
+
 					// if this is a singleton bundle ...
 					if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 					{

--- a/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
@@ -205,8 +205,8 @@ namespace dtn
 						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
 
 						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 
 						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 						{

--- a/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
@@ -173,8 +173,8 @@ namespace dtn
 						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
 
 						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 
 						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 						{

--- a/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
@@ -169,18 +169,20 @@ namespace dtn
 					try {
 						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
 
-						// check if the peer accepts bundles for other nodes
-						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
-
-						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
-
-						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if the peer accepts bundles for other nodes
+							if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+						}
+						else
 						{
 							// check if destination permits non-singleton bundles
 							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
 						}
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
 
 					// if this is a singleton bundle ...

--- a/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
@@ -165,6 +165,24 @@ namespace dtn
 						return false;
 					}
 
+					// request limits from neighbor database
+					try {
+						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
+
+						// check if the peer accepts bundles for other nodes
+						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+
+						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if destination permits non-singleton bundles
+							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
+						}
+					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
+
 					// if this is a singleton bundle ...
 					if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 					{

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -404,18 +404,20 @@ namespace dtn
 					try {
 						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
 
-						// check if the peer accepts bundles for other nodes
-						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
-
-						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
-
-						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if the peer accepts bundles for other nodes
+							if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+						}
+						else
 						{
 							// check if destination permits non-singleton bundles
 							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
 						}
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
 
 					// if this is a singleton bundle ...

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -400,6 +400,24 @@ namespace dtn
 						return false;
 					}
 
+					// request limits from neighbor database
+					try {
+						const RoutingLimitations &limits = _entry.getDataset<RoutingLimitations>();
+
+						// check if the peer accepts bundles for other nodes
+						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
+
+						// check if the payload is too large for the neighbor
+						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+
+						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
+						{
+							// check if destination permits non-singleton bundles
+							if (limits.getLimit(RoutingLimitations::LIMIT_SINGLETON_ONLY) > 0) return false;
+						}
+					} catch (const NeighborDatabase::DatasetNotAvailableException&) { }
+
 					// if this is a singleton bundle ...
 					if (meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 					{

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -408,8 +408,8 @@ namespace dtn
 						if (limits.getLimit(RoutingLimitations::LIMIT_LOCAL_ONLY) > 0) return false;
 
 						// check if the payload is too large for the neighbor
-						if ((limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) > 0) &&
-							((size_t)limits.getLimit(RoutingLimitations::LIMIT_BLOCKSIZE) < meta.getPayloadLength())) return false;
+						if ((limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) > 0) &&
+							((size_t)limits.getLimit(RoutingLimitations::LIMIT_FOREIGN_BLOCKSIZE) < meta.getPayloadLength())) return false;
 
 						if (!meta.get(dtn::data::PrimaryBlock::DESTINATION_IS_SINGLETON))
 						{

--- a/ibrdtn/daemon/tests/unittests/ConfigurationTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/ConfigurationTest.cpp
@@ -254,6 +254,13 @@ void ConfigurationTest::testDoForwarding()
 	CPPUNIT_ASSERT_EQUAL(true, conf.getNetwork().doForwarding());
 }
 
+void ConfigurationTest::testDoAcceptNonsingleton()
+{
+	/* test signature () const */
+	dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
+	CPPUNIT_ASSERT_EQUAL(true, conf.getNetwork().doAcceptNonSingleton());
+}
+
 void ConfigurationTest::testGetTCPOptionNoDelay()
 {
 	/* test signature () const */

--- a/ibrdtn/daemon/tests/unittests/ConfigurationTest.hh
+++ b/ibrdtn/daemon/tests/unittests/ConfigurationTest.hh
@@ -59,6 +59,7 @@ class ConfigurationTest : public CppUnit::TestFixture {
 		void testGetStaticRoutes();
 		void testGetRoutingExtension();
 		void testDoForwarding();
+		void testDoAcceptNonsingleton();
 		void testGetTCPOptionNoDelay();
 		void testGetTCPChunkSize();
 		/*=== END   tests for class 'Network' ===*/
@@ -101,6 +102,7 @@ class ConfigurationTest : public CppUnit::TestFixture {
 			CPPUNIT_TEST(testGetStaticRoutes);
 			CPPUNIT_TEST(testGetRoutingExtension);
 			CPPUNIT_TEST(testDoForwarding);
+			CPPUNIT_TEST(testDoAcceptNonsingleton);
 			CPPUNIT_TEST(testGetTCPOptionNoDelay);
 			CPPUNIT_TEST(testGetTCPChunkSize);
 			CPPUNIT_TEST(testGetDiscovery);


### PR DESCRIPTION
Routing limitations specifies forwarding limits for block sizes or if foreign bundles or non-singleton bundles are accepted. With this patch-set, these limitations are exchanged using the routing handshake. A peer will checks bundles to transfer against the limitations before sending them out. This reduces the number of aborted transmissions in case of limitations.

The limitations are still configured using the configuration file. Related options are listed below.
```
limit_blocksize = <size-in-bytes>
limit_foreign_blocksize = <size-in-bytes>
routing_forwarding = <yes|no>
routing_accept_nonsingleton = <yes|no>
```

The scope of the option *routing_forwarding* has been reduced to singleton bundles. The acceptance of non-singleton bundles are configured with the new option *routing_accept_nonsingleton*.

Example:
```
limit_blocksize = 1M
limit_foreign_blocksize = 500K
routing_forwarding = yes
routing_accept_nonsingleton = no
```
A daemon with this configuration accepts bundles with up to 1 MB payload. If the bundle is not addressed directly to the node, it is only accepted if the payload does not exceeds 500 KB. Bundles for other nodes are generally accepted, but non-singleton bundles are rejected.