### PR TITLE
Fixing DatagramClTest::queueTest test

### DIFF
--- a/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
+++ b/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
@@ -105,7 +105,7 @@ size_t FakeDatagramService::recvfrom(char *buf, size_t length, char &type, char 
 		seqno = msg.seqno;
 		address = msg.address;
 		ret = msg.data.size();
-		if (ret > 0) ::memcpy(buf, msg.data.data(), std::min(ret, length));
+		if (ret > 0) ::memcpy(buf, &msg.data[0], std::min(ret, length));
 		lq.pop();
 	} catch (const ibrcommon::QueueUnblockedException&) {
 		throw dtn::net::DatagramException("unblocked");

--- a/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
+++ b/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
@@ -105,7 +105,7 @@ size_t FakeDatagramService::recvfrom(char *buf, size_t length, char &type, char 
 		seqno = msg.seqno;
 		address = msg.address;
 		ret = msg.data.size();
-		::memcpy(buf, &msg.data[0], (ret > length) ? length : ret);
+		if (ret > 0) ::memcpy(buf, msg.data.data(), std::min(ret, length));
 		lq.pop();
 	} catch (const ibrcommon::QueueUnblockedException&) {
 		throw dtn::net::DatagramException("unblocked");

--- a/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
+++ b/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
@@ -21,6 +21,8 @@
 
 #include "FakeDatagramService.h"
 #include "net/DiscoveryBeacon.h"
+
+#include <algorithm>
 #include <string.h>
 #include <unistd.h>
 


### PR DESCRIPTION
DatagramClTest::queueTest line 108 references msg.data[0] which causes
'std::out_of_range' exception where msg.data.size() is 0.

DatagramClTest::queueTestterminate called after throwing an instance of 'std::out_of_range'
what():  vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)