### PR TITLE
Make Conditional mutable.

### DIFF
--- a/ibrcommon/ibrcommon/thread/Queue.h
+++ b/ibrcommon/ibrcommon/thread/Queue.h
@@ -73,7 +73,7 @@ namespace ibrcommon
 	template <class T>
 	class Queue
 	{
-		ibrcommon::Conditional _cond;
+		mutable ibrcommon::Conditional _cond;
 		std::queue<T> _queue;
 		ibrcommon::Semaphore _sem;
 		bool _limit;


### PR DESCRIPTION
front() and back() are defined as const but modify a non-mutable member.
This is a compilation error on some toolchains.