### PR TITLE
SecurityCertificateManager.cpp: include cstring

### DIFF
--- a/ibrdtn/daemon/src/security/SecurityCertificateManager.cpp
+++ b/ibrdtn/daemon/src/security/SecurityCertificateManager.cpp
@@ -22,6 +22,7 @@
 #include "security/SecurityCertificateManager.h"
 #include "Configuration.h"
 
+#include <cstring>
 #include <cstdlib>
 
 #include <ibrcommon/Logger.h>


### PR DESCRIPTION
Fixes build with gcc-8.2.0:

SecurityCertificateManager.cpp:208:8: error: 'memcmp' was not declared in this scope
     if(memcmp(utf8_eid, utf8_cert_name, utf8_eid_len) == 0){
        ^~~~~~
SecurityCertificateManager.cpp:208:8: note: 'memcmp' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
SecurityCertificateManager.cpp:29:1:
+#include <cstring>
