### PR TITLE
ibrdtnd: added openssl 1.1 compatibility

### DIFF
--- a/ibrdtn/daemon/src/security/exchange/Makefile.am
+++ b/ibrdtn/daemon/src/security/exchange/Makefile.am
@@ -22,6 +22,8 @@ exchange_SOURCES += \
 	NFCProtocol.cpp \
 	NoneProtocol.h \
 	NoneProtocol.cpp \
+	openssl_compat.h \
+	openssl_compat.cpp \
 	QRCodeProtocol.h \
 	QRCodeProtocol.cpp
 	

--- a/ibrdtn/daemon/src/security/exchange/openssl_compat.cpp
+++ b/ibrdtn/daemon/src/security/exchange/openssl_compat.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include "openssl_compat.h"
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+void DH_get0_pqg(const DH *dh,
+                 const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
+{
+    if (p != NULL)
+        *p = dh->p;
+    if (q != NULL)
+        *q = dh->q;
+    if (g != NULL)
+        *g = dh->g;
+}
+
+int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+    /* If the fields p and g in d are NULL, the corresponding input
+     * parameters MUST be non-NULL.  q may remain NULL.
+     */
+    if ((dh->p == NULL && p == NULL)
+        || (dh->g == NULL && g == NULL))
+        return 0;
+
+    if (p != NULL) {
+        BN_free(dh->p);
+        dh->p = p;
+    }
+    if (q != NULL) {
+        BN_free(dh->q);
+        dh->q = q;
+    }
+    if (g != NULL) {
+        BN_free(dh->g);
+        dh->g = g;
+    }
+
+    if (q != NULL) {
+        dh->length = BN_num_bits(q);
+    }
+
+    return 1;
+}
+
+void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+    if (pub_key != NULL)
+        *pub_key = dh->pub_key;
+    if (priv_key != NULL)
+        *priv_key = dh->priv_key;
+}
+
+#endif /* OPENSSL_VERSION_NUMBER */

--- a/ibrdtn/daemon/src/security/exchange/openssl_compat.h
+++ b/ibrdtn/daemon/src/security/exchange/openssl_compat.h
@@ -1,0 +1,13 @@
+#ifndef LIBCRYPTO_COMPAT_H
+#define LIBCRYPTO_COMPAT_H
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+#include <openssl/dh.h>
+
+void DH_get0_pqg(const DH *dh, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);
+int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
+void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key);
+
+#endif /* OPENSSL_VERSION_NUMBER */
+#endif /* LIBCRYPTO_COMPAT_H */


### PR DESCRIPTION
This patch adds compatibility with openssl 1.1.0 to ibrdtnd.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>