### PR TITLE
Set <any> interface as default

### DIFF
--- a/ibrcommon/ibrcommon/net/vinterface.cpp
+++ b/ibrcommon/ibrcommon/net/vinterface.cpp
@@ -39,7 +39,7 @@ namespace ibrcommon
 	const std::string vinterface::ANY = "any";
 
 	vinterface::vinterface()
-	 : _name()
+	 : _name(ANY)
 	{
 	}
 
@@ -61,7 +61,9 @@ namespace ibrcommon
 
 	const std::string vinterface::toString() const
 	{
-		if (_name.length() == 0) return "<any>";
+		if (_name.length() == 0) return "<undefined>";
+		if (isAny()) return "<any>";
+		if (isLoopback()) return "<loopback>";
 		return _name;
 	}
 

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -639,11 +639,7 @@ namespace dtn
 
 			try {
 				const std::string interface_name = _conf.read<std::string>("api_interface");
-
-				if (interface_name != "any")
-				{
-					nc.iface = ibrcommon::vinterface(interface_name);
-				}
+				nc.iface = ibrcommon::vinterface(interface_name);
 			} catch (const ConfigFile::key_not_found&) {
 				nc.iface = ibrcommon::vinterface(ibrcommon::vinterface::LOOPBACK);
 			}
@@ -880,7 +876,8 @@ namespace dtn
 							try {
 								nc.iface = ibrcommon::vinterface(conf.read<std::string>(key_interface));
 							} catch (const ConfigFile::key_not_found&) {
-								// no interface assigned
+								// no interface specfied - use ANY
+								nc.iface = ibrcommon::vinterface(ibrcommon::vinterface::ANY);
 							}
 
 							break;
