### PR TITLE
Fix temporary strings causing getaddrinfo to fail

### DIFF
--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -497,20 +497,20 @@ namespace ibrcommon
 		hints.ai_socktype = SOCK_DGRAM;
 		hints.ai_flags = AI_ADDRCONFIG;
 
-		const char *address = NULL;
-		const char *service = NULL;
+		std::string address;
+		std::string service;
 
 		try {
-			address = addr.address().c_str();
+			address = addr.address();
 		} catch (const vaddress::address_not_set&) {
 			throw socket_exception("need at least an address to send to");
 		};
 
 		try {
-			service = addr.service().c_str();
+			service = addr.service();
 		} catch (const vaddress::address_not_set&) { };
 
-		if ((ret = ::getaddrinfo(address, service, &hints, &res)) != 0)
+		if ((ret = ::getaddrinfo(address.c_str(), service.c_str(), &hints, &res)) != 0)
 		{
 			throw socket_exception("getaddrinfo(): " + std::string(gai_strerror(ret)));
 		}
@@ -799,20 +799,20 @@ namespace ibrcommon
 		struct addrinfo *res = NULL;
 		int ret = 0;
 
-		const char *address = NULL;
-		const char *service = NULL;
+		std::string address;
+		std::string service;
 
 		try {
-			address = _address.address().c_str();
+			address = _address.address();
 		} catch (const vaddress::address_not_set&) {
 			throw socket_exception("need at least an address to connect to");
 		};
 
 		try {
-			service = _address.service().c_str();
+			service = _address.service();
 		} catch (const vaddress::service_not_set&) { };
 
-		if ((ret = ::getaddrinfo(address, service, &hints, &res)) != 0)
+		if ((ret = ::getaddrinfo(address.c_str(), service.c_str(), &hints, &res)) != 0)
 		{
 			throw socket_exception("getaddrinfo(): " + std::string(gai_strerror(ret)));
 		}

--- a/ibrcommon/ibrcommon/net/vaddress.cpp
+++ b/ibrcommon/ibrcommon/net/vaddress.cpp
@@ -179,18 +179,18 @@ namespace ibrcommon
 		struct addrinfo *res;
 		int ret = 0;
 
-		const char *address = NULL;
-		const char *service = NULL;
+		std::string address;
+		std::string service;
 
 		// throw exception if the address is not set.
 		// without an address we can not determine the address family
-		address = this->address().c_str();
+		address = this->address();
 
 		try {
-			service = this->service().c_str();
+			service = this->service();
 		} catch (const vaddress::service_not_set&) { };
 
-		if ((ret = ::getaddrinfo(address, service, &hints, &res)) != 0)
+		if ((ret = ::getaddrinfo(address.c_str(), service.c_str(), &hints, &res)) != 0)
 		{
 			throw address_exception("getaddrinfo(): " + std::string(gai_strerror(ret)));
 		}


### PR DESCRIPTION
Hi, I discovered this subtle bug while testing IBR-DTN in an ad-hoc network with nodes configured only with IPv6 Link-Local addresses. The IPND works well and nodes discover each other. But while trying to send some data, for example using the dtnping tool, a TCPConnection failed error pops up (I use the TCP-CL). Looking at code I saw that Link-Local addresses are supported including the scope-id, so I started to debug with gdb. The problem is that the "getaddrinfo" call fails because "address" variable is pointing to a non valid memory location containing garabage. This variable (and "service" variable too) is defined as C style char array and is pointing to the address of the char array obtained calling std::string::c_str method on the temporary std::string object returned by vaddress::address() method. The C++ standard says "Unless bound to a reference or used to initialize a named object, a temporary object is destroyed at the end of the full expression in which it was created". So calling like this "address = _address.address().c_str()" and then using "address" on the subsequent "getaddrinfo" call was causing the bug. When strings containing addresses are short (in case of IPv4, or the service variable containing just the port number) this bug doesn't manifest itself, but with longer addresses it does. So I changed few lines of code and now address and service variables are named std::string objects, so their vailidity extends to the scope of the containing block. Into the getaddrinfo call now the std::string::c_str method has to be called on this variables. I changed this behaviour on all locations I was able to spot using find and grep on sources.