### PR TITLE
Fix: EID needs copy constructor since it maintains a pointer

### DIFF
--- a/ibrdtn/ibrdtn/ibrdtn/data/EID.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/EID.cpp
@@ -293,6 +293,25 @@ namespace dtn
 			}
 		}
 
+		EID::EID(const EID &other)
+		{
+			_scheme_type = other._scheme_type;
+			_scheme = other._scheme;
+			_ssp = other._ssp;
+
+			_application = other._application;
+
+			_cbhe_node = other._cbhe_node;
+			_cbhe_application = other._cbhe_application;
+
+			_regex = NULL;
+
+			if(other._regex != NULL)
+			{
+				prepare();
+			}
+		}
+
 		EID::~EID()
 		{
 #ifdef HAVE_REGEX_H

--- a/ibrdtn/ibrdtn/ibrdtn/data/EID.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/EID.h
@@ -66,6 +66,8 @@ namespace dtn
 			 */
 			EID(const dtn::data::Number &node, const dtn::data::Number &application);
 
+			EID(const EID &other);
+
 			virtual ~EID();
 
 			bool operator==(const EID &other) const;


### PR DESCRIPTION
Due to the introduction of a pointer (_regex) to the member variables of EID, it now needs a dedicated copy constructor to ensure correct destruction of objects duplicated, e. g., by a return-by-value.

This is especially important when returning EID instances in STL collections such as in the Registration class here: https://github.com/ibrdtn/ibrdtn/blob/master/ibrdtn/daemon/src/api/Registration.cpp#L162 where the copy constructor will be used frequently and would wrongly just copy the address stored in pointer _regex of EID.

This also fixes issue #214 .

Correct handling of _regex is solved in the copy constructor by calling EID::prepare() if the other instance's _regex pointer is not NULL, of course feel free to adapt the patch if this is wrong.