### PR TITLE
Fix: API payload get does not return BLOB for ExtensionBlock

### DIFF
--- a/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
+++ b/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
@@ -779,7 +779,7 @@ namespace dtn
 
 							// abort there if the stream is no payload block
 							try {
-								dtn::data::PayloadBlock &pb = dynamic_cast<dtn::data::PayloadBlock&>(block);
+								dtn::data::BlobBlock &pb = dynamic_cast<dtn::data::BlobBlock&>(block);
 
 								// write continue request to API
 								_stream << ClientHandler::API_STATUS_CONTINUE << " PAYLOAD PUT" << std::endl;

--- a/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
+++ b/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
@@ -736,10 +736,14 @@ namespace dtn
 										ibrcommon::BLOB::Reference ref = pb.getBLOB();
 										ibrcommon::BLOB::iostream stream = ref.iostream();
 
-										if (static_cast<std::streamsize>(payload_offset) >= stream.size())
+										/* update BLOB with changed block contents */
+										Length payload_size = 0;
+										block.serialize((*stream), payload_size);
+
+										if (static_cast<std::streamsize>(payload_offset) >= payload_size)
 											throw ibrcommon::Exception("offset out of range");
 
-										size_t remaining = stream.size() - payload_offset;
+										size_t remaining = payload_size - payload_offset;
 
 										if ((length > 0) && (remaining > length)) {
 											remaining = length;

--- a/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
+++ b/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
@@ -33,6 +33,7 @@
 #include <ibrcommon/data/Base64Stream.h>
 #include "core/BundleCore.h"
 #include <ibrdtn/utils/Random.h>
+#include <ibrdtn/data/BlobBlock.h>
 
 #include <ibrdtn/ibrdtn.h>
 #ifdef IBRDTN_SUPPORT_BSP
@@ -729,7 +730,7 @@ namespace dtn
 
 									// abort here if the stream is no payload block
 									try {
-										dtn::data::PayloadBlock &pb = dynamic_cast<dtn::data::PayloadBlock&>(block);
+										dtn::data::BlobBlock &pb = dynamic_cast<dtn::data::BlobBlock&>(block);
 
 										// open the payload BLOB
 										ibrcommon::BLOB::Reference ref = pb.getBLOB();

--- a/ibrdtn/ibrdtn/ibrdtn/api/PlainSerializer.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/api/PlainSerializer.cpp
@@ -594,7 +594,8 @@ namespace dtn
 				}
 				else
 				{
-					throw dtn::InvalidDataException("unknown block header");
+					/* API documentation states "while header fields except the length field may be omitted" */
+					//throw dtn::InvalidDataException("unknown block header");
 				}
 			}
 

--- a/ibrdtn/ibrdtn/ibrdtn/data/BlobBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BlobBlock.h
@@ -1,0 +1,48 @@
+/*
+ * BlobBlock.h
+ *
+ * Copyright (C) 2017 IBR, TU Braunschweig
+ *
+ * Written-by: Tim Schubert <tim.schubert@tu-bs.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef IBRDTN_IBRDTN_IBRDTN_DATA_BLOBBLOCK_H_
+#define IBRDTN_IBRDTN_IBRDTN_DATA_BLOBBLOCK_H_
+
+#include "ibrdtn/data/Block.h"
+#include "ibrcommon/data/BLOB.h"
+
+namespace dtn
+{
+	namespace data
+	{
+		class BlobBlock: public Block
+		{
+		public:
+			BlobBlock(dtn::data::block_t type)
+					: Block(type)
+			{
+			}
+			virtual ~BlobBlock()
+			{
+			}
+
+			virtual ibrcommon::BLOB::Reference getBLOB() const = 0;
+		};
+	}
+}
+
+#endif /* IBRDTN_IBRDTN_IBRDTN_DATA_BLOBBLOCK_H_ */

--- a/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.cpp
@@ -93,12 +93,12 @@ namespace dtn
 		}
 
 		ExtensionBlock::ExtensionBlock()
-		 : Block(0), _blobref(ibrcommon::BLOB::create())
+		 : BlobBlock(0), _blobref(ibrcommon::BLOB::create())
 		{
 		}
 
 		ExtensionBlock::ExtensionBlock(ibrcommon::BLOB::Reference ref)
-		 : Block(0), _blobref(ref)
+		 : BlobBlock(0), _blobref(ref)
 		{
 		}
 

--- a/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.h
@@ -23,6 +23,7 @@
 #define EXTENSIONBLOCK_H_
 
 #include "ibrdtn/data/Block.h"
+#include "ibrdtn/data/BlobBlock.h"
 #include <ibrcommon/data/BLOB.h>
 #include <ibrdtn/data/Number.h>
 #include <map>
@@ -31,7 +32,7 @@ namespace dtn
 {
 	namespace data
 	{
-		class ExtensionBlock : public Block
+		class ExtensionBlock : public BlobBlock
 		{
 		public:
 			class Factory

--- a/ibrdtn/ibrdtn/ibrdtn/data/Makefile.am
+++ b/ibrdtn/ibrdtn/ibrdtn/data/Makefile.am
@@ -5,6 +5,7 @@ h_sources = \
 	AgeBlock.h \
 	ScopeControlHopLimitBlock.h \
 	Block.h \
+	BlobBlock.h \
 	Bundle.h \
 	BundleID.h \
 	BundleList.h \

--- a/ibrdtn/ibrdtn/ibrdtn/data/PayloadBlock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/PayloadBlock.cpp
@@ -31,12 +31,12 @@ namespace dtn
 		const dtn::data::block_t PayloadBlock::BLOCK_TYPE = 1;
 
 		PayloadBlock::PayloadBlock()
-		 : Block(PayloadBlock::BLOCK_TYPE), _blobref(ibrcommon::BLOB::create())
+		 : BlobBlock(PayloadBlock::BLOCK_TYPE), _blobref(ibrcommon::BLOB::create())
 		{
 		}
 
 		PayloadBlock::PayloadBlock(ibrcommon::BLOB::Reference ref)
-		 : Block(PayloadBlock::BLOCK_TYPE), _blobref(ref)
+		 : BlobBlock(PayloadBlock::BLOCK_TYPE), _blobref(ref)
 		{
 		}
 

--- a/ibrdtn/ibrdtn/ibrdtn/data/PayloadBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/PayloadBlock.h
@@ -27,12 +27,13 @@
 #include "ibrdtn/data/Number.h"
 #include "ibrdtn/data/Block.h"
 #include "ibrcommon/data/BLOB.h"
+#include "ibrdtn/data/BlobBlock.h"
 
 namespace dtn
 {
 	namespace data
 	{
-		class PayloadBlock : public Block
+		class PayloadBlock : public BlobBlock
 		{
 		public:
 			static const dtn::data::block_t BLOCK_TYPE;


### PR DESCRIPTION
This commit includes a fix for the payload command.
The payload command previously did not return any other payload BLOBs other than the BLOB associated with the payload block.
Both ExtensionBlock and PrimaryBlock already implemented getBlob().
This commit creates a virtual class BlobBlock that both ExtensionBlock and PrimaryBlock inherit from and that contains only the fully virtual getBlob() method.