### PR TITLE
Make LIBNL_ABOVE_3_2_21 to be really equals or above

### DIFF
--- a/ibrcommon/ibrcommon/link/NetLinkManager.cpp
+++ b/ibrcommon/ibrcommon/link/NetLinkManager.cpp
@@ -29,7 +29,7 @@
 #endif
 
 #ifdef HAVE_LIBNL3
-#if (LIBNL_VER_NUM >= LIBNL_VER(3,2)) && (LIBNL_VER_MIC == 21)
+#if (LIBNL_VER_NUM >= LIBNL_VER(3,2)) && (LIBNL_VER_MIC >= 21)
 #define LIBNL_ABOVE_3_2_21
 #endif
 #endif


### PR DESCRIPTION
Currently, LIBNL_ABOVE_3_2_21 is not defined for versions above 3.2.21.
This results in old headers to be pulled in with lib versions 3.2.>21.