### PR TITLE
Adding CMake configuration as an option for ibrcommon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,15 @@ before_script:
   - cd ibrdtn
 
 script:
+  - set -e
   - if [ "$WITH_CMAKE" == "yes" ]; then
-      CMAKE_OPTS="-DNetlink=ON -DLowpan=ON -DOpenssl=ON -DXml=ON"
-      mkdir .compile && pushd .compile
-      cmake ${CMAKE_OPTS} ..
-      popd
+      CMAKE_OPTS="-DNetlink=ON -DLowpan=ON -DOpenssl=ON -DXml=ON";
+      mkdir .compile && pushd .compile;
+      cmake ${CMAKE_OPTS} ..;
+      popd;
     else
-      CONFIGURE_OPTS="${CONFIGURE_OPTS_EXTRA} --with-tffs=$(pwd)/../tffs-lib --with-openssl --with-curl --with-lowpan --with-sqlite --with-compression --with-xml --with-tls --with-dht"
-      ./autogen.sh
+      CONFIGURE_OPTS="${CONFIGURE_OPTS_EXTRA} --with-tffs=$(pwd)/../tffs-lib --with-openssl --with-curl --with-lowpan --with-sqlite --with-compression --with-xml --with-tls --with-dht";
+      ./autogen.sh;
       if [ "${DO_COVERAGE}" == "yes" ]; then
         ./configure ${CONFIGURE_OPTS} --enable-gcov;
       else

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: DO_COVERAGE=no CONFIGURE_OPTS_EXTRA="--without-vmime --disable-dtndht"
     - compiler: clang
       env: DO_COVERAGE=no CONFIGURE_OPTS_EXTRA="--disable-netlink --without-vmime --disable-dtndht"
+    - compiler: gcc
+      env: DO_COVERAGE=no WITH_CMAKE=yes
 
 addons:
   apt:
@@ -53,12 +55,19 @@ before_script:
   - cd ibrdtn
 
 script:
-  - CONFIGURE_OPTS="${CONFIGURE_OPTS_EXTRA} --with-tffs=$(pwd)/../tffs-lib --with-openssl --with-curl --with-lowpan --with-sqlite --with-compression --with-xml --with-tls --with-dht"
-  - ./autogen.sh
-  - if [ "${DO_COVERAGE}" == "yes" ]; then
-      ./configure ${CONFIGURE_OPTS} --enable-gcov;
+  - if [ "$WITH_CMAKE" == "yes" ]; then
+      CMAKE_OPTS="-DNetlink=ON -DLowpan=ON -DOpenssl=ON -DXml=ON"
+      mkdir .compile && pushd .compile
+      cmake ${CMAKE_OPTS} ..
+      popd
     else
-      ./configure ${CONFIGURE_OPTS};
+      CONFIGURE_OPTS="${CONFIGURE_OPTS_EXTRA} --with-tffs=$(pwd)/../tffs-lib --with-openssl --with-curl --with-lowpan --with-sqlite --with-compression --with-xml --with-tls --with-dht"
+      ./autogen.sh
+      if [ "${DO_COVERAGE}" == "yes" ]; then
+        ./configure ${CONFIGURE_OPTS} --enable-gcov;
+      else
+        ./configure ${CONFIGURE_OPTS};
+      fi
     fi
   - make
   - make check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.2)
+
+subdirs("ibrcommon")

--- a/ibrcommon/CMakeLists.txt
+++ b/ibrcommon/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.2)
+
+project (ibrcommon)
+
+find_package(PkgConfig REQUIRED QUIET)
+
+option(Debug "Build for debugging [default=OFF]" OFF)
+
+if(Debug)
+  message(STATUS "Building for Debugging")
+  add_definitions(-D __DEVELOPMENT_ASSERTIONS__)
+  # TODO: CXXFLAGS
+endif()
+
+include_directories("${CMAKE_SOURCE_DIR}/ibrcommon")
+
+add_subdirectory("ibrcommon")

