### PR TITLE
Bugfix/issue 187

### DIFF
--- a/ibrcommon/ibrcommon/data/File.cpp
+++ b/ibrcommon/ibrcommon/data/File.cpp
@@ -34,10 +34,7 @@
 #include <cstring>
 #include <cerrno>
 #include <fstream>
-
-#if !defined(HAVE_FEATURES_H) || defined(ANDROID)
 #include <libgen.h>
-#endif
 
 #ifdef __WIN32__
 #include <io.h>
@@ -225,14 +222,7 @@ namespace ibrcommon
 
 	std::string File::getBasename() const
 	{
-#if !defined(ANDROID) && defined(HAVE_FEATURES_H)
-		return std::string(basename(_path.c_str()));
-#else
-		char path[_path.length()+1];
-		::memcpy(&path, _path.c_str(), _path.length()+1);
-
-		return std::string(basename(path));
-#endif
+		return std::string(basename((char*)_path.c_str()));
 	}
 
 	File File::get(const std::string &filename) const

--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -1078,7 +1078,7 @@ namespace ibrcommon
 		try {
 			switch (get_family()) {
 			case AF_INET: {
-#ifdef HAVE_FEATURES_H
+#ifdef __linux__
 				int val = 1;
 				if ( __compat_setsockopt(_fd, IPPROTO_IP, IP_MULTICAST_LOOP, (const char *)&val, sizeof(val)) < 0 )
 				{
@@ -1100,7 +1100,7 @@ namespace ibrcommon
 			}
 
 			case AF_INET6: {
-#ifdef HAVE_FEATURES_H
+#ifdef __linux__
 				int val = 1;
 				if ( __compat_setsockopt(_fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (const char *)&val, sizeof(val)) < 0 )
 				{
@@ -1132,7 +1132,7 @@ namespace ibrcommon
 	{
 		switch (get_family()) {
 		case AF_INET: {
-#ifdef HAVE_FEATURES_H
+#ifdef __linux__
 			int val = 0;
 			if ( __compat_setsockopt(_fd, IPPROTO_IP, IP_MULTICAST_LOOP, (const char *)&val, sizeof(val)) < 0 )
 			{
@@ -1143,7 +1143,7 @@ namespace ibrcommon
 		}
 
 		case AF_INET6: {
-#ifdef HAVE_FEATURES_H
+#ifdef __linux__
 			int val = 0;
 			if ( __compat_setsockopt(_fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (const char *)&val, sizeof(val)) < 0 )
 			{

--- a/ibrcommon/ibrcommon/net/vsocket.cpp
+++ b/ibrcommon/ibrcommon/net/vsocket.cpp
@@ -24,7 +24,7 @@
 #include "ibrcommon/thread/MutexLock.h"
 #include "ibrcommon/Logger.h"
 
-#ifndef HAVE_FEATURES_H
+#ifndef __linux__
 #include "ibrcommon/TimeMeasurement.h"
 #endif
 
@@ -131,7 +131,7 @@ namespace ibrcommon
 #define pipewrite(a,b,c) ::write(a,b,c)
 #endif
 
-#ifdef HAVE_FEATURES_H
+#ifdef __linux__
 #define __compat_select ::select
 #else
 	int __compat_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout)


### PR DESCRIPTION
Fix patch-set fixes #187. Further code exceptions for linux are now enabled using __linux__ macro instead of HAVE_FEATURES_H.