### PR TITLE
Multicast binding of IPNDAgent refactored

### DIFF
--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -37,6 +37,7 @@
 #include <sys/un.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <net/if.h>
 #endif
 
 #include <string.h>
@@ -227,6 +228,19 @@ namespace ibrcommon
 		if (__compat_setsockopt((fd == -1) ? _fd : fd, IPPROTO_TCP, TCP_NODELAY, &set, sizeof(set)) < 0) {
 			throw socket_exception("set no delay option failed");
 		}
+	}
+
+	void basesocket::set_interface(const vinterface &iface, int fd) const throw (socket_exception)
+	{
+#ifndef __WIN32__
+		char devname[IF_NAMESIZE];
+		const std::string s_devname = iface.toString();
+		::strncpy(devname, s_devname.c_str(), IF_NAMESIZE);
+
+		if (__compat_setsockopt((fd == -1) ? _fd : fd, SOL_SOCKET, SO_BINDTODEVICE, &devname, IF_NAMESIZE) < 0) {
+			check_socket_error(errno);
+		}
+#endif
 	}
 
 	sa_family_t basesocket::get_family() const throw (socket_exception)
@@ -976,6 +990,11 @@ namespace ibrcommon
 	{
 	}
 
+	udpsocket::udpsocket(const vinterface &iface, const vaddress &address)
+	 : _iface(iface), _address(address)
+	{
+	}
+
 	udpsocket::~udpsocket()
 	{
 		try {
@@ -986,6 +1005,11 @@ namespace ibrcommon
 	const vaddress& udpsocket::get_address() const
 	{
 		return _address;
+	}
+
+	const vinterface& udpsocket::get_interface() const
+	{
+		return _iface;
 	}
 
 	void udpsocket::up() throw (socket_exception)
@@ -1006,6 +1030,10 @@ namespace ibrcommon
 		try {
 			// try to bind on port and/or address
 			this->bind(_address);
+
+			if (!_iface.isAny() && !_iface.isLoopback()) {
+				this->set_interface(_iface);
+			}
 		} catch (const socket_exception&) {
 			// clean-up socket
 			__close(_fd);
@@ -1064,6 +1092,11 @@ namespace ibrcommon
 
 	multicastsocket::multicastsocket(const vaddress &address)
 	 : udpsocket(address)
+	{
+	}
+
+	multicastsocket::multicastsocket(const vinterface &iface, const vaddress &address)
+	 : udpsocket(iface, address)
 	{
 	}
 
@@ -1335,6 +1368,18 @@ namespace ibrcommon
 
 		case EPROTONOSUPPORT:
 			throw socket_exception("The protocol type or the specified protocol is not supported within this domain.");
+
+		case EBADF:
+			throw socket_exception("The argument sockfd is not a valid file descriptor.");
+
+		case EFAULT:
+			throw socket_exception("The address pointed to by optval is not in a valid part of the process address space.");
+
+		case ENOPROTOOPT:
+			throw socket_exception("The option is unknown at the level indicated.");
+
+		case ENOTSOCK:
+			throw socket_exception("The file descriptor sockfd does not refer to a socket.");
 
 		default:
 			throw socket_exception("Cannot create a socket.");

--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -700,7 +700,7 @@ namespace ibrcommon
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
 
-		init_socket(_address, SOCK_STREAM, 0);
+		init_socket(_address, SOCK_STREAM, IPPROTO_TCP);
 
 		// enable reuse to avoid delay on process restart
 		this->set_reuseaddr(true);
@@ -1017,7 +1017,7 @@ namespace ibrcommon
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
 
-		init_socket(_address, SOCK_DGRAM, 0);
+		init_socket(_address, SOCK_DGRAM, IPPROTO_UDP);
 
 		try {
 			// test if the service is defined

--- a/ibrcommon/ibrcommon/net/socket.h
+++ b/ibrcommon/ibrcommon/net/socket.h
@@ -198,6 +198,7 @@ namespace ibrcommon {
 		void set_linger(bool val, int l = 1, int fd = -1) const throw (socket_exception);
 		void set_reuseaddr(bool val, int fd = -1) const throw (socket_exception);
 		void set_nodelay(bool val, int fd = -1) const throw (socket_exception);
+		void set_interface(const vinterface &iface, int fd = -1) const throw (socket_exception);
 
 		void init_socket(const vaddress &addr, int type, int protocol) throw (socket_exception);
 		void init_socket(int domain, int type, int protocol) throw (socket_exception);
@@ -360,21 +361,25 @@ namespace ibrcommon {
 	public:
 		udpsocket();
 		udpsocket(const vaddress &address);
+		udpsocket(const vinterface &iface, const vaddress &address);
 		virtual ~udpsocket();
 		virtual void up() throw (socket_exception);
 		virtual void down() throw (socket_exception);
 
+		const vinterface& get_interface() const;
 		const vaddress& get_address() const;
 
 	protected:
 		void bind(const vaddress &addr) throw (socket_exception);
 
+		const vinterface _iface;
 		const vaddress _address;
 	};
 
 	class multicastsocket : public udpsocket {
 	public:
 		multicastsocket(const vaddress &address);
+		multicastsocket(const vinterface &iface, const vaddress &address);
 		virtual ~multicastsocket();
 		virtual void up() throw (socket_exception);
 		virtual void down() throw (socket_exception);

--- a/ibrdtn/daemon/src/net/IPNDAgent.cpp
+++ b/ibrdtn/daemon/src/net/IPNDAgent.cpp
@@ -52,11 +52,7 @@ namespace dtn
 		const std::string IPNDAgent::TAG = "IPNDAgent";
 
 		IPNDAgent::IPNDAgent(int port)
-		 :
-#ifndef __WIN32__
-		   _virtual_mcast_iface("__virtual_multicast_interface__"),
-#endif
-		   _state(false), _port(port)
+		 : _state(false), _port(port)
 		{
 		}
 
@@ -345,43 +341,6 @@ namespace dtn
 			} catch (const ibrcommon::socket_exception &ex) {
 				IBRCOMMON_LOGGER_TAG(IPNDAgent::TAG, error) << ex.what() << IBRCOMMON_LOGGER_ENDL;
 			}
-
-#ifndef __WIN32__
-			std::set<sa_family_t> bound_set;
-
-			// create a socket for each multicast address and bind explicit
-			// to the multicast addresses
-			for (std::set<ibrcommon::vaddress>::const_iterator it_addr = _destinations.begin(); it_addr != _destinations.end(); ++it_addr)
-			{
-				const ibrcommon::vaddress &addr = (*it_addr);
-
-				try {
-					sa_family_t fam = addr.family();
-
-					if (bound_set.find(fam) == bound_set.end()) {
-						const ibrcommon::vaddress any_addr(_port, fam);
-
-						// create a multicast socket and bind to given addr
-						ibrcommon::multicastsocket *msock = new ibrcommon::multicastsocket(any_addr);
-
-						try {
-							// bring up
-							msock->up();
-
-							// add mcast socket to vsocket
-							_socket.add(msock, _virtual_mcast_iface);
-						} catch (const ibrcommon::socket_exception &ex) {
-							IBRCOMMON_LOGGER_TAG(IPNDAgent::TAG, error) << "failed to set-up multicast socket on " << any_addr.toString() << ": " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-							delete msock;
-						}
-
-						bound_set.insert(fam);
-					}
-				} catch (const ibrcommon::vaddress::address_exception &ex) {
-					IBRCOMMON_LOGGER_TAG(IPNDAgent::TAG, error) << "unsupported multicast address " << addr.toString() << ": " << ex.what() << IBRCOMMON_LOGGER_ENDL;
-				}
-			}
-#endif
 
 			// listen to P2P dial-up events
 			dtn::core::EventDispatcher<dtn::net::P2PDialupEvent>::add(this);

--- a/ibrdtn/daemon/src/net/IPNDAgent.h
+++ b/ibrdtn/daemon/src/net/IPNDAgent.h
@@ -85,10 +85,6 @@ namespace dtn
 
 			void send(const DiscoveryBeacon &a, const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr);
 
-#ifndef __WIN32__
-			ibrcommon::vinterface _virtual_mcast_iface;
-#endif
-
 			ibrcommon::vsocket _socket;
 			bool _state;
 			int _port;


### PR DESCRIPTION
Now sockets bound to 0.0.0.0 and ::/0 are always created for receiving multicast packets. For sending message over specific interfaces, a socket with a random port is created for each address of used interfaces.