### PR TITLE
Always show the application part in IPN endpoint identifiers

### DIFF
--- a/ibrdtn/daemon/src/core/BundleCore.cpp
+++ b/ibrdtn/daemon/src/core/BundleCore.cpp
@@ -143,7 +143,7 @@ namespace dtn
 		{
 			// set local eid
 			dtn::core::BundleCore::local = config.getNodename();
-			IBRCOMMON_LOGGER_TAG(BundleCore::TAG, info) << "Local node name: " << config.getNodename() << IBRCOMMON_LOGGER_ENDL;
+			IBRCOMMON_LOGGER_TAG(BundleCore::TAG, info) << "Local node name: " << dtn::core::BundleCore::local.getString() << IBRCOMMON_LOGGER_ENDL;
 
 			// set block size limit
 			dtn::core::BundleCore::blocksizelimit = config.getLimit("blocksize");

--- a/ibrdtn/ibrdtn/ibrdtn/data/EID.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/EID.cpp
@@ -389,10 +389,7 @@ namespace dtn
 			switch (_scheme_type) {
 			case SCHEME_CBHE:
 				ss << getSchemeName(SCHEME_CBHE) << ":" << _cbhe_node.get<size_t>();
-
-				if (_cbhe_application > 0) {
-					ss << "." << _cbhe_application.get<size_t>();
-				}
+				ss << "." << _cbhe_application.get<size_t>();
 				break;
 
 			case SCHEME_DTN:
@@ -530,10 +527,7 @@ namespace dtn
 			{
 				std::stringstream ss;
 				ss << _cbhe_node.get<size_t>();
-
-				if (_cbhe_application > 0) {
-					ss << "." << _cbhe_application.get<size_t>();
-				}
+				ss << "." << _cbhe_application.get<size_t>();
 
 				return ss.str();
 			}

--- a/ibrdtn/ibrdtn/tests/data/TestEID.cpp
+++ b/ibrdtn/ibrdtn/tests/data/TestEID.cpp
@@ -45,12 +45,12 @@ void TestEID::testCBHEwithApplication(void)
 
 void TestEID::testCBHEwithoutApplication(void)
 {
-	dtn::data::EID a("ipn:12");
+	dtn::data::EID a("ipn:12.0");
 
 	CPPUNIT_ASSERT(a.isCompressable());
 	CPPUNIT_ASSERT_EQUAL((size_t)12, a.getCompressed().first.get<size_t>());
 	CPPUNIT_ASSERT_EQUAL((size_t)0, a.getCompressed().second.get<size_t>());
-	CPPUNIT_ASSERT_EQUAL(std::string("ipn:12"), a.getString());
+	CPPUNIT_ASSERT_EQUAL(std::string("ipn:12.0"), a.getString());
 }
 
 void TestEID::testCBHEConstructorNumbers(void)
@@ -60,7 +60,7 @@ void TestEID::testCBHEConstructorNumbers(void)
 	CPPUNIT_ASSERT(a.isCompressable());
 	CPPUNIT_ASSERT_EQUAL((size_t)12, a.getCompressed().first.get<size_t>());
 	CPPUNIT_ASSERT_EQUAL((size_t)0, a.getCompressed().second.get<size_t>());
-	CPPUNIT_ASSERT_EQUAL(std::string("ipn:12"), a.getString());
+	CPPUNIT_ASSERT_EQUAL(std::string("ipn:12.0"), a.getString());
 }
 
 void TestEID::testCBHEConstructorSchemeSsp(void)
@@ -85,5 +85,5 @@ void TestEID::testCBHEHost(void)
 {
 	dtn::data::EID a("ipn:12.34");
 	CPPUNIT_ASSERT_EQUAL(std::string("12"), a.getHost());
-	CPPUNIT_ASSERT_EQUAL(std::string("ipn:12"), a.getNode().getString());
+	CPPUNIT_ASSERT_EQUAL(std::string("ipn:12.0"), a.getNode().getString());
 }


### PR DESCRIPTION
The application part of endpoint identifiers in IPN scheme is mandatory and
must be always added to the string representation even if the application
part is set to zero / not set.

Closes #206.