--- a/ibrcommon/ibrcommon/CMakeLists.txt
+++ b/ibrcommon/ibrcommon/CMakeLists.txt
@@ -1,0 +1,132 @@
+set(ibrcommon_sources
+    appstreambuf.cpp
+    Logger.cpp
+    MonotonicClock.cpp
+    TimeMeasurement.cpp
+    data/Base64.cpp
+    data/Base64Reader.cpp
+    data/Base64Stream.cpp
+    data/BLOB.cpp
+    data/BloomFilter.cpp
+    data/ConfigFile.cpp
+    data/File.cpp
+    data/iobuffer.cpp
+    link/CompatLinkManager.cpp
+    link/LinkEvent.cpp
+    link/LinkManager.cpp
+    link/LinkMonitor.cpp
+    net/socket.cpp
+    net/socketstream.cpp
+    net/stopandwait.cpp
+    net/vaddress.cpp
+    net/vinterface.cpp
+    net/vsocket.cpp
+    thread/AtomicCounter.cpp
+    thread/Conditional.cpp
+    thread/Mutex.cpp
+    thread/MutexLock.cpp
+    thread/RWLock.cpp
+    thread/RWMutex.cpp
+    thread/Semaphore.cpp
+    thread/SignalHandler.cpp
+    thread/Thread.cpp
+    thread/Timer.cpp
+)
+
+set(sslsupport_sources
+    ssl/AES128Stream.cpp
+    ssl/CipherStream.cpp
+    ssl/HashStream.cpp
+    ssl/HMacStream.cpp
+    ssl/InputCipherStream.cpp
+    ssl/iostreamBIO.cpp
+    ssl/MD5Stream.cpp
+    ssl/RSASHA256Stream.cpp
+    ssl/SHA256Stream.cpp
+    ssl/TLSStream.cpp
+    ssl/XORStream.cpp
+    ssl/gcm/gcm.cpp
+    ssl/gcm/gf128mul.cpp
+)
+
+# Choose an implementation for netlink manager.
+option(Netlink "Build with netlink library [default=ON]" ON)
+
+if (WIN32)
+  list(APPEND ibrcommon_sources link/Win32LinkManager.cpp)
+else()
+  if (Netlink)
+    pkg_search_module(PC_LIBNL libnl-3.0)
+    if(PKG_CONFIG_FOUND)
+      add_definitions(-DHAVE_LIBNL3=1)
+      set(HAS_NETLINK 1)
+    else()
+      pkg_search_module(PC_LIBNL libnl-2.0)
+      if(PKG_CONFIG_FOUND)
+        add_definitions(-DHAVE_LIBNL2=1)
+        set(HAS_NETLINK 1)
+      else()
+        pkg_search_module(PC_LIBNL libnl-1)
+        if(PKG_CONFIG_FOUND)
+          add_definitions(-DHAVE_LIBNL=1)
+          set(HAS_NETLINK 1)
+        endif()
+      endif()
+    endif()
+  endif ()
+  if (HAS_NETLINK)
+    message(STATUS "Building with libnl-" ${PC_LIBNL_VERSION})
+    include_directories("${PC_LIBNL_INCLUDE_DIRS}")
+    list(APPEND ibrcommon_sources link/NetLinkManager.cpp)
+  else()
+    list(APPEND ibrcommon_sources link/PosixLinkManager.cpp)
+  endif()
+endif()
+
+# Enable/disable lowpan.
+option(Lowpan "Build with lowpan support [default=OFF]" OFF)
+
+if (Lowpan)
+  message(STATUS "Building with lowpan")
+  if (NOT(HAS_NETLINK))
+    message(SEND_ERROR "Netlink is required for lowpan support")
+  endif()
+  list(APPEND ibrcommon_sources net/lowpansocket.cpp net/lowpanstream.cpp)
+endif()
+
+# Enable/disable openssl
+option(Openssl "Build with openssl support [default=OFF]" OFF)
+
+if (Openssl)
+  pkg_search_module(OPENSSL REQUIRED openssl)
+  message(STATUS "Building with openssl-" ${OPENSSL_VERSION})
+  list(APPEND ibrcommon_sources ${sslsupport_sources})
+endif()
+
+# Enable/disable xml
+option(Xml "Build with xml support [default=OFF]" OFF)
+
+if (Xml)
+  pkg_search_module(LIBXML2 REQUIRED libxml-2.0)
+  message(STATUS "Building with libxml-" ${LIBXML2_VERSION})
+  list(APPEND ibrcommon_sources xml/XMLStreamReader.cpp xml/XMLStreamWriter.cpp)
+  include_directories("${LIBXML2_INCLUDE_DIRS}")
+endif()
+
+# TODO: implement and test HAVE_FEATURES_H
+
+# TODO: implement and test HAVE_MACH_MACH_TIME_H
+
+# TODO: implement and test HAVE_SYSLOG_H
+#  list(APPEND ibrcommon_sources SyslogStream.cpp)
+
+# TODO: find out where CLOCK_BOOTTIME can come from.
+# TODO: find out where MCAST_JOIN_GROUP can come from.
+# TODO: find out where MCAST_LEAVE_GROUP can come from.
+
+# Generate a dummy config.h not used with CMake.
+configure_file(config.h.cmake ibrcommon/config.h COPYONLY)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+# build ibrcommon as static lib.
+add_library(ibrcommon MODULE ${ibrcommon_sources})

--- a/ibrcommon/ibrcommon/config.h.cmake
+++ b/ibrcommon/ibrcommon/config.h.cmake
@@ -1,0 +1,6 @@
+/*
+  CMake config.h replacement.
+
+  config.h is not used with CMake, build flags are passed on the command line.
+  This file is present here to avoid compilation errors.
+*/


### PR DESCRIPTION
Adding support for building with CMake. This should not affect existing build in any way. Also, touching .travis to see if it can build that way too.

This patch only includes ibrcommon, I can work on the rest if it's accepted. Rationale for the patch:
 - the build is much quicker
 - integration with CLion

Caveats:
 - only tested on linux
 - some defines were not identified, may be defined outside the project or history artifacts, added TODOs.