### PR TITLE
daemon: Return bundle ID after bundle is sent via plain-text API

### DIFF
--- a/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
+++ b/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
@@ -529,7 +529,7 @@ namespace dtn
 							dtn::api::Registration::processIncomingBundle(_endpoint, _bundle_reg);
 
 							ibrcommon::MutexLock l(_write_lock);
-							_stream << ClientHandler::API_STATUS_OK << " BUNDLE SENT" << std::endl;
+							_stream << ClientHandler::API_STATUS_OK << " BUNDLE SENT "; sayBundleID(_stream, _bundle_reg); _stream << std::endl;
 						}
 						else if (cmd[1] == "info")
 						{


### PR DESCRIPTION
If a bundle is sent via 'bundle sent', the response now also includes
the unique information of a bundle (timestamp, sequence number, and
source endpoint identifier).