### PR TITLE
Fix for tcpstreamtest::baseTest hanging on select

### DIFF
--- a/ibrcommon/ibrcommon/net/socket.h
+++ b/ibrcommon/ibrcommon/net/socket.h
@@ -335,8 +335,8 @@ namespace ibrcommon {
 	 */
 	class tcpserversocket : public serversocket {
 	public:
-		tcpserversocket(const int port, int listen = 0);
-		tcpserversocket(const vaddress &address, int listen = 0);
+		tcpserversocket(const int port, int listen = 2);
+		tcpserversocket(const vaddress &address, int listen = 2);
 		virtual ~tcpserversocket();
 		virtual void up() throw (socket_exception);
 		virtual void down() throw (socket_exception);


### PR DESCRIPTION
"The `backlog` argument defines the maximum length to which the queue
of pending connections for sockfd may grow.  If a connection request
arrives when the queue is full, the client may receive an error with
an indication of ECONNREFUSED or, if the underlying protocol supports
retransmission, the request may be ignored so that a later reattempt
at connection succeeds."

Default value of 0 results in the test hanging undefinetely on one of
my boxes (linux-4.12.12, glibc-2.23) (looks like requests ignored as
described above). I'm not sure how no one has hit this before but it
took me like 6 hours to find out what's wrong with select().

Changing backlog argument to 2 on listen resolved the issue
immediately. I suggest this as a reasonable default.
`tcpserversocket` seems to be used in tests only currently.