### PR TITLE
ibrcommon/ssl/gcm: fix static build with openssl

### DIFF
--- a/ibrcommon/ibrcommon/ssl/gcm/gcm.cpp
+++ b/ibrcommon/ibrcommon/ssl/gcm/gcm.cpp
@@ -89,7 +89,7 @@ ret_type gcm_init_and_key(                      /* initialise mode and set key  
 #elif defined( TABLES_256 )
 #define gf_mul_hh(a, ctx, scr)  gf_mul_256(a, ctx->gf_t256, scr)
 #else
-#define gf_mul_hh(a, ctx, scr)  gf_mul(a, ui8_ptr(ctx->ghash_h))
+#define gf_mul_hh(a, ctx, scr)  ibrdtn_gf_mul(a, ui8_ptr(ctx->ghash_h))
 #endif
 
 ret_type gcm_init_message(                      /* initialise a new message     */
@@ -334,9 +334,9 @@ ret_type gcm_compute_tag(                       /* compute authentication tag   
         memcpy(tbuf, ctx->ghash_h, BLOCK_SIZE);
         for( ; ; )
         {
-            if(ln & 1) gf_mul(ui8_ptr(ctx->hdr_ghv), tbuf);
+            if(ln & 1) ibrdtn_gf_mul(ui8_ptr(ctx->hdr_ghv), tbuf);
             if(!(ln >>= 1)) break;
-            gf_mul(tbuf, tbuf);
+            ibrdtn_gf_mul(tbuf, tbuf);
         }
     }
 #else   /* this one seems slower on x86 and x86_64 :-( */
@@ -348,12 +348,12 @@ ret_type gcm_compute_tag(                       /* compute authentication tag   
         tbuf[0] = 0x80;
         while(i)
         {
-            gf_mul(tbuf, tbuf);
+            ibrdtn_gf_mul(tbuf, tbuf);
             if(i & ln)
                 gf_mul_hh(tbuf, ctx, scratch);
             i >>= 1;
         }
-        gf_mul(ui8_ptr(ctx->hdr_ghv), tbuf);
+        ibrdtn_gf_mul(ui8_ptr(ctx->hdr_ghv), tbuf);
     }
 #endif
     i = BLOCK_SIZE; ln = (uint_32t)(ctx->txt_acnt << 3);

--- a/ibrcommon/ibrcommon/ssl/gcm/gf128mul.cpp
+++ b/ibrcommon/ibrcommon/ssl/gcm/gf128mul.cpp
@@ -103,7 +103,7 @@
 
 const unsigned short gf_tab[256] = gf_dat(xda);
 
-void gf_mul(void *a, const void* b)
+void ibrdtn_gf_mul(void *a, const void* b)
 {   uint_32t r[GF_BYTE_LEN >> 2], p[8][GF_BYTE_LEN >> 2];
     int i;
 

--- a/ibrcommon/ibrcommon/ssl/gcm/gf128mul.h
+++ b/ibrcommon/ibrcommon/ssl/gcm/gf128mul.h
@@ -619,7 +619,7 @@ gf_inline void mul_x(void *r, const void *x)
 
 /*  A slow generic version of gf_mul (a = a * b) */
 
-void gf_mul(void *a, const void* b);
+void ibrdtn_gf_mul(void *a, const void* b);
 
 /*  This version uses 64k bytes of table space on the stack.
     A 16 byte buffer has to be multiplied by a 16 byte key


### PR DESCRIPTION
gf_mul is already defined in libcrypto (openssl) so rename it into
ibrdtn_gf_mul to fix following build failure:

/home/buildroot/autobuild/instance-3/output/host/bin/../arm-buildroot-uclinux-uclibcgnueabi/sysroot/usr/lib/libcrypto.a(f_impl.o): In function `gf_mul':
f_impl.c:(.text+0x0): multiple definition of `gf_mul'
/home/buildroot/autobuild/instance-3/output/host/arm-buildroot-uclinux-uclibcgnueabi/sysroot/usr/lib/libibrcommon.a(gf128mul.o):gf128mul.cpp:(.text+0x30): first defined here
collect2: error: ld returned 1 exit status
Makefile:560: recipe for target 'dtnd' failed

Fixes:
 - http://autobuild.buildroot.org/results/1d3b4b6cf043a3e185ce758b617a0a18c3d36cdb

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>