### PR TITLE
Add NDK path from local.properties to gradle build file

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 
+Properties properties = new Properties()
+properties.load(project.rootProject.file('local.properties').newDataInputStream())
+def ndkDir = properties.getProperty('ndk.dir')
+
 def createVersionName() {
     if (System.getenv().containsKey("BUILD_NUMBER")) {
         if (System.getenv().containsKey("GIT_COMMIT")) {
@@ -52,7 +56,11 @@ if (android.signingConfigs.release.storeFile.exists()) {
 task ndkBuild(type: Exec) {
     executable "sh"
     workingDir "src/main/jni"
-    args "build.sh"
+    if (ndkDir != null) {
+        args "-c", "export PATH=${ndkDir}:\$PATH; ./build.sh"
+    } else {
+        args "build.sh"
+    }
 }
 preBuild.dependsOn ndkBuild
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,9 +1,14 @@
 apply plugin: 'android-sdk-manager'
 apply plugin: 'com.android.application'
 
+def ndkDir = null;
 Properties properties = new Properties()
-properties.load(project.rootProject.file('local.properties').newDataInputStream())
-def ndkDir = properties.getProperty('ndk.dir')
+try {
+    properties.load(project.rootProject.file('local.properties').newDataInputStream())
+    ndkDir = properties.getProperty('ndk.dir')
+} catch (IOException e) {}
+
+
 
 def createVersionName() {
     if (System.getenv().containsKey("BUILD_NUMBER")) {


### PR DESCRIPTION
I ran into the problem that my path to Android NDK was not set during build (since it was only defined in ~/.bashrc like mentioned in the [wiki](https://github.com/ibrdtn/ibrdtn/wiki/Build-IBR-DTN-for-Android)). Now the NDK path is also taken from the local.properties if available.
This could also be achieved by setting the path in the correct configuration file for sh/dash but using the path from the project settings looks more intuitive to me.