@@ -892,6 +889,24 @@ namespace dtn
 				}
 			} catch (const ConfigFile::key_not_found&) {
 				// stop the one network is not found.
+			}
+
+			/**
+			 * Set ANY as default interface if no network is configured
+			 */
+			if (_interfaces.empty())
+			{
+				// create a new netconfig object
+				Configuration::NetConfig any("default", Configuration::NetConfig::NETWORK_TCP);
+
+				// create any interface object
+				any.iface = ibrcommon::vinterface(ibrcommon::vinterface::ANY);
+
+				// set default port
+				any.port = 4556;
+
+				// add to interfaces list
+				_interfaces.push_back( any );
 			}
 
 			/**

--- a/ibrdtn/daemon/src/net/DiscoveryAgent.cpp
+++ b/ibrdtn/daemon/src/net/DiscoveryAgent.cpp
@@ -113,8 +113,7 @@ namespace dtn
 		void DiscoveryAgent::registerService(dtn::net::DiscoveryBeaconHandler *handler)
 		{
 			ibrcommon::MutexLock l(_provider_lock);
-			handler_list &list = _providers[_any_iface];
-			list.push_back(handler);
+			_default_providers.push_back(handler);
 		}
 
 		void DiscoveryAgent::unregisterService(const dtn::net::DiscoveryBeaconHandler *handler)
@@ -260,9 +259,6 @@ namespace dtn
 
 			ibrcommon::MutexLock l(_provider_lock);
 
-			// get list for ANY interface
-			const handler_list &any_list = _providers[_any_iface];
-
 			for (handler_map::const_iterator it_p = _providers.begin(); it_p != _providers.end(); ++it_p)
 			{
 				const ibrcommon::vinterface &iface = (*it_p).first;
@@ -285,22 +281,6 @@ namespace dtn
 
 						}
 					}
-
-					// add service information for ANY interface
-					if (iface != _any_iface)
-					{
-						for (handler_list::const_iterator iter = any_list.begin(); iter != any_list.end(); ++iter)
-						{
-							DiscoveryBeaconHandler &handler = (**iter);
-
-							try {
-								// update service information
-								handler.onUpdateBeacon(iface, beacon);
-							} catch (const dtn::net::DiscoveryBeaconHandler::NoServiceHereException&) {
-
-							}
-						}
-					}
 				}
 
 				// broadcast announcement
@@ -310,6 +290,22 @@ namespace dtn
 
 					// broadcast beacon
 					handler.onAdvertiseBeacon(iface, beacon);
+				}
+			}
+
+			if (!_config.shortbeacon())
+			{
+				const ibrcommon::vinterface any;
+				for (handler_list::const_iterator iter = _default_providers.begin(); iter != _default_providers.end(); ++iter)
+				{
+					DiscoveryBeaconHandler &handler = (**iter);
+
+					try {
+						// update service information
+						handler.onUpdateBeacon(any, beacon);
+					} catch (const dtn::net::DiscoveryBeaconHandler::NoServiceHereException&) {
+
+					}
 				}
 			}
 

--- a/ibrdtn/daemon/src/net/DiscoveryAgent.h
+++ b/ibrdtn/daemon/src/net/DiscoveryAgent.h
@@ -86,8 +86,7 @@ namespace dtn
 			typedef std::pair<ibrcommon::vinterface, handler_list> handler_map_entry;
 
 			handler_map _providers;
-
-			const ibrcommon::vinterface _any_iface;
+			handler_list _default_providers;
 		};
 	}
 }

--- a/ibrdtn/daemon/src/net/IPNDAgent.cpp
+++ b/ibrdtn/daemon/src/net/IPNDAgent.cpp
@@ -66,7 +66,7 @@ namespace dtn
 		}
 
 		void IPNDAgent::add(const ibrcommon::vaddress &address) {
-			IBRCOMMON_LOGGER_TAG("DiscoveryAgent", info) << "listen to " << address.toString() << IBRCOMMON_LOGGER_ENDL;
+			IBRCOMMON_LOGGER_TAG(TAG, info) << "listen to " << address.toString() << IBRCOMMON_LOGGER_ENDL;
 			_destinations.insert(address);
 		}
 
@@ -78,7 +78,7 @@ namespace dtn
 			// only add the interface once
 			if (_interfaces.find(net) != _interfaces.end()) return;
 
-			IBRCOMMON_LOGGER_TAG("DiscoveryAgent", info) << "add interface " << net.toString() << IBRCOMMON_LOGGER_ENDL;
+			IBRCOMMON_LOGGER_TAG(TAG, info) << "advertise on interface " << net.toString() << IBRCOMMON_LOGGER_ENDL;
 
 			// store the new interface in the list of interfaces
 			_interfaces.insert(net);

--- a/ibrdtn/daemon/src/net/IPNDAgent.cpp
+++ b/ibrdtn/daemon/src/net/IPNDAgent.cpp
@@ -72,13 +72,13 @@ namespace dtn
 
 		void IPNDAgent::bind(const ibrcommon::vinterface &net)
 		{
-			IBRCOMMON_LOGGER_TAG("DiscoveryAgent", info) << "add interface " << net.toString() << IBRCOMMON_LOGGER_ENDL;
-
 			// add the interface to the stored set
 			ibrcommon::MutexLock l(_interface_lock);
 
 			// only add the interface once
 			if (_interfaces.find(net) != _interfaces.end()) return;
+
+			IBRCOMMON_LOGGER_TAG("DiscoveryAgent", info) << "add interface " << net.toString() << IBRCOMMON_LOGGER_ENDL;
 
 			// store the new interface in the list of interfaces
 			_interfaces.insert(net);


### PR DESCRIPTION
If not defined, the 'any' interface is now default for all convergence-layers. This also changes the
default behavior of dtnd. Previously, the daemon comes up without any interface. Now, the default is to bind to <any> and create a TCP-CL instance.

```
$ dtnd
Sat Oct 14 15:14:58 2017 INFO NativeDaemon: IBR-DTN daemon 1.0.1 (build a171900)
Sat Oct 14 15:14:58 2017 INFO Configuration: Using default settings. Call with --help for options.
Sat Oct 14 15:14:58 2017 INFO NativeDaemon: Parallel event processing enabled using 4 processes.
Sat Oct 14 15:14:58 2017 INFO BundleCore: Local node name: dtn://link
Sat Oct 14 15:14:58 2017 INFO BundleCore: Forwarding of bundles enabled.
Sat Oct 14 15:14:58 2017 INFO BundleCore: Non-singleton bundles are accepted.
Sat Oct 14 15:14:58 2017 INFO NativeDaemon: using bundle storage in memory-only mode
Sat Oct 14 15:14:58 2017 INFO NativeDaemon: API initialized using tcp socket: <loopback>:4550
Sat Oct 14 15:14:58 2017 INFO NativeDaemon: TCP ConvergenceLayer added on <any>:4556
Sat Oct 14 15:14:58 2017 INFO IPNDAgent: listen to [ff02::142]:4551
Sat Oct 14 15:14:58 2017 INFO IPNDAgent: listen to [224.0.0.142]:4551
Sat Oct 14 15:14:58 2017 INFO IPNDAgent: advertise on interface <any>
Sat Oct 14 15:14:58 2017 INFO NativeDaemon: Using default routing extensions
```