### PR TITLE
Rebind to sockets if a net interface goes back up

### DIFF
--- a/ibrdtn/daemon/src/net/TCPConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/TCPConvergenceLayer.h
@@ -128,6 +128,11 @@ namespace dtn
 			void listen(const ibrcommon::vinterface &iface, int port) throw ();
 
 			/**
+			 * Binds or rebinds sockets for a given interface and port.
+			 */
+			void bindSockets(const ibrcommon::vinterface &net, const int port) throw ();
+
+			/**
 			 * Remove a specific interface
 			 */
 			void unlisten(const ibrcommon::vinterface &iface) throw ();


### PR DESCRIPTION
Fixes issue #252.

On ACTION_LINK_DOWN event TCPConvergenceLayer closes and removes the sockets but ACTION_LINK_UP is ignored. That means the layer will only bind to the configured interfaces once. If a link (e.g. eth0) goes down and up again, daemon will never re-link.