### PR TITLE
Support for emulation mode in IBRDTN

### DIFF
--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -703,9 +703,33 @@ namespace ibrcommon
 		this->set_reuseaddr(true);
 
 		try {
-			// try to bind on port and/or address
-			this->bind(_address);
-			this->listen(_listen);
+                  // Get port number from _address
+                  int port;
+                  std::string service;
+                  try {
+                    service = _address.service();
+                    port = atoi(service.c_str());
+                  } catch (const vaddress::address_not_set&) {
+                    port = 0;
+                  };
+
+		  // try to bind on port and/or address
+		  //
+                  // Bind only if port number != 0. Otherwise
+                  // let the OS assign a port number.
+                  if (port != 0) {
+		    this->bind(_address);
+		  }
+		  
+		  this->listen(_listen);
+
+		  // Now that the socket is open, let
+                  // us try to get its port number and update
+                  // _address accordingly
+                  if (port == 0) {
+                    port = get_port();
+                    _address.setService(port);
+                  }
 		} catch (const socket_exception&) {
 			// clean-up socket
 			__close(_fd);

--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -312,6 +312,17 @@ namespace ibrcommon
 		}
 	}
 
+        int basesocket::get_port()
+	{
+	  struct   sockaddr_in sin;
+	  socklen_t addrlen = sizeof(sin);
+	  memset(&sin, 0, addrlen);
+	  getsockname(_fd,(struct sockaddr*)&sin,&addrlen);  
+	  int port = ntohs(sin.sin_port);
+	  
+	  return port;
+	}
+
 	clientsocket::clientsocket()
 	{
 	}

--- a/ibrcommon/ibrcommon/net/socket.h
+++ b/ibrcommon/ibrcommon/net/socket.h
@@ -353,7 +353,7 @@ namespace ibrcommon {
 		void bind(const vaddress &addr) throw (socket_exception);
 
 	private:
-		const vaddress _address;
+		vaddress _address;
 		const int _listen;
 	};
 

--- a/ibrcommon/ibrcommon/net/socket.h
+++ b/ibrcommon/ibrcommon/net/socket.h
@@ -167,6 +167,11 @@ namespace ibrcommon {
 		 */
 		static bool hasSupport(const sa_family_t family, const int type = SOCK_DGRAM, const int protocol = 0) throw ();
 
+		/**
+		 * Returns the local port number of this socket.
+		 */
+		int get_port();
+
 	protected:
 		/**
 		 * The socket state determine if the socket file descriptor

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -621,6 +621,11 @@ namespace dtn
 			return Configuration::getInstance()._conf.read<int>("discovery_port", 4551);
 		}
 
+		int Configuration::Discovery::localPort() const
+		{
+       		  return Configuration::getInstance()._conf.read<int>("discovery_local_port", port());
+		}
+
 		unsigned int Configuration::Discovery::interval() const
 		{
 			return _interval;

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -101,7 +101,8 @@ namespace dtn
 		{}
 
 		Configuration::Daemon::Daemon()
-		 : _daemonize(false), _kill(false), _threads(0)
+		 : _daemonize(false), _kill(false), _threads(0),
+		    _start_time(-1), _stop_time(-1), _seed(-1)
 		{}
 
 		Configuration::TimeSync::TimeSync()
@@ -230,6 +231,10 @@ namespace dtn
 #ifdef __WIN32__
 						{"interfaces", no_argument, 0, 'I'},
 #endif
+						{"start", required_argument, 0, 'b'},
+						{"stop", required_argument, 0, 's'},
+						{"seed", required_argument, 0, 'r'},
+
 						{0, 0, 0, 0}
 				};
 
@@ -282,6 +287,9 @@ namespace dtn
 #ifdef __WIN32__
 					std::cout << " --interfaces    list all available interfaces" << std::endl;
 #endif
+					std::cout << " --start <time>  start time (EPOCH in ms)" << std::endl;
+					std::cout << " --stop <time>   stop time (EPOCH in ms)" << std::endl;
+					std::cout << " --seed <val>    random seed (uint)" << std::endl;
 					exit(0);
 					break;
 
@@ -352,6 +360,18 @@ namespace dtn
 				case '?':
 					/* getopt_long already printed an error message. */
 					break;
+
+				case 'b': 
+				  _daemon._start_time = atol(optarg);
+				  break;
+				  
+				case 's': 
+				  _daemon._stop_time = atol(optarg);
+				  break;
+
+				case 'r': 
+				  _daemon._seed = atol(optarg);
+				  break;
 
 				default:
 					abort();
@@ -1330,6 +1350,21 @@ namespace dtn
 			return _pidfile;
 		}
 
+	        long Configuration::Daemon::start_time() const
+		{
+		  return _start_time;
+		}
+
+	        long Configuration::Daemon::stop_time() const
+		{
+		  return _stop_time;
+		}
+
+	        long Configuration::Daemon::seed() const
+		{
+		  return _seed;
+		}
+	  
 		bool Configuration::TimeSync::hasReference() const
 		{
 			return _reference;

--- a/ibrdtn/daemon/src/Configuration.h
+++ b/ibrdtn/daemon/src/Configuration.h
@@ -538,6 +538,9 @@ namespace dtn
 				ibrcommon::File _pidfile;
 				bool _kill;
 				dtn::data::Size _threads;
+				long _start_time;
+				long _stop_time;
+				long _seed;
 
 			protected:
 				Daemon();
@@ -549,6 +552,9 @@ namespace dtn
 				const ibrcommon::File& getPidFile() const;
 				bool kill_daemon() const;
 				dtn::data::Size getThreads() const;
+				long start_time() const;
+				long stop_time() const;
+				long seed() const;
 			};
 
 			class TimeSync : public Configuration::Extension

--- a/ibrdtn/daemon/src/Configuration.h
+++ b/ibrdtn/daemon/src/Configuration.h
@@ -184,6 +184,7 @@ namespace dtn
 				int version() const;
 				const std::set<ibrcommon::vaddress> address() const throw (ParameterNotFoundException);
 				int port() const;
+				int localPort() const;
 				unsigned int interval() const;
 				bool enableCrosslayer() const;
 			};

--- a/ibrdtn/daemon/src/NativeDaemon.cpp
+++ b/ibrdtn/daemon/src/NativeDaemon.cpp
@@ -1509,7 +1509,7 @@ namespace dtn
 			if (conf.getDiscovery().enabled())
 			{
 				// get the discovery port
-				int disco_port = conf.getDiscovery().port();
+				int disco_port = conf.getDiscovery().localPort();
 
 				// create the IPND agent
 				dtn::net::IPNDAgent *ipnd = new dtn::net::IPNDAgent( disco_port );

--- a/ibrdtn/daemon/src/net/IPNDAgent.cpp
+++ b/ibrdtn/daemon/src/net/IPNDAgent.cpp
@@ -333,6 +333,21 @@ namespace dtn
 		{
 			// routine checked for throw() on 15.02.2013
 
+		  // If the discovery port number is 0, we must obtain
+		  // a valid port number from the OS. To do so we
+		  // create a temporary socket (dyn_sock) on local
+		  // port 0. Once this socket is up we grab its actual
+		  // port number, and use this number to create the
+		  // other sockets.
+		  ibrcommon::multicastsocket *dyn_sock = NULL;
+		  if (_port == 0) {
+		    const ibrcommon::vaddress any_addr("0.0.0.0", 0, AF_INET);
+		    dyn_sock = new ibrcommon::multicastsocket(any_addr);
+		    dyn_sock->up();
+		    _port = dyn_sock->get_port();
+		    IBRCOMMON_LOGGER_TAG(IPNDAgent::TAG, info) << "Assigned local port=" << _port << " dynamically (was 0)" << IBRCOMMON_LOGGER_ENDL;
+		  }
+
 			try {
 				// setup the sockets
 				_socket.up();
@@ -379,6 +394,15 @@ namespace dtn
 				}
 			}
 #endif
+
+			// If the port number has been assigned
+			// dynamically, let us close and delete the
+			// socket we created temporarily in order to
+			// obtain that port
+			if (dyn_sock != NULL) {
+			  dyn_sock->down();
+			  delete dyn_sock;
+			}
 
 			// listen to P2P dial-up events
 			dtn::core::EventDispatcher<dtn::net::P2PDialupEvent>::add(this);

--- a/ibrdtn/daemon/src/net/TCPConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/TCPConvergenceLayer.cpp
@@ -78,6 +78,19 @@ namespace dtn
 			// do not allow any futher binding if we already bound to any interface
 			if (_any_port > 0) return;
 
+			// If the port number is 0, we must obtain a valid
+			// port number from the OS. To do so we create a
+			// temporary socket (dyn_sock) on local port 0. Once
+			// this socket is up we grab its actual port number,
+			// and use this number to create the other sockets.
+			ibrcommon::tcpserversocket *dyn_sock = NULL;
+			if (port == 0) {
+			  dyn_sock = new ibrcommon::tcpserversocket(port);
+			  dyn_sock->up();
+			  port = dyn_sock->get_port();
+			  IBRCOMMON_LOGGER_TAG(TCPConvergenceLayer::TAG, info) << "Assigned local port=" << port << " dynamically (was 0)" << IBRCOMMON_LOGGER_ENDL;
+			}
+
 			if (net.isAny()) {
 				// bind to any interface
 				_vsocket.add(new ibrcommon::tcpserversocket(port));
@@ -94,6 +107,15 @@ namespace dtn
 				_vsocket.add(new ibrcommon::tcpserversocket(addr4));
 			} else {
 				listen(net, port);
+			}
+
+			// If the port number has been assigned
+			// dynamically, let us close and delete the
+			// socket we created temporarily in order to
+			// obtain that port
+			if (dyn_sock != NULL) {
+			  dyn_sock->down();
+			  delete dyn_sock;
 			}
 		}
 


### PR DESCRIPTION
In emulation mode, several instances of IBRDTN can run concurrently on the same host, and all traffic is sent (as unicast traffic) to a software hub, which forwards messages to their actual destination(s). This software hub can itself be controlled by a mobility simulator, in which case each message is only forwarded by the hub if the sender is considered as a neighbor of the destination at the time the message is received by the hub.

LEPTON (http://www-casa.irisa.fr/lepton) is a lightweight emulation platform for opportunistic networking that works along that line, and that is meant to be interoperable with several existing opportunistic networking systems (including IBRDTN).

In order for IBRDTN nodes to support emulation mode, the original IBRDTN code must be slightly modified. The modifications required mostly pertain to UDP-based beaconing and to the TCP convergence layer.  Additionally,  a few optional command-line parameters are defined.

None of these modifications compromise the "standard"  behavior of IBRDTN nodes, which can still interact using multicast beacons and direct (i.e., node-to-node) TCP sessions.
