### PR TITLE
changed injection of merged bundles to be treated as non-local

### DIFF
--- a/ibrdtn/daemon/src/core/FragmentManager.cpp
+++ b/ibrdtn/daemon/src/core/FragmentManager.cpp
@@ -149,7 +149,7 @@ namespace dtn
 						if (BundleCore::getInstance().filter(BundleFilter::INPUT, context, merged) == BundleFilter::ACCEPT)
 						{
 							// inject bundle into core
-							dtn::core::BundleCore::getInstance().inject(dtn::core::BundleCore::local, merged, true);
+							dtn::core::BundleCore::getInstance().inject(dtn::core::BundleCore::local, merged, false);
 						}
 
 						// delete all fragments of the merged bundle


### PR DESCRIPTION
The FragmentManager does not inject merged bundles correctly. See [https://github.com/ibrdtn/ibrdtn/issues/218](url) for details.