### PR TITLE
Making enable-debug to turn optimizations off

### DIFF
--- a/ibrcommon/configure.ac
+++ b/ibrcommon/configure.ac
@@ -211,12 +211,12 @@ ANDROID_AC_BUILD([
 	AC_ARG_ENABLE(debug,
 	AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 	[
-		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
 		AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
 	], [
-		CPPFLAGS="${CPPFLAGS} -O2"
-		CFLAGS="${CFLAGS} -O2"
+		CPPFLAGS="${CPPFLAGS} -O3 -g -pipe"
+		CFLAGS="${CFLAGS} -O3 -g -pipe"
 		AC_MSG_NOTICE([Building with optimizations])
 	])
 

--- a/ibrcommon/configure.ac
+++ b/ibrcommon/configure.ac
@@ -51,6 +51,10 @@ AC_SUBST(GENERIC_LIBRARY_VERSION)
 AC_SUBST(GENERIC_LIBRARY_NAME)
 AC_SUBST(GENERIC_VERSION)
 
+dnl Drops autotools defaults but keeps user-specific options.
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
+
 dnl -----------------------------------------------
 dnl Checks for programs.
 dnl -----------------------------------------------
@@ -207,8 +211,13 @@ ANDROID_AC_BUILD([
 	AC_ARG_ENABLE(debug,
 	AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 	[
-		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-		CFLAGS="${CFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
+	], [
+		CPPFLAGS="${CPPFLAGS} -O2"
+		CFLAGS="${CFLAGS} -O2"
+		AC_MSG_NOTICE([Building with optimizations])
 	])
 
 	dnl -----------------------------------------------

--- a/ibrdtn/daemon/configure.ac
+++ b/ibrdtn/daemon/configure.ac
@@ -23,6 +23,10 @@ dnl -----------------------------------------------
 define([buildnumber], esyscmd([sh -c "git rev-parse --short HEAD|tr -d '\n'"]))dnl
 AC_DEFINE(BUILD_NUMBER, "buildnumber", [build number based on the version control system])
 
+dnl Drops autotools defaults but keeps user-specific options.
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
+
 dnl -----------------------------------------------
 dnl Checks for programs.
 dnl -----------------------------------------------
@@ -170,8 +174,13 @@ ANDROID_AC_BUILD([
 	AC_ARG_ENABLE(debug,
 	AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 	[
-		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-		CFLAGS="${CFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
+	], [
+		CPPFLAGS="${CPPFLAGS} -O2"
+		CFLAGS="${CFLAGS} -O2"
+		AC_MSG_NOTICE([Building with optimizations])
 	])
 
 	AC_ARG_ENABLE([libdaemon],

--- a/ibrdtn/daemon/configure.ac
+++ b/ibrdtn/daemon/configure.ac
@@ -174,12 +174,12 @@ ANDROID_AC_BUILD([
 	AC_ARG_ENABLE(debug,
 	AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 	[
-		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
 		AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
 	], [
-		CPPFLAGS="${CPPFLAGS} -O2"
-		CFLAGS="${CFLAGS} -O2"
+		CPPFLAGS="${CPPFLAGS} -O3 -g -pipe"
+		CFLAGS="${CFLAGS} -O3 -g -pipe"
 		AC_MSG_NOTICE([Building with optimizations])
 	])
 

--- a/ibrdtn/ibrdtn/configure.ac
+++ b/ibrdtn/ibrdtn/configure.ac
@@ -184,12 +184,12 @@ ANDROID_AC_BUILD([
 	AC_ARG_ENABLE(debug,
 	AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 	[
-		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
 		AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
 	], [
-		CPPFLAGS="${CPPFLAGS} -O2"
-		CFLAGS="${CFLAGS} -O2"
+		CPPFLAGS="${CPPFLAGS} -O3 -g -pipe"
+		CFLAGS="${CFLAGS} -O3 -g -pipe"
 		AC_MSG_NOTICE([Building with optimizations])
 	])
 

--- a/ibrdtn/ibrdtn/configure.ac
+++ b/ibrdtn/ibrdtn/configure.ac
@@ -51,6 +51,10 @@ AC_SUBST(GENERIC_LIBRARY_VERSION)
 AC_SUBST(GENERIC_LIBRARY_NAME)
 AC_SUBST(GENERIC_VERSION)
 
+dnl Drops autotools defaults but keeps user-specific options.
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
+
 dnl -----------------------------------------------
 dnl Checks for programs.
 dnl -----------------------------------------------
@@ -180,8 +184,13 @@ ANDROID_AC_BUILD([
 	AC_ARG_ENABLE(debug,
 	AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 	[
-		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-		CFLAGS="${CFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
+	], [
+		CPPFLAGS="${CPPFLAGS} -O2"
+		CFLAGS="${CFLAGS} -O2"
+		AC_MSG_NOTICE([Building with optimizations])
 	])
 
 	dnl -----------------------------------------------

--- a/ibrdtn/tools/configure.ac
+++ b/ibrdtn/tools/configure.ac
@@ -16,6 +16,10 @@ AM_MAINTAINER_MODE
 # Test for new silent rules and enable only if they are available
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+dnl Drops autotools defaults but keeps user-specific options.
+: ${CFLAGS=""}
+: ${CXXFLAGS=""}
+
 dnl -----------------------------------------------
 dnl Checks for programs.
 dnl -----------------------------------------------
@@ -91,8 +95,13 @@ AC_HELP_STRING([--enable-gcov], [Turn on gcov coverage testing.]),
 AC_ARG_ENABLE(debug,
 AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 [
-	CPPFLAGS="${CPPFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-	CFLAGS="${CFLAGS} -ggdb -g3 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+	CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+	CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+	AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
+], [
+	CPPFLAGS="${CPPFLAGS} -O2"
+	CFLAGS="${CFLAGS} -O2"
+	AC_MSG_NOTICE([Building with optimizations])
 ])
 
 AC_ARG_WITH([libdaemon],

--- a/ibrdtn/tools/configure.ac
+++ b/ibrdtn/tools/configure.ac
@@ -95,12 +95,12 @@ AC_HELP_STRING([--enable-gcov], [Turn on gcov coverage testing.]),
 AC_ARG_ENABLE(debug,
 AC_HELP_STRING([--enable-debug], [Turn on debugging symbols.]),
 [
-	CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
-	CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__"
+		CPPFLAGS="${CPPFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
+		CFLAGS="${CFLAGS} -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -pipe"
 	AC_MSG_NOTICE([Debug symbols enabled, optimizations off])
 ], [
-	CPPFLAGS="${CPPFLAGS} -O2"
-	CFLAGS="${CFLAGS} -O2"
+	CPPFLAGS="${CPPFLAGS} -O3 -g -pipe"
+	CFLAGS="${CFLAGS} -O3 -g -pipe"
 	AC_MSG_NOTICE([Building with optimizations])
 ])
 


### PR DESCRIPTION
Fixes issue #242.

W/o enable-debug:
g++ -DHAVE_CONFIG_H -I.. -O2 -MT SyslogStream.lo -MD -MP -MF .deps/SyslogStream.Tpo -c -o SyslogStream.lo SyslogStream.cpp

With enable-debug:
g++ -DHAVE_CONFIG_H -I.. -ggdb -g3 -O0 -Wall -Wextra -pedantic -Wconversion -D__DEVELOPMENT_ASSERTIONS__ -MT SyslogStream.lo -MD -MP -MF .deps/SyslogStream.Tpo -c -o SyslogStream.lo SyslogStream.cpp