### PR TITLE
V1.0.1 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/ibrcommon/Makefile.am
+++ b/ibrcommon/Makefile.am
@@ -1,6 +1,7 @@
 ## top directory
 
 #Build in these directories:
+AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS = $(GENERIC_LIBRARY_NAME)
 
 #Distribute these directories:

--- a/ibrcommon/ibrcommon/Exceptions.h
+++ b/ibrcommon/ibrcommon/Exceptions.h
@@ -42,20 +42,20 @@ namespace ibrcommon
 	class Exception : public std::exception
 	{
 		public:
-			Exception() throw()
+			Exception() noexcept
 			{};
 
-			Exception(const exception&) throw()
+			Exception(const exception&) noexcept
 			{};
 
-			virtual ~Exception() throw()
+			virtual ~Exception() noexcept
 			{};
 
 			/**
 			 * Get the explaining reason as string value.
 			 * @return The reason as string value.
 			 */
-			virtual const char* what() const throw()
+			virtual const char* what() const noexcept
 			{
 				return _what.c_str();
 			}
@@ -64,7 +64,7 @@ namespace ibrcommon
 			 * constructor with attached string value as reason.
 			 * @param what The detailed reason for this exception.
 			 */
-			Exception(string what) throw()
+			Exception(string what) noexcept
 			{
 				_what = what;
 			};
@@ -79,7 +79,7 @@ namespace ibrcommon
 	class NotImplementedException : public Exception
 	{
 	public:
-		NotImplementedException(string what = "This method isn't implemented.") throw() : Exception(what)
+		NotImplementedException(string what = "This method isn't implemented.") noexcept : Exception(what)
 		{
 		};
 	};
@@ -90,7 +90,7 @@ namespace ibrcommon
 	class IOException : public Exception
 	{
 	public:
-		IOException(string what = "Input/Output error.") throw() : Exception(what)
+		IOException(string what = "Input/Output error.") noexcept : Exception(what)
 		{
 		};
 	};

--- a/ibrcommon/ibrcommon/Logger.cpp
+++ b/ibrcommon/ibrcommon/Logger.cpp
@@ -632,7 +632,7 @@ namespace ibrcommon
 		}
 	}
 
-	void LogWriter::run() throw ()
+	void LogWriter::run() noexcept
 	{
 		try {
 			while (true)
@@ -671,7 +671,7 @@ namespace ibrcommon
 		}
 	}
 
-	void LogWriter::__cancellation() throw ()
+	void LogWriter::__cancellation() noexcept
 	{
 		// cancel the main thread in here
 		_queue.abort();

--- a/ibrcommon/ibrcommon/Logger.h
+++ b/ibrcommon/ibrcommon/Logger.h
@@ -382,8 +382,8 @@ namespace ibrcommon
 
 	protected:
 		void flush();
-		void run() throw ();
-		void __cancellation() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
 
 	private:
 		class LoggerOutput

--- a/ibrcommon/ibrcommon/TLSExceptions.h
+++ b/ibrcommon/ibrcommon/TLSExceptions.h
@@ -29,7 +29,7 @@ namespace ibrcommon
 	class TLSException : public ibrcommon::Exception
 	{
 	public:
-		TLSException(const std::string &what) throw() : Exception(what)
+		TLSException(const std::string &what) noexcept : Exception(what)
 		{
 		}
 	};
@@ -37,7 +37,7 @@ namespace ibrcommon
 	class ContextCreationException : public TLSException
 	{
 	public:
-		ContextCreationException(const std::string &what) throw() : TLSException(what)
+		ContextCreationException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -45,7 +45,7 @@ namespace ibrcommon
 	class SSLCreationException : public TLSException
 	{
 	public:
-		SSLCreationException(const std::string &what) throw() : TLSException(what)
+		SSLCreationException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -53,7 +53,7 @@ namespace ibrcommon
 	class BIOCreationException : public TLSException
 	{
 	public:
-		BIOCreationException(const std::string &what) throw() : TLSException(what)
+		BIOCreationException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -61,7 +61,7 @@ namespace ibrcommon
 	class TLSHandshakeException : public TLSException
 	{
 	public:
-		TLSHandshakeException(const std::string &what) throw() : TLSException(what)
+		TLSHandshakeException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -69,7 +69,7 @@ namespace ibrcommon
 	class TLSNotInitializedException : public TLSException
 	{
 	public:
-		TLSNotInitializedException(const std::string &what) throw() : TLSException(what)
+		TLSNotInitializedException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -77,7 +77,7 @@ namespace ibrcommon
 	class TLSCertificateFileException : public TLSException
 	{
 	public:
-		TLSCertificateFileException(const std::string &what) throw() : TLSException(what)
+		TLSCertificateFileException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -85,7 +85,7 @@ namespace ibrcommon
 	class TLSKeyFileException : public TLSException
 	{
 	public:
-		TLSKeyFileException(const std::string &what) throw() : TLSException(what)
+		TLSKeyFileException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};
@@ -93,7 +93,7 @@ namespace ibrcommon
 	class TLSCertificateVerificationException : public TLSException
 	{
 	public:
-		TLSCertificateVerificationException(const std::string &what) throw() : TLSException(what)
+		TLSCertificateVerificationException(const std::string &what) noexcept : TLSException(what)
 		{
 		};
 	};

--- a/ibrcommon/ibrcommon/data/BLOB.h
+++ b/ibrcommon/ibrcommon/data/BLOB.h
@@ -36,7 +36,7 @@ namespace ibrcommon
 	class CanNotOpenFileException : public ibrcommon::IOException
 	{
 	public:
-		CanNotOpenFileException(ibrcommon::File f) throw() : IOException("Could not open file " + f.getPath() + ".")
+		CanNotOpenFileException(ibrcommon::File f) noexcept : IOException("Could not open file " + f.getPath() + ".")
 		{
 		};
 	};

--- a/ibrcommon/ibrcommon/data/File.h
+++ b/ibrcommon/ibrcommon/data/File.h
@@ -189,7 +189,7 @@ namespace ibrcommon
 	class FileNotExistsException : public ibrcommon::IOException
 	{
 	public:
-		FileNotExistsException(ibrcommon::File f) throw() : IOException("The file " + f.getPath() + " does not exists.")
+		FileNotExistsException(ibrcommon::File f) noexcept : IOException("The file " + f.getPath() + " does not exists.")
 		{
 		};
 	};

--- a/ibrcommon/ibrcommon/link/LinkManager.cpp
+++ b/ibrcommon/ibrcommon/link/LinkManager.cpp
@@ -64,7 +64,7 @@ namespace ibrcommon
 		}
 	}
 
-	void LinkManager::addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ()
+	void LinkManager::addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept
 	{
 		if (cb == NULL) return;
 		ibrcommon::MutexLock l(_listener_mutex);
@@ -73,7 +73,7 @@ namespace ibrcommon
 		ss.insert(cb);
 	}
 
-	void LinkManager::removeEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ()
+	void LinkManager::removeEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept
 	{
 		if (cb == NULL) return;
 		ibrcommon::MutexLock l(_listener_mutex);
@@ -88,7 +88,7 @@ namespace ibrcommon
 		}
 	}
 
-	void LinkManager::removeEventListener(LinkManager::EventCallback *cb) throw ()
+	void LinkManager::removeEventListener(LinkManager::EventCallback *cb) noexcept
 	{
 		if (cb == NULL) return;
 

--- a/ibrcommon/ibrcommon/link/LinkManager.h
+++ b/ibrcommon/ibrcommon/link/LinkManager.h
@@ -44,15 +44,15 @@ namespace ibrcommon
 
 		virtual ~LinkManager() {};
 
-		virtual void up() throw () { };
-		virtual void down() throw () { };
+		virtual void up() noexcept { };
+		virtual void down() noexcept { };
 
 		virtual const ibrcommon::vinterface getInterface(int index) const = 0;
 		virtual const std::list<vaddress> getAddressList(const vinterface &iface, const std::string &scope = "") = 0;
 
-		virtual void addEventListener(const vinterface&, LinkManager::EventCallback*) throw ();
-		virtual void removeEventListener(const vinterface&, LinkManager::EventCallback*) throw ();
-		virtual void removeEventListener(LinkManager::EventCallback*) throw ();
+		virtual void addEventListener(const vinterface&, LinkManager::EventCallback*) noexcept;
+		virtual void removeEventListener(const vinterface&, LinkManager::EventCallback*) noexcept;
+		virtual void removeEventListener(LinkManager::EventCallback*) noexcept;
 
 		void raiseEvent(const LinkEvent &lme);
 

--- a/ibrcommon/ibrcommon/link/LinkMonitor.cpp
+++ b/ibrcommon/ibrcommon/link/LinkMonitor.cpp
@@ -42,7 +42,7 @@ namespace ibrcommon
 		join();
 	}
 
-	void LinkMonitor::add(const ibrcommon::vinterface &iface) throw ()
+	void LinkMonitor::add(const ibrcommon::vinterface &iface) noexcept
 	{
 		// check if there exists an address set for this interface
 		if (_addr_map.find(iface) != _addr_map.end()) return;
@@ -54,7 +54,7 @@ namespace ibrcommon
 		_addr_map[iface].insert(addr.begin(), addr.end());
 	}
 
-	void LinkMonitor::remove() throw ()
+	void LinkMonitor::remove() noexcept
 	{
 		// get all monitored interfaces
 		const std::set<vinterface> ifaces = _lmgr.getMonitoredInterfaces();
@@ -72,7 +72,7 @@ namespace ibrcommon
 		}
 	}
 
-	void LinkMonitor::run() throw ()
+	void LinkMonitor::run() noexcept
 	{
 		ibrcommon::MutexLock l(_cond);
 
@@ -162,7 +162,7 @@ namespace ibrcommon
 		}
 	}
 
-	void LinkMonitor::__cancellation() throw ()
+	void LinkMonitor::__cancellation() noexcept
 	{
 		// debug
 		IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 60) << "cancelled" << IBRCOMMON_LOGGER_ENDL;

--- a/ibrcommon/ibrcommon/link/LinkMonitor.h
+++ b/ibrcommon/ibrcommon/link/LinkMonitor.h
@@ -43,12 +43,12 @@ namespace ibrcommon
 		LinkMonitor(LinkManager &lm);
 		virtual ~LinkMonitor();
 
-		void add(const ibrcommon::vinterface &iface) throw ();
-		void remove() throw ();
+		void add(const ibrcommon::vinterface &iface) noexcept;
+		void remove() noexcept;
 
 	protected:
-		void run() throw ();
-		void __cancellation() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
 
 	private:
 		ibrcommon::Conditional _cond;

--- a/ibrcommon/ibrcommon/link/NetLinkManager.cpp
+++ b/ibrcommon/ibrcommon/link/NetLinkManager.cpp
@@ -47,7 +47,7 @@
 #else
 // netlink API header for < 3.2.21
 #include <netlink/object-api.h>
-#include <netlink/cache-api.h>
+#include <netlink/cache.h>
 #endif
 
 #include <netlink/route/link.h>
@@ -255,7 +255,7 @@ namespace ibrcommon
 	{
 	}
 
-	void NetLinkManager::netlinkcache::up() throw (socket_exception)
+	void NetLinkManager::netlinkcache::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -304,7 +304,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void NetLinkManager::netlinkcache::down() throw (socket_exception)
+	void NetLinkManager::netlinkcache::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -324,13 +324,13 @@ namespace ibrcommon
 			_state = SOCKET_DOWN;
 	}
 
-	int NetLinkManager::netlinkcache::fd() const throw (socket_exception)
+	int NetLinkManager::netlinkcache::fd() const noexcept (false)
 	{
 		if (_state == SOCKET_DOWN) throw socket_exception("fd not available");
 		return nl_cache_mngr_get_fd(_mngr);
 	}
 
-	void NetLinkManager::netlinkcache::receive() throw (socket_exception)
+	void NetLinkManager::netlinkcache::receive() noexcept (false)
 	{
 		if (_state == SOCKET_DOWN) throw socket_exception("socket not connected");
 		nl_cache_mngr_data_ready(_mngr);
@@ -347,7 +347,7 @@ namespace ibrcommon
 #endif
 	}
 
-	void NetLinkManager::netlinkcache::add(const std::string &cachename) throw (socket_exception)
+	void NetLinkManager::netlinkcache::add(const std::string &cachename) noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up; adding not possible");
@@ -359,7 +359,7 @@ namespace ibrcommon
 		_caches[cachename] = NULL;
 	}
 
-	struct nl_cache* NetLinkManager::netlinkcache::get(const std::string &cachename) const throw (socket_exception)
+	struct nl_cache* NetLinkManager::netlinkcache::get(const std::string &cachename) const noexcept (false)
 	{
 		if (_state == SOCKET_DOWN) throw socket_exception("socket not available");
 
@@ -393,7 +393,7 @@ namespace ibrcommon
 		}
 	}
 
-	void NetLinkManager::up() throw ()
+	void NetLinkManager::up() noexcept
 	{
 		// add netlink fd to vsocket
 		_sock.add(&_route_cache);
@@ -402,7 +402,7 @@ namespace ibrcommon
 		this->start();
 	}
 
-	void NetLinkManager::down() throw ()
+	void NetLinkManager::down() noexcept
 	{
 		_sock.down();
 		_sock.clear();
@@ -411,13 +411,13 @@ namespace ibrcommon
 		this->join();
 	}
 
-	void NetLinkManager::__cancellation() throw ()
+	void NetLinkManager::__cancellation() noexcept
 	{
 		_running = false;
 		_sock.down();
 	}
 
-	void NetLinkManager::run() throw ()
+	void NetLinkManager::run() noexcept
 	{
 		try {
 			while (_running)

--- a/ibrcommon/ibrcommon/link/NetLinkManager.h
+++ b/ibrcommon/ibrcommon/link/NetLinkManager.h
@@ -42,8 +42,8 @@ namespace ibrcommon
 	public:
 		virtual ~NetLinkManager();
 
-		void up() throw ();
-		void down() throw ();
+		void up() noexcept;
+		void down() noexcept;
 
 		const vinterface getInterface(int index) const;
 		const std::list<vaddress> getAddressList(const vinterface &iface, const std::string &scope = "");
@@ -56,8 +56,8 @@ namespace ibrcommon
 		};
 
 	protected:
-		void run() throw ();
-		void __cancellation() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
 
 	private:
 		NetLinkManager();
@@ -68,15 +68,15 @@ namespace ibrcommon
 			netlinkcache(int protocol);
 			virtual ~netlinkcache();
 
-			virtual void up() throw (socket_exception);
-			virtual void down() throw (socket_exception);
+			virtual void up() noexcept (false);
+			virtual void down() noexcept (false);
 
-			virtual int fd() const throw (socket_exception);
+			virtual int fd() const noexcept (false);
 
-			void add(const std::string &cachename) throw (socket_exception);
-			struct nl_cache* get(const std::string &cachename) const throw (socket_exception);
+			void add(const std::string &cachename) noexcept (false);
+			struct nl_cache* get(const std::string &cachename) const noexcept (false);
 
-			void receive() throw (socket_exception);
+			void receive() noexcept (false);
 
 		private:
 			const int _protocol;

--- a/ibrcommon/ibrcommon/link/PosixLinkManager.cpp
+++ b/ibrcommon/ibrcommon/link/PosixLinkManager.cpp
@@ -35,12 +35,12 @@ namespace ibrcommon
 		down();
 	}
 
-	void PosixLinkManager::up() throw()
+	void PosixLinkManager::up() noexcept
 	{
 		_lm.start();
 	}
 
-	void PosixLinkManager::down() throw()
+	void PosixLinkManager::down() noexcept
 	{
 		_lm.stop();
 		_lm.join();
@@ -179,7 +179,7 @@ namespace ibrcommon
 		return ret;
 	}
 
-	void PosixLinkManager::addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ()
+	void PosixLinkManager::addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept
 	{
 		// initialize LinkManager with new listened interface
 		_lm.add(iface);
@@ -188,7 +188,7 @@ namespace ibrcommon
 		LinkManager::addEventListener(iface, cb);
 	}
 
-	void PosixLinkManager::removeEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ()
+	void PosixLinkManager::removeEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept
 	{
 		// call super-method
 		LinkManager::removeEventListener(iface, cb);
@@ -197,7 +197,7 @@ namespace ibrcommon
 		_lm.remove();
 	}
 
-	void PosixLinkManager::removeEventListener(LinkManager::EventCallback *cb) throw ()
+	void PosixLinkManager::removeEventListener(LinkManager::EventCallback *cb) noexcept
 	{
 		// call super-method
 		LinkManager::removeEventListener(cb);

--- a/ibrcommon/ibrcommon/link/PosixLinkManager.h
+++ b/ibrcommon/ibrcommon/link/PosixLinkManager.h
@@ -22,15 +22,15 @@ namespace ibrcommon
 		PosixLinkManager();
 		virtual ~PosixLinkManager();
 
-		void up() throw();
-		void down() throw();
+		void up() noexcept;
+		void down() noexcept;
 
 		const vinterface getInterface(int index) const;
 		const std::list<vaddress> getAddressList(const vinterface &iface, const std::string &scope = "");
 
-		virtual void addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ();
-		virtual void removeEventListener(const vinterface&, LinkManager::EventCallback*) throw ();
-		virtual void removeEventListener(LinkManager::EventCallback*) throw ();
+		virtual void addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept;
+		virtual void removeEventListener(const vinterface&, LinkManager::EventCallback*) noexcept;
+		virtual void removeEventListener(LinkManager::EventCallback*) noexcept;
 
 	private:
 		LinkMonitor _lm;

--- a/ibrcommon/ibrcommon/link/Win32LinkManager.cpp
+++ b/ibrcommon/ibrcommon/link/Win32LinkManager.cpp
@@ -28,12 +28,12 @@ namespace ibrcommon
 	{
 		down();
 	}
-	void Win32LinkManager::up() throw()
+	void Win32LinkManager::up() noexcept
 	{
 		_lm.start();
 	}
 
-	void Win32LinkManager::down() throw()
+	void Win32LinkManager::down() noexcept
 	{
 		_lm.stop();
 		_lm.join();
@@ -185,7 +185,7 @@ namespace ibrcommon
 		return ret;
 	}
 
-	void Win32LinkManager::addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ()
+	void Win32LinkManager::addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept
 	{
 		// initialize LinkManager with new listened interface
 		_lm.add(iface);
@@ -194,7 +194,7 @@ namespace ibrcommon
 		LinkManager::addEventListener(iface, cb);
 	}
 
-	void Win32LinkManager::removeEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ()
+	void Win32LinkManager::removeEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept
 	{
 		// call super-method
 		LinkManager::removeEventListener(iface, cb);
@@ -203,7 +203,7 @@ namespace ibrcommon
 		_lm.remove();
 	}
 
-	void Win32LinkManager::removeEventListener(LinkManager::EventCallback *cb) throw ()
+	void Win32LinkManager::removeEventListener(LinkManager::EventCallback *cb) noexcept
 	{
 		// call super-method
 		LinkManager::removeEventListener(cb);

--- a/ibrcommon/ibrcommon/link/Win32LinkManager.h
+++ b/ibrcommon/ibrcommon/link/Win32LinkManager.h
@@ -27,17 +27,17 @@ namespace ibrcommon
 		Win32LinkManager();
 		virtual ~Win32LinkManager();
 
-		void up() throw();
-		void down() throw();
+		void up() noexcept;
+		void down() noexcept;
 
 		const vinterface getInterface(int index) const;
 		const std::list<vaddress> getAddressList(const vinterface &iface, const std::string &scope = "");
 
 		std::set<ibrcommon::vinterface> getInterfaces() const;
 
-		virtual void addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) throw ();
-		virtual void removeEventListener(const vinterface&, LinkManager::EventCallback*) throw ();
-		virtual void removeEventListener(LinkManager::EventCallback*) throw ();
+		virtual void addEventListener(const vinterface &iface, LinkManager::EventCallback *cb) noexcept;
+		virtual void removeEventListener(const vinterface&, LinkManager::EventCallback*) noexcept;
+		virtual void removeEventListener(LinkManager::EventCallback*) noexcept;
 
 	private:
 		void freeAdapterInfo(IP_ADAPTER_ADDRESSES *pAddresses) const;

--- a/ibrcommon/ibrcommon/net/lowpansocket.cpp
+++ b/ibrcommon/ibrcommon/net/lowpansocket.cpp
@@ -57,7 +57,7 @@ namespace ibrcommon
 
 	}
 
-	void lowpansocket::up() throw (socket_exception)
+	void lowpansocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -83,7 +83,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void lowpansocket::down() throw (socket_exception)
+	void lowpansocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -91,7 +91,7 @@ namespace ibrcommon
 		this->close();
 	}
 
-	void lowpansocket::setAutoAck(bool enable) throw (socket_exception)
+	void lowpansocket::setAutoAck(bool enable) noexcept (false)
 	{
 		int optval = (enable ? 1 : 0);
 		if (::setsockopt(_fd, SOL_IEEE802154, WPAN_WANTACK, &optval, sizeof(optval)) < 0) {
@@ -99,7 +99,7 @@ namespace ibrcommon
 		}
 	}
 
-	ssize_t lowpansocket::recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) throw (socket_exception)
+	ssize_t lowpansocket::recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) noexcept (false)
 	{
 		struct sockaddr_storage clientAddress;
 		socklen_t clientAddressLength = sizeof(clientAddress);
@@ -122,7 +122,7 @@ namespace ibrcommon
 		return ret;
 	}
 
-	void lowpansocket::sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) throw (socket_exception)
+	void lowpansocket::sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) noexcept (false)
 	{
 		ssize_t ret = 0;
 		struct sockaddr_ieee802154 sockaddr;

--- a/ibrcommon/ibrcommon/net/lowpansocket.h
+++ b/ibrcommon/ibrcommon/net/lowpansocket.h
@@ -37,16 +37,16 @@ namespace ibrcommon
 	public:
 		lowpansocket(const uint16_t &panid, const vinterface &iface);
 		~lowpansocket();
-		void up() throw (socket_exception);
-		void down() throw (socket_exception);
+		void up() noexcept (false);
+		void down() noexcept (false);
 
 		/**
 		 * If set to true, the auto-ack request is set on each message
 		 */
-		void setAutoAck(bool enable) throw (socket_exception);
+		void setAutoAck(bool enable) noexcept (false);
 
-		virtual ssize_t recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) throw (socket_exception);
-		virtual void sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) throw (socket_exception);
+		virtual ssize_t recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) noexcept (false);
+		virtual void sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) noexcept (false);
 
 		static void getAddress(const vinterface &iface, const std::string &panid, ibrcommon::vaddress &addr);
 		static void getAddress(struct ieee802154_addr *ret, const vinterface &iface);

--- a/ibrcommon/ibrcommon/net/socket.cpp
+++ b/ibrcommon/ibrcommon/net/socket.cpp
@@ -116,13 +116,13 @@ namespace ibrcommon
 #endif
 	}
 
-	int basesocket::fd() const throw (socket_exception)
+	int basesocket::fd() const noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED) || (_fd == -1)) throw socket_exception("fd not available");
 		return _fd;
 	}
 
-	int basesocket::release() throw (socket_exception)
+	int basesocket::release() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED)) throw socket_exception("fd not available");
 		int fd = _fd;
@@ -136,7 +136,7 @@ namespace ibrcommon
 		return fd;
 	}
 
-	void basesocket::close() throw (socket_exception)
+	void basesocket::close() noexcept (false)
 	{
 		int ret = __close(this->fd());
 		if (ret == -1)
@@ -150,7 +150,7 @@ namespace ibrcommon
 			_state = SOCKET_DOWN;
 	}
 
-	void basesocket::shutdown(int how) throw (socket_exception)
+	void basesocket::shutdown(int how) noexcept (false)
 	{
 		int ret = ::shutdown(this->fd(), how);
 		if (ret == -1)
@@ -167,7 +167,7 @@ namespace ibrcommon
 		return ((_state == SOCKET_UP) || (_state == SOCKET_UNMANAGED));
 	}
 
-	void basesocket::set_blocking_mode(bool val, int fd) const throw (socket_exception)
+	void basesocket::set_blocking_mode(bool val, int fd) const noexcept (false)
 	{
 #ifdef __WIN32__
 		// set blocking mode - the win32 way
@@ -191,7 +191,7 @@ namespace ibrcommon
 #endif
 	}
 
-	void basesocket::set_keepalive(bool val, int fd) const throw (socket_exception)
+	void basesocket::set_keepalive(bool val, int fd) const noexcept (false)
 	{
 		/* Set the option active */
 		int optval = (val ? 1 : 0);
@@ -200,7 +200,7 @@ namespace ibrcommon
 		}
 	}
 
-	void basesocket::set_linger(bool val, int l, int fd) const throw (socket_exception)
+	void basesocket::set_linger(bool val, int l, int fd) const noexcept (false)
 	{
 		// set linger option to the socket
 		struct linger linger;
@@ -212,7 +212,7 @@ namespace ibrcommon
 		}
 	}
 
-	void basesocket::set_reuseaddr(bool val, int fd) const throw (socket_exception)
+	void basesocket::set_reuseaddr(bool val, int fd) const noexcept (false)
 	{
 		int on = (val ? 1: 0);
 		if (__compat_setsockopt((fd == -1) ? _fd : fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0)
@@ -221,7 +221,7 @@ namespace ibrcommon
 		}
 	}
 
-	void basesocket::set_nodelay(bool val, int fd) const throw (socket_exception)
+	void basesocket::set_nodelay(bool val, int fd) const noexcept (false)
 	{
 		int set = (val ? 1 : 0);
 		if (__compat_setsockopt((fd == -1) ? _fd : fd, IPPROTO_TCP, TCP_NODELAY, &set, sizeof(set)) < 0) {
@@ -229,12 +229,12 @@ namespace ibrcommon
 		}
 	}
 
-	sa_family_t basesocket::get_family() const throw (socket_exception)
+	sa_family_t basesocket::get_family() const noexcept (false)
 	{
 		return _family;
 	}
 
-	sa_family_t basesocket::get_family(int fd) throw (socket_exception)
+	sa_family_t basesocket::get_family(int fd) noexcept (false)
 	{
 		struct sockaddr_storage bound_addr;
 		socklen_t bound_len = sizeof(bound_addr);
@@ -249,7 +249,7 @@ namespace ibrcommon
 		return bound_addr.ss_family;
 	}
 
-	bool basesocket::hasSupport(const sa_family_t family, const int type, const int protocol) throw ()
+	bool basesocket::hasSupport(const sa_family_t family, const int type, const int protocol) noexcept
 	{
 		int fd = 0;
 		if ((fd = ::socket(family, type, protocol)) < 0) {
@@ -259,7 +259,7 @@ namespace ibrcommon
 		return true;
 	}
 
-	void basesocket::init_socket(const vaddress &addr, int type, int protocol) throw (socket_exception)
+	void basesocket::init_socket(const vaddress &addr, int type, int protocol) noexcept (false)
 	{
 		try {
 			_family = addr.family();
@@ -285,7 +285,7 @@ namespace ibrcommon
 		}
 	}
 
-	void basesocket::init_socket(int domain, int type, int protocol) throw (socket_exception)
+	void basesocket::init_socket(int domain, int type, int protocol) noexcept (false)
 	{
 		_family = static_cast<sa_family_t>(domain);
 		if ((_fd = ::socket(domain, type, protocol)) < 0) {
@@ -293,7 +293,7 @@ namespace ibrcommon
 		}
 	}
 
-	void basesocket::bind(int fd, struct sockaddr *addr, socklen_t len) throw (socket_exception)
+	void basesocket::bind(int fd, struct sockaddr *addr, socklen_t len) noexcept (false)
 	{
 		int ret = ::bind(fd, addr, len);
 
@@ -328,7 +328,7 @@ namespace ibrcommon
 		} catch (const socket_exception&) { }
 	}
 
-	void clientsocket::up() throw (socket_exception)
+	void clientsocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -336,7 +336,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void clientsocket::down() throw (socket_exception)
+	void clientsocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -344,7 +344,7 @@ namespace ibrcommon
 		this->close();
 	}
 
-	ssize_t clientsocket::send(const char *data, size_t len, int flags) throw (socket_exception)
+	ssize_t clientsocket::send(const char *data, size_t len, int flags) noexcept (false)
 	{
 		ssize_t ret = ::send(this->fd(), data, len, flags);
 		if (ret == -1) {
@@ -369,7 +369,7 @@ namespace ibrcommon
 		return ret;
 	}
 
-	ssize_t clientsocket::recv(char *data, size_t len, int flags) throw (socket_exception)
+	ssize_t clientsocket::recv(char *data, size_t len, int flags) noexcept (false)
 	{
 		ssize_t ret = ::recv(this->fd(), data, len, flags);
 		if (ret == -1) {
@@ -387,7 +387,7 @@ namespace ibrcommon
 		return ret;
 	}
 
-	void clientsocket::set(CLIENT_OPTION opt, bool val) throw (socket_exception)
+	void clientsocket::set(CLIENT_OPTION opt, bool val) noexcept (false)
 	{
 		switch (opt) {
 		case NO_DELAY:
@@ -414,14 +414,14 @@ namespace ibrcommon
 	{
 	}
 
-	void serversocket::listen(int connections) throw (socket_exception)
+	void serversocket::listen(int connections) noexcept (false)
 	{
 		int ret = ::listen(_fd, connections);
 		if (ret == -1)
 			throw socket_exception("listen failed");
 	}
 
-	int serversocket::_accept_fd(ibrcommon::vaddress &addr) throw (socket_exception)
+	int serversocket::_accept_fd(ibrcommon::vaddress &addr) noexcept (false)
 	{
 		struct sockaddr_storage cliaddr;
 		socklen_t len = sizeof(cliaddr);
@@ -465,7 +465,7 @@ namespace ibrcommon
 	{
 	}
 
-	ssize_t datagramsocket::recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) throw (socket_exception)
+	ssize_t datagramsocket::recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) noexcept (false)
 	{
 		struct sockaddr_storage clientAddress;
 		socklen_t clientAddressLength = sizeof(clientAddress);
@@ -487,7 +487,7 @@ namespace ibrcommon
 		return ret;
 	}
 
-	void datagramsocket::sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) throw (socket_exception)
+	void datagramsocket::sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) noexcept (false)
 	{
 		int ret = 0;
 		struct addrinfo hints, *res;
@@ -543,7 +543,7 @@ namespace ibrcommon
 		} catch (const socket_exception&) { }
 	}
 
-	void filesocket::up() throw (socket_exception)
+	void filesocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -588,7 +588,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void filesocket::down() throw (socket_exception)
+	void filesocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -608,7 +608,7 @@ namespace ibrcommon
 		} catch (const socket_exception&) { }
 	}
 
-	void fileserversocket::up() throw (socket_exception)
+	void fileserversocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -633,7 +633,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void fileserversocket::down() throw (socket_exception)
+	void fileserversocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -641,12 +641,12 @@ namespace ibrcommon
 		this->close();
 	}
 
-	clientsocket* fileserversocket::accept(ibrcommon::vaddress &addr) throw (socket_exception)
+	clientsocket* fileserversocket::accept(ibrcommon::vaddress &addr) noexcept (false)
 	{
 		return new filesocket(_accept_fd(addr));
 	}
 
-	void fileserversocket::bind(const File &file) throw (socket_exception)
+	void fileserversocket::bind(const File &file) noexcept (false)
 	{
 #ifndef __WIN32__
 		// remove old sockets
@@ -681,7 +681,7 @@ namespace ibrcommon
 		} catch (const socket_exception&) { }
 	}
 
-	void tcpserversocket::up() throw (socket_exception)
+	void tcpserversocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -705,7 +705,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void tcpserversocket::down() throw (socket_exception)
+	void tcpserversocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -713,7 +713,7 @@ namespace ibrcommon
 		this->close();
 	}
 
-	void tcpserversocket::bind(const vaddress &addr) throw (socket_exception)
+	void tcpserversocket::bind(const vaddress &addr) noexcept (false)
 	{
 		struct addrinfo hints, *res;
 		memset(&hints, 0, sizeof hints);
@@ -753,7 +753,7 @@ namespace ibrcommon
 		}
 	}
 
-	clientsocket* tcpserversocket::accept(ibrcommon::vaddress &addr) throw (socket_exception)
+	clientsocket* tcpserversocket::accept(ibrcommon::vaddress &addr) noexcept (false)
 	{
 		return new tcpsocket(_accept_fd(addr));
 	}
@@ -786,7 +786,7 @@ namespace ibrcommon
 		} catch (const socket_exception&) { }
 	}
 
-	void tcpsocket::up() throw (socket_exception)
+	void tcpsocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -961,7 +961,7 @@ namespace ibrcommon
 		probesocket.destroy();
 	}
 
-	void tcpsocket::down() throw (socket_exception)
+	void tcpsocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -990,7 +990,7 @@ namespace ibrcommon
 		return _address;
 	}
 
-	void udpsocket::up() throw (socket_exception)
+	void udpsocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -1018,7 +1018,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void udpsocket::down() throw (socket_exception)
+	void udpsocket::down() noexcept (false)
 	{
 		if ((_state == SOCKET_DOWN) || (_state == SOCKET_DESTROYED))
 			throw socket_exception("socket is not up");
@@ -1026,7 +1026,7 @@ namespace ibrcommon
 		this->close();
 	}
 
-	void udpsocket::bind(const vaddress &addr) throw (socket_exception)
+	void udpsocket::bind(const vaddress &addr) noexcept (false)
 	{
 		struct addrinfo hints, *res;
 		memset(&hints, 0, sizeof hints);
@@ -1075,7 +1075,7 @@ namespace ibrcommon
 	{
 	}
 
-	void multicastsocket::up() throw (socket_exception)
+	void multicastsocket::up() noexcept (false)
 	{
 		udpsocket::up();
 
@@ -1132,7 +1132,7 @@ namespace ibrcommon
 		}
 	}
 
-	void multicastsocket::down() throw (socket_exception)
+	void multicastsocket::down() noexcept (false)
 	{
 		switch (get_family()) {
 		case AF_INET: {
@@ -1161,7 +1161,7 @@ namespace ibrcommon
 		udpsocket::down();
 	}
 
-	void multicastsocket::join(const vaddress &group, const vinterface &iface) throw (socket_exception)
+	void multicastsocket::join(const vaddress &group, const vinterface &iface) noexcept (false)
 	{
 #ifndef MCAST_JOIN_GROUP
 		if (group.family() == AF_INET6) {
@@ -1174,7 +1174,7 @@ namespace ibrcommon
 #endif
 	}
 
-	void multicastsocket::leave(const vaddress &group, const vinterface &iface) throw (socket_exception)
+	void multicastsocket::leave(const vaddress &group, const vinterface &iface) noexcept (false)
 	{
 #ifndef MCAST_LEAVE_GROUP
 		if (group.family() == AF_INET6) {
@@ -1217,7 +1217,7 @@ namespace ibrcommon
 	}
 #endif
 
-	void multicastsocket::mcast_op(int optname, const vaddress &group, const vinterface &iface) throw (socket_exception)
+	void multicastsocket::mcast_op(int optname, const vaddress &group, const vinterface &iface) noexcept (false)
 	{
 		struct sockaddr_storage mcast_addr;
 		::memset(&mcast_addr, 0, sizeof(mcast_addr));
@@ -1311,7 +1311,7 @@ namespace ibrcommon
 		IBRCOMMON_LOGGER_DEBUG_TAG("multicastsocket", 70) << "multicast operation (" << optname << ") successful with " << group.toString() << " on " << iface.toString() << IBRCOMMON_LOGGER_ENDL;
 	}
 
-	void basesocket::check_socket_error(const int err) const throw (socket_exception)
+	void basesocket::check_socket_error(const int err) const noexcept (false)
 	{
 		switch (err)
 		{
@@ -1342,7 +1342,7 @@ namespace ibrcommon
 		}
 	}
 
-	void basesocket::check_bind_error(const int err, const std::string &msg) const throw (socket_exception)
+	void basesocket::check_bind_error(const int err, const std::string &msg) const noexcept (false)
 	{
 		switch ( err )
 		{

--- a/ibrcommon/ibrcommon/net/socket.h
+++ b/ibrcommon/ibrcommon/net/socket.h
@@ -88,10 +88,10 @@ namespace ibrcommon {
 			__what = ss.str();
 		};
 
-		virtual ~socket_raw_error() throw()
+		virtual ~socket_raw_error() noexcept
 		{};
 
-		virtual const char* what() const throw()
+		virtual const char* what() const noexcept
 		{
 			return __what.c_str();
 		}
@@ -121,20 +121,20 @@ namespace ibrcommon {
 		 * and bind to the interface if necessary.
 		 * @throw socket_exception if the action has failed
 		 */
-		virtual void up() throw (socket_exception) = 0;
+		virtual void up() noexcept (false) = 0;
 
 		/**
 		 * Close and destroy the file descriptor of this
 		 * socket assignment.
 		 * @throw socket_exception if the action has failed
 		 */
-		virtual void down() throw (socket_exception) = 0;
+		virtual void down() noexcept (false) = 0;
 
 		/**
 		 * Return the file descriptor for this socket.
 		 * @throw socket_exception if no file descriptor is available
 		 */
-		virtual int fd() const throw (socket_exception);
+		virtual int fd() const noexcept (false);
 
 		/**
 		 * Return the file descriptor and bring the socket into the down state
@@ -142,13 +142,13 @@ namespace ibrcommon {
 		 * destroyed.
 		 * @return The file descriptor of this socket.
 		 */
-		virtual int release() throw (socket_exception);
+		virtual int release() noexcept (false);
 
 		/**
 		 * Standard socket calls
 		 */
-		void close() throw (socket_exception);
-		void shutdown(int how) throw (socket_exception);
+		void close() noexcept (false);
+		void shutdown(int how) noexcept (false);
 
 		/**
 		 * @return True, if this socket is up and ready.
@@ -159,13 +159,13 @@ namespace ibrcommon {
 		 * return the family of a socket
 		 * @return
 		 */
-		sa_family_t get_family() const throw (socket_exception);
-		static sa_family_t get_family(int fd) throw (socket_exception);
+		sa_family_t get_family() const noexcept (false);
+		static sa_family_t get_family(int fd) noexcept (false);
 
 		/**
 		 * Checks if the given network protocol is supported
 		 */
-		static bool hasSupport(const sa_family_t family, const int type = SOCK_DGRAM, const int protocol = 0) throw ();
+		static bool hasSupport(const sa_family_t family, const int type = SOCK_DGRAM, const int protocol = 0) noexcept;
 
 	protected:
 		/**
@@ -190,19 +190,19 @@ namespace ibrcommon {
 		/**
 		 * Error check methods
 		 */
-		void check_socket_error(const int err) const throw (socket_exception);
-		void check_bind_error(const int err, const std::string &msg = "") const throw (socket_exception);
+		void check_socket_error(const int err) const noexcept (false);
+		void check_bind_error(const int err, const std::string &msg = "") const noexcept (false);
 
-		void set_blocking_mode(bool val, int fd = -1) const throw (socket_exception);
-		void set_keepalive(bool val, int fd = -1) const throw (socket_exception);
-		void set_linger(bool val, int l = 1, int fd = -1) const throw (socket_exception);
-		void set_reuseaddr(bool val, int fd = -1) const throw (socket_exception);
-		void set_nodelay(bool val, int fd = -1) const throw (socket_exception);
+		void set_blocking_mode(bool val, int fd = -1) const noexcept (false);
+		void set_keepalive(bool val, int fd = -1) const noexcept (false);
+		void set_linger(bool val, int l = 1, int fd = -1) const noexcept (false);
+		void set_reuseaddr(bool val, int fd = -1) const noexcept (false);
+		void set_nodelay(bool val, int fd = -1) const noexcept (false);
 
-		void init_socket(const vaddress &addr, int type, int protocol) throw (socket_exception);
-		void init_socket(int domain, int type, int protocol) throw (socket_exception);
+		void init_socket(const vaddress &addr, int type, int protocol) noexcept (false);
+		void init_socket(int domain, int type, int protocol) noexcept (false);
 
-		void bind(int fd, struct sockaddr *addr, socklen_t len) throw (socket_exception);
+		void bind(int fd, struct sockaddr *addr, socklen_t len) noexcept (false);
 
 		// contains the current socket state
 		socketstate _state;
@@ -226,13 +226,13 @@ namespace ibrcommon {
 		};
 
 		virtual ~clientsocket() = 0;
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
-		ssize_t send(const char *data, size_t len, int flags = 0) throw (socket_exception);
-		ssize_t recv(char *data, size_t len, int flags = 0) throw (socket_exception);
+		ssize_t send(const char *data, size_t len, int flags = 0) noexcept (false);
+		ssize_t recv(char *data, size_t len, int flags = 0) noexcept (false);
 
-		void set(CLIENT_OPTION opt, bool val) throw (socket_exception);
+		void set(CLIENT_OPTION opt, bool val) noexcept (false);
 
 	protected:
 		clientsocket();
@@ -246,11 +246,11 @@ namespace ibrcommon {
 		};
 
 		virtual ~serversocket() = 0;
-		virtual void up() throw (socket_exception) = 0;
-		virtual void down() throw (socket_exception) = 0;
+		virtual void up() noexcept (false) = 0;
+		virtual void down() noexcept (false) = 0;
 
-		void listen(int connections) throw (socket_exception);
-		virtual clientsocket* accept(ibrcommon::vaddress &addr) throw (socket_exception) = 0;
+		void listen(int connections) noexcept (false);
+		virtual clientsocket* accept(ibrcommon::vaddress &addr) noexcept (false) = 0;
 
 		void set(SERVER_OPTION opt, bool val);
 
@@ -258,17 +258,17 @@ namespace ibrcommon {
 		serversocket();
 		serversocket(int fd);
 
-		int _accept_fd(ibrcommon::vaddress &addr) throw (socket_exception);
+		int _accept_fd(ibrcommon::vaddress &addr) noexcept (false);
 	};
 
 	class datagramsocket : public basesocket {
 	public:
 		virtual ~datagramsocket() = 0;
-		virtual void up() throw (socket_exception) = 0;
-		virtual void down() throw (socket_exception) = 0;
+		virtual void up() noexcept (false) = 0;
+		virtual void down() noexcept (false) = 0;
 
-		virtual ssize_t recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) throw (socket_exception);
-		virtual void sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) throw (socket_exception);
+		virtual ssize_t recvfrom(char *buf, size_t buflen, int flags, ibrcommon::vaddress &addr) noexcept (false);
+		virtual void sendto(const char *buf, size_t buflen, int flags, const ibrcommon::vaddress &addr) noexcept (false);
 
 	protected:
 		datagramsocket();
@@ -283,8 +283,8 @@ namespace ibrcommon {
 		filesocket(int fd);
 		filesocket(const File &file);
 		virtual ~filesocket();
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
 	private:
 		const File _filename;
@@ -298,13 +298,13 @@ namespace ibrcommon {
 	public:
 		fileserversocket(const File &file, int listen = 0);
 		virtual ~fileserversocket();
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
-		virtual clientsocket* accept(ibrcommon::vaddress &addr) throw (socket_exception);
+		virtual clientsocket* accept(ibrcommon::vaddress &addr) noexcept (false);
 
 	private:
-		void bind(const File &file) throw (socket_exception);
+		void bind(const File &file) noexcept (false);
 
 	private:
 		const File _filename;
@@ -319,8 +319,8 @@ namespace ibrcommon {
 		tcpsocket(int fd);
 		tcpsocket(const vaddress &destination, const timeval *timeout = NULL);
 		virtual ~tcpsocket();
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
 	private:
 		const vaddress _address;
@@ -337,15 +337,15 @@ namespace ibrcommon {
 		tcpserversocket(const int port, int listen = 0);
 		tcpserversocket(const vaddress &address, int listen = 0);
 		virtual ~tcpserversocket();
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
 		const vaddress& get_address() const;
 
-		virtual clientsocket* accept(ibrcommon::vaddress &addr) throw (socket_exception);
+		virtual clientsocket* accept(ibrcommon::vaddress &addr) noexcept (false);
 
 	protected:
-		void bind(const vaddress &addr) throw (socket_exception);
+		void bind(const vaddress &addr) noexcept (false);
 
 	private:
 		const vaddress _address;
@@ -361,13 +361,13 @@ namespace ibrcommon {
 		udpsocket();
 		udpsocket(const vaddress &address);
 		virtual ~udpsocket();
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
 		const vaddress& get_address() const;
 
 	protected:
-		void bind(const vaddress &addr) throw (socket_exception);
+		void bind(const vaddress &addr) noexcept (false);
 
 		const vaddress _address;
 	};
@@ -376,14 +376,14 @@ namespace ibrcommon {
 	public:
 		multicastsocket(const vaddress &address);
 		virtual ~multicastsocket();
-		virtual void up() throw (socket_exception);
-		virtual void down() throw (socket_exception);
+		virtual void up() noexcept (false);
+		virtual void down() noexcept (false);
 
-		void join(const vaddress &group, const vinterface &iface) throw (socket_exception);
-		void leave(const vaddress &group, const vinterface &iface) throw (socket_exception);
+		void join(const vaddress &group, const vinterface &iface) noexcept (false);
+		void leave(const vaddress &group, const vinterface &iface) noexcept (false);
 
 	private:
-		void mcast_op(int optname, const vaddress &group, const vinterface &iface) throw (socket_exception);
+		void mcast_op(int optname, const vaddress &group, const vinterface &iface) noexcept (false);
 	};
 }
 

--- a/ibrcommon/ibrcommon/net/vaddress.cpp
+++ b/ibrcommon/ibrcommon/net/vaddress.cpp
@@ -166,7 +166,7 @@ namespace ibrcommon
 		return (_address == VADDR_ANY);
 	}
 
-	sa_family_t vaddress::family() const throw (address_exception)
+	sa_family_t vaddress::family() const noexcept (false)
 	{
 		if (_family != AF_UNSPEC)
 			return _family;
@@ -201,20 +201,20 @@ namespace ibrcommon
 		return fam;
 	}
 
-	std::string vaddress::scope() const throw (scope_not_set)
+	std::string vaddress::scope() const noexcept (false)
 	{
 		if (_scope.length() == 0) throw scope_not_set();
 		return _scope;
 	}
 
-	const std::string vaddress::address() const throw (address_not_set)
+	const std::string vaddress::address() const noexcept (false)
 	{
 		if (_address.length() == 0) throw address_not_set();
 		if (isAny()) throw address_not_set();
 		return _address;
 	}
 
-	const std::string vaddress::name() const throw (address_exception)
+	const std::string vaddress::name() const noexcept (false)
 	{
 		struct addrinfo hints;
 		char addr_str[256];
@@ -241,7 +241,7 @@ namespace ibrcommon
 		return std::string(addr_str);
 	}
 
-	const std::string vaddress::service() const throw (service_not_set)
+	const std::string vaddress::service() const noexcept (false)
 	{
 		if (_service.length() == 0) throw service_not_set();
 		return _service;

--- a/ibrcommon/ibrcommon/net/vaddress.h
+++ b/ibrcommon/ibrcommon/net/vaddress.h
@@ -82,11 +82,11 @@ namespace ibrcommon
 			bool isLocal() const;
 			bool isAny() const;
 
-			sa_family_t family() const throw (address_exception);
-			std::string scope() const throw (scope_not_set);
-			const std::string address() const throw (address_not_set);
-			const std::string name() const throw (address_exception);
-			const std::string service() const throw (service_not_set);
+			sa_family_t family() const noexcept (false);
+			std::string scope() const noexcept (false);
+			const std::string address() const noexcept (false);
+			const std::string name() const noexcept (false);
+			const std::string service() const noexcept (false);
 
 			void setService(const uint32_t port);
 			void setService(const std::string &service);

--- a/ibrcommon/ibrcommon/net/vsocket.cpp
+++ b/ibrcommon/ibrcommon/net/vsocket.cpp
@@ -189,13 +189,13 @@ namespace ibrcommon
 	{
 	}
 
-	int vsocket::pipesocket::getOutput() const throw (socket_exception)
+	int vsocket::pipesocket::getOutput() const noexcept (false)
 	{
 		if (_state == SOCKET_DOWN) throw socket_exception("output fd not available");
 		return _output_fd;
 	}
 
-	void vsocket::pipesocket::up() throw (socket_exception)
+	void vsocket::pipesocket::up() noexcept (false)
 	{
 		if (_state != SOCKET_DOWN)
 			throw socket_exception("socket is already up");
@@ -218,7 +218,7 @@ namespace ibrcommon
 		_state = SOCKET_UP;
 	}
 
-	void vsocket::pipesocket::down() throw (socket_exception)
+	void vsocket::pipesocket::down() noexcept (false)
 	{
 		if (_state != SOCKET_UP)
 			throw socket_exception("socket is not up");
@@ -229,7 +229,7 @@ namespace ibrcommon
 		_state = SOCKET_DOWN;
 	}
 
-	void vsocket::pipesocket::read(char *buf, size_t len) throw (socket_exception)
+	void vsocket::pipesocket::read(char *buf, size_t len) noexcept (false)
 	{
 		ssize_t ret = piperead(this->fd(), buf, len);
 		if (ret == -1)
@@ -238,7 +238,7 @@ namespace ibrcommon
 			throw socket_exception("end of file");
 	}
 
-	void vsocket::pipesocket::write(const char *buf, size_t len) throw (socket_exception)
+	void vsocket::pipesocket::write(const char *buf, size_t len) noexcept (false)
 	{
 		ssize_t ret = pipewrite(_output_fd, buf, len);
 		if (ret == -1)
@@ -636,7 +636,7 @@ namespace ibrcommon
 		return (*iter).second;
 	}
 
-	void vsocket::up() throw (socket_exception)
+	void vsocket::up() noexcept (false)
 	{
 		{
 			ibrcommon::MutexLock l(_state);
@@ -664,7 +664,7 @@ namespace ibrcommon
 		_state.set(SocketState::IDLE);
 	}
 
-	void vsocket::down() throw ()
+	void vsocket::down() noexcept
 	{
 		try {
 			ibrcommon::MutexLock l(_state);
@@ -706,7 +706,7 @@ namespace ibrcommon
 		_pipe.write("i", 1);
 	}
 
-	void vsocket::select(socketset *readset, socketset *writeset, socketset *errorset, struct timeval *tv) throw (socket_exception)
+	void vsocket::select(socketset *readset, socketset *writeset, socketset *errorset, struct timeval *tv) noexcept (false)
 	{
 		fd_set fds_read;
 		fd_set fds_write;

--- a/ibrcommon/ibrcommon/net/vsocket.cpp
+++ b/ibrcommon/ibrcommon/net/vsocket.cpp
@@ -259,7 +259,7 @@ namespace ibrcommon
 		return _state;
 	}
 
-	void vsocket::SocketState::set(STATE s) throw (state_exception)
+	void vsocket::SocketState::set(STATE s) noexcept (false)
 	{
 		try {
 			// try to get into state "s" and wait until this is possible
@@ -328,7 +328,7 @@ namespace ibrcommon
 		}
 	}
 
-	void vsocket::SocketState::setwait(STATE s, STATE abortstate) throw (state_exception)
+	void vsocket::SocketState::setwait(STATE s, STATE abortstate) noexcept (false)
 	{
 		try {
 			// try to get into state "s" and wait until this is possible
@@ -421,7 +421,7 @@ namespace ibrcommon
 		}
 	}
 
-	void vsocket::SocketState::wait(STATE s, STATE abortstate) throw (state_exception)
+	void vsocket::SocketState::wait(STATE s, STATE abortstate) noexcept (false)
 	{
 		try {
 			while (_state != s) {

--- a/ibrcommon/ibrcommon/net/vsocket.h
+++ b/ibrcommon/ibrcommon/net/vsocket.h
@@ -121,19 +121,19 @@ namespace ibrcommon
 		/**
 		 * Enable all sockets and turn into the up state.
 		 */
-		void up() throw (socket_exception);
+		void up() noexcept (false);
 
 		/**
 		 * Disable all sockets and turn into the down state.
 		 */
-		void down() throw ();
+		void down() noexcept;
 
 		/**
 		 * Execute a select on all associated sockets.
 		 * @param callback
 		 * @param tv
 		 */
-		void select(socketset *readset, socketset *writeset, socketset *errorset, struct timeval *tv = NULL) throw (socket_exception);
+		void select(socketset *readset, socketset *writeset, socketset *errorset, struct timeval *tv = NULL) noexcept (false);
 
 	private:
 		class pipesocket : public basesocket
@@ -141,13 +141,13 @@ namespace ibrcommon
 		public:
 			pipesocket();
 			virtual ~pipesocket();
-			virtual void up() throw (socket_exception);
-			virtual void down() throw (socket_exception);
+			virtual void up() noexcept (false);
+			virtual void down() noexcept (false);
 
-			void read(char *buf, size_t len) throw (socket_exception);
-			void write(const char *buf, size_t len) throw (socket_exception);
+			void read(char *buf, size_t len) noexcept (false);
+			void write(const char *buf, size_t len) noexcept (false);
 
-			int getOutput() const throw (socket_exception);
+			int getOutput() const noexcept (false);
 
 		private:
 			int _output_fd;

--- a/ibrcommon/ibrcommon/net/vsocket.h
+++ b/ibrcommon/ibrcommon/net/vsocket.h
@@ -180,9 +180,9 @@ namespace ibrcommon
 
 			STATE get() const;
 
-			void set(STATE s) throw (state_exception);
-			void wait(STATE s, STATE abortstate = NONE) throw (state_exception);
-			void setwait(STATE s, STATE abortstate = NONE) throw (state_exception);
+			void set(STATE s) noexcept (false);
+			void wait(STATE s, STATE abortstate = NONE) noexcept (false);
+			void setwait(STATE s, STATE abortstate = NONE) noexcept (false);
 
 		private:
 			void __change(STATE s);

--- a/ibrcommon/ibrcommon/ssl/iostreamBIO.h
+++ b/ibrcommon/ibrcommon/ssl/iostreamBIO.h
@@ -40,7 +40,7 @@ public:
 	class BIOException : public ibrcommon::Exception
 	{
 	public:
-		BIOException(const std::string &what) throw() : Exception(what)
+		BIOException(const std::string &what) noexcept : Exception(what)
 		{
 		};
 	};

--- a/ibrcommon/ibrcommon/thread/Conditional.cpp
+++ b/ibrcommon/ibrcommon/thread/Conditional.cpp
@@ -55,7 +55,7 @@ namespace ibrcommon
 		return false;
 	}
 
-	void Conditional::signal (bool broadcast) throw ()
+	void Conditional::signal (bool broadcast) noexcept
 	{
 #ifdef __DEVELOPMENT_ASSERTIONS__
 		// assert a locked Conditional
@@ -68,7 +68,7 @@ namespace ibrcommon
 			pthread_cond_signal( &cond );
 	}
 
-	void Conditional::wait(size_t timeout) throw (ConditionalAbortException)
+	void Conditional::wait(size_t timeout) noexcept (false)
 	{
 #ifdef __DEVELOPMENT_ASSERTIONS__
 		// assert a locked Conditional
@@ -91,7 +91,7 @@ namespace ibrcommon
 		}
 	}
 
-	void Conditional::wait(struct timespec *ts) throw (ConditionalAbortException)
+	void Conditional::wait(struct timespec *ts) noexcept (false)
 	{
 #ifdef __DEVELOPMENT_ASSERTIONS__
 		// assert a locked Conditional
@@ -129,7 +129,7 @@ namespace ibrcommon
 #endif
 	}
 
-	void Conditional::gettimeout(size_t msec, struct timespec *ts) throw ()
+	void Conditional::gettimeout(size_t msec, struct timespec *ts) noexcept
 	{
 #if _POSIX_TIMERS > 0 && defined(HAVE_PTHREAD_CONDATTR_SETCLOCK)
 	#if defined(_POSIX_MONOTONIC_CLOCK)
@@ -151,7 +151,7 @@ namespace ibrcommon
 		}
 	}
 
-	void Conditional::abort() throw ()
+	void Conditional::abort() noexcept
 	{
 #ifdef __DEVELOPMENT_ASSERTIONS__
 		// assert a locked Conditional
@@ -162,7 +162,7 @@ namespace ibrcommon
 		_abort = true;
 	}
 
-	void Conditional::reset() throw ()
+	void Conditional::reset() noexcept
 	{
 		_abort = false;
 	}

--- a/ibrcommon/ibrcommon/thread/Conditional.h
+++ b/ibrcommon/ibrcommon/thread/Conditional.h
@@ -43,7 +43,7 @@ namespace ibrcommon
 					COND_ERROR = 2
 				};
 
-				ConditionalAbortException(abort_t abort, string what = "Conditional has been unblocked.") throw() : ibrcommon::Exception(what), reason(abort)
+				ConditionalAbortException(abort_t abort, string what = "Conditional has been unblocked.") noexcept : ibrcommon::Exception(what), reason(abort)
 				{
 				};
 
@@ -53,25 +53,25 @@ namespace ibrcommon
 			Conditional();
 			virtual ~Conditional();
 
-			void signal(bool broadcast = false) throw ();
+			void signal(bool broadcast = false) noexcept;
 
 			/*
 			 * Wait until signal() is called or the timeout exceeds.
 			 * @param timeout A timeout in milliseconds.
 			 * @throw ConditionalAbortException If a timeout occur or the Conditional is aborted by abort() the ConditionalAbortException is thrown.
 			 */
-			void wait(size_t timeout = 0) throw (ConditionalAbortException);
-			void wait(struct timespec *ts) throw (ConditionalAbortException);
+			void wait(size_t timeout = 0) noexcept (false);
+			void wait(struct timespec *ts) noexcept (false);
 
 			/**
 			 * Abort all waits on this conditional.
 			 */
-			void abort() throw ();
+			void abort() noexcept;
 
 			/**
 			 * Removes the abort call off this conditional.
 			 */
-			void reset() throw ();
+			void reset() noexcept;
 
 			/**
 			 * Convert a millisecond timeout into use for high resolution
@@ -79,7 +79,7 @@ namespace ibrcommon
 			 * @param timeout to convert.
 			 * @param hires timespec representation to fill.
 			 */
-			static void gettimeout(size_t timeout, struct timespec *hires) throw ();
+			static void gettimeout(size_t timeout, struct timespec *hires) noexcept;
 
 		private:
 			bool isLocked();

--- a/ibrcommon/ibrcommon/thread/Mutex.cpp
+++ b/ibrcommon/ibrcommon/thread/Mutex.cpp
@@ -42,7 +42,7 @@ namespace ibrcommon
 		pthread_mutexattr_destroy(&m_attr);
 	}
 
-	void Mutex::trylock() throw (MutexException)
+	void Mutex::trylock() noexcept (false)
 	{
 		int ret = pthread_mutex_trylock( &m_mutex );
 
@@ -57,7 +57,7 @@ namespace ibrcommon
 		}
 	}
 
-	void Mutex::enter() throw (MutexException)
+	void Mutex::enter() noexcept (false)
 	{
 		switch (pthread_mutex_lock( &m_mutex ))
 		{
@@ -95,7 +95,7 @@ namespace ibrcommon
 		}
 	}
 
-	void Mutex::leave() throw (MutexException)
+	void Mutex::leave() noexcept (false)
 	{
 		if (0 != pthread_mutex_unlock( &m_mutex ))
 		{

--- a/ibrcommon/ibrcommon/thread/Mutex.h
+++ b/ibrcommon/ibrcommon/thread/Mutex.h
@@ -40,9 +40,9 @@ namespace ibrcommon
 	public:
 		virtual ~MutexInterface() = 0;
 
-		virtual void trylock() throw (MutexException) = 0;
-		virtual void enter() throw (MutexException) = 0;
-		virtual void leave() throw (MutexException) = 0;
+		virtual void trylock() noexcept (false) = 0;
+		virtual void enter() noexcept (false) = 0;
+		virtual void leave() noexcept (false) = 0;
 	};
 
 	class MutexMock : public MutexInterface
@@ -51,9 +51,9 @@ namespace ibrcommon
 		MutexMock() {};
 		virtual ~MutexMock() {};
 
-		virtual void trylock() throw (MutexException) {};
-		virtual void enter() throw (MutexException) {};
-		virtual void leave() throw (MutexException) {};
+		virtual void trylock() noexcept (false) {};
+		virtual void enter() noexcept (false) {};
+		virtual void leave() noexcept (false) {};
 	};
 
 	class Mutex : public MutexInterface
@@ -69,9 +69,9 @@ namespace ibrcommon
 			Mutex(MUTEX_TYPE type = MUTEX_NORMAL);
 			virtual ~Mutex();
 
-			virtual void trylock() throw (MutexException);
-			virtual void enter() throw (MutexException);
-			virtual void leave() throw (MutexException);
+			virtual void trylock() noexcept (false);
+			virtual void enter() noexcept (false);
+			virtual void leave() noexcept (false);
 
 			static MutexInterface& dummy();
 

--- a/ibrcommon/ibrcommon/thread/Mutex.h
+++ b/ibrcommon/ibrcommon/thread/Mutex.h
@@ -30,7 +30,7 @@ namespace ibrcommon
 	class MutexException : public ibrcommon::Exception
 	{
 	public:
-		MutexException(string what = "An error occured during mutex operation.") throw() : ibrcommon::Exception(what)
+		MutexException(string what = "An error occured during mutex operation.") noexcept : ibrcommon::Exception(what)
 		{
 		};
 	};

--- a/ibrcommon/ibrcommon/thread/Queue.h
+++ b/ibrcommon/ibrcommon/thread/Queue.h
@@ -149,7 +149,7 @@ namespace ibrcommon
 		 *
 		 * @return The next element of the queue
 		 */
-		T take() throw (QueueUnblockedException)
+		T take() noexcept(false)
 		{
 			try {
 				ibrcommon::MutexLock l(_cond);
@@ -173,7 +173,7 @@ namespace ibrcommon
 		 * @param timeout A timeout in milliseconds
 		 * @return The next element of the queue
 		 */
-		T poll(size_t timeout = 0) throw (QueueUnblockedException)
+		T poll(size_t timeout = 0) noexcept(false)
 		{
 			try {
 				ibrcommon::MutexLock l(_cond);
@@ -197,13 +197,13 @@ namespace ibrcommon
 			}
 		}
 
-		void abort() throw ()
+		void abort() noexcept()
 		{
 			ibrcommon::MutexLock l(_cond);
 			_cond.abort();
 		}
 
-		void reset() throw ()
+		void reset() noexcept()
 		{
 			_cond.reset();
 		}
@@ -214,7 +214,7 @@ namespace ibrcommon
 			QUEUE_EMPTY = 1
 		};
 
-		void wait(WAIT_MODES mode, const size_t timeout = 0) throw (QueueUnblockedException)
+		void wait(WAIT_MODES mode, const size_t timeout = 0) noexcept(false)
 		{
 			ibrcommon::MutexLock l(_cond);
 			if (timeout == 0)
@@ -240,7 +240,7 @@ namespace ibrcommon
 				if (_changed) _queue._cond.signal(true);
 			};
 
-			void wait(WAIT_MODES mode, const size_t timeout = 0) throw (QueueUnblockedException)
+			void wait(WAIT_MODES mode, const size_t timeout = 0) noexcept(false)
 			{
 				if (timeout == 0)
 				{
@@ -307,7 +307,7 @@ namespace ibrcommon
 			}
 		}
 
-		void __wait(const WAIT_MODES mode) throw (QueueUnblockedException)
+		void __wait(const WAIT_MODES mode) noexcept(false)
 		{
 			try {
 				switch (mode)
@@ -345,7 +345,7 @@ namespace ibrcommon
 			}
 		}
 
-		void __wait(const WAIT_MODES mode, const size_t timeout) throw (QueueUnblockedException)
+		void __wait(const WAIT_MODES mode, const size_t timeout) noexcept(false)
 		{
 			try {
 				struct timespec ts;

--- a/ibrcommon/ibrcommon/thread/Queue.h
+++ b/ibrcommon/ibrcommon/thread/Queue.h
@@ -197,13 +197,13 @@ namespace ibrcommon
 			}
 		}
 
-		void abort() noexcept()
+		void abort() noexcept
 		{
 			ibrcommon::MutexLock l(_cond);
 			_cond.abort();
 		}
 
-		void reset() noexcept()
+		void reset() noexcept
 		{
 			_cond.reset();
 		}

--- a/ibrcommon/ibrcommon/thread/Queue.h
+++ b/ibrcommon/ibrcommon/thread/Queue.h
@@ -42,11 +42,11 @@ namespace ibrcommon
 			QUEUE_TIMEOUT = 2
 		};
 
-		QueueUnblockedException(const type_t r, string what = "Queue is unblocked.") throw() : ibrcommon::Exception(what), reason(r)
+		QueueUnblockedException(const type_t r, string what = "Queue is unblocked.") noexcept : ibrcommon::Exception(what), reason(r)
 		{
 		};
 
-		QueueUnblockedException(const ibrcommon::Conditional::ConditionalAbortException &ex, string what = "Queue is unblocked.") throw() : ibrcommon::Exception(what)
+		QueueUnblockedException(const ibrcommon::Conditional::ConditionalAbortException &ex, string what = "Queue is unblocked.") noexcept : ibrcommon::Exception(what)
 		{
 			switch (ex.reason)
 			{

--- a/ibrcommon/ibrcommon/thread/RWMutex.cpp
+++ b/ibrcommon/ibrcommon/thread/RWMutex.cpp
@@ -34,7 +34,7 @@ namespace ibrcommon
 		pthread_rwlock_destroy(&_rwlock);
 	}
 
-	void RWMutex::trylock() throw (MutexException)
+	void RWMutex::trylock() noexcept (false)
 	{
 		switch (pthread_rwlock_tryrdlock(&_rwlock))
 		{
@@ -52,17 +52,17 @@ namespace ibrcommon
 		}
 	}
 
-	void RWMutex::enter() throw (MutexException)
+	void RWMutex::enter() noexcept (false)
 	{
 		pthread_rwlock_rdlock(&_rwlock);
 	}
 
-	void RWMutex::leave() throw (MutexException)
+	void RWMutex::leave() noexcept (false)
 	{
 		pthread_rwlock_unlock(&_rwlock);
 	}
 
-	void RWMutex::trylock_wr() throw (MutexException)
+	void RWMutex::trylock_wr() noexcept (false)
 	{
 		switch (pthread_rwlock_trywrlock(&_rwlock))
 		{
@@ -80,7 +80,7 @@ namespace ibrcommon
 		}
 	}
 
-	void RWMutex::enter_wr() throw (MutexException)
+	void RWMutex::enter_wr() noexcept (false)
 	{
 		pthread_rwlock_wrlock(&_rwlock);
 	}

--- a/ibrcommon/ibrcommon/thread/RWMutex.h
+++ b/ibrcommon/ibrcommon/thread/RWMutex.h
@@ -33,12 +33,12 @@ namespace ibrcommon
 		RWMutex();
 		virtual ~RWMutex();
 
-		virtual void trylock() throw (MutexException);
-		virtual void enter() throw (MutexException);
-		virtual void leave() throw (MutexException);
+		virtual void trylock() noexcept (false);
+		virtual void enter() noexcept (false);
+		virtual void leave() noexcept (false);
 
-		virtual void trylock_wr() throw (MutexException);
-		virtual void enter_wr() throw (MutexException);
+		virtual void trylock_wr() noexcept (false);
+		virtual void enter_wr() noexcept (false);
 
 	protected:
 		pthread_rwlock_t _rwlock;

--- a/ibrcommon/ibrcommon/thread/Semaphore.cpp
+++ b/ibrcommon/ibrcommon/thread/Semaphore.cpp
@@ -47,17 +47,17 @@ namespace ibrcommon
 		sem_post(&count_sem);
 	}
 
-	void Semaphore::trylock() throw (MutexException)
+	void Semaphore::trylock() noexcept (false)
 	{
 		throw MutexException("trylock is not available for semaphores");
 	}
 
-	void Semaphore::enter() throw (MutexException)
+	void Semaphore::enter() noexcept (false)
 	{
 		wait();
 	}
 
-	void Semaphore::leave() throw (MutexException)
+	void Semaphore::leave() noexcept (false)
 	{
 		post();
 	}

--- a/ibrcommon/ibrcommon/thread/Semaphore.h
+++ b/ibrcommon/ibrcommon/thread/Semaphore.h
@@ -42,9 +42,9 @@ namespace ibrcommon
 			void wait();
 			void post();
 
-			void trylock() throw (MutexException);
-			void enter() throw (MutexException);
-			void leave() throw (MutexException);
+			void trylock() noexcept (false);
+			void enter() noexcept (false);
+			void leave() noexcept (false);
 		private:
 			sem_t count_sem;
 	};

--- a/ibrcommon/ibrcommon/thread/SharedReference.h
+++ b/ibrcommon/ibrcommon/thread/SharedReference.h
@@ -36,7 +36,7 @@ namespace ibrcommon {
 			: _item(ref), _l(mutex)
 		{}
 
-		T& operator*() const throw (ibrcommon::Exception)
+		T& operator*() const noexcept (false)
 		{
 			if (_item == NULL) throw ibrcommon::Exception("object not initialized");
 			return *_item;

--- a/ibrcommon/ibrcommon/thread/SignalHandler.cpp
+++ b/ibrcommon/ibrcommon/thread/SignalHandler.cpp
@@ -52,7 +52,7 @@ namespace ibrcommon
 		::signal(signal, _proxy_handler);
 	}
 
-	void SignalHandler::run(void) throw ()
+	void SignalHandler::run(void) noexcept
 	{
 		try {
 			int signal = _signal_queue.poll();
@@ -62,7 +62,7 @@ namespace ibrcommon
 		}
 	}
 
-	void SignalHandler::__cancellation() throw ()
+	void SignalHandler::__cancellation() noexcept
 	{
 		_signal_queue.abort();
 	}

--- a/ibrcommon/ibrcommon/thread/SignalHandler.h
+++ b/ibrcommon/ibrcommon/thread/SignalHandler.h
@@ -47,13 +47,13 @@ namespace ibrcommon
 		/**
 		 * Abstract interface for thread context run method.
 		 */
-		virtual void run(void) throw ();
+		virtual void run(void) noexcept;
 
 	protected:
 		/**
 		 * This method is call when the thread is stopped.
 		 */
-		virtual void __cancellation() throw ();
+		virtual void __cancellation() noexcept;
 
 	private:
 		static void _proxy_handler(int signal);

--- a/ibrcommon/ibrcommon/thread/Thread.cpp
+++ b/ibrcommon/ibrcommon/thread/Thread.cpp
@@ -69,7 +69,7 @@ namespace ibrcommon
 #endif
 	}
 
-	void* Thread::__execute__(void *obj) throw ()
+	void* Thread::__execute__(void *obj) noexcept
 	{
 #ifdef __DEVELOPMENT_ASSERTIONS__
 		// the given object should never be null
@@ -153,7 +153,7 @@ namespace ibrcommon
 		pthread_attr_destroy(&attr);
 	}
 
-	void Thread::reset() throw (ThreadException)
+	void Thread::reset() noexcept (false)
 	{
 		if ( _state != THREAD_FINALIZED )
 			throw ThreadException(0, "invalid state for reset");
@@ -178,7 +178,7 @@ namespace ibrcommon
 		return pthread_kill(tid, sig);
 	}
 
-	void Thread::cancel() throw ()
+	void Thread::cancel() noexcept
 	{
 		// block multiple cancel calls
 		{
@@ -230,7 +230,7 @@ namespace ibrcommon
 		join();
 	}
 
-	void JoinableThread::start(int adj) throw (ThreadException)
+	void JoinableThread::start(int adj) noexcept (false)
 	{
 		int ret;
 
@@ -309,12 +309,12 @@ namespace ibrcommon
 #endif
 	}
 
-	void JoinableThread::stop() throw ()
+	void JoinableThread::stop() noexcept
 	{
 		Thread::cancel();
 	}
 
-	void JoinableThread::join(void) throw (ThreadException)
+	void JoinableThread::join(void) noexcept (false)
 	{
 		ibrcommon::ThreadsafeState<THREAD_STATE>::Locked ls = _state.lock();
 
@@ -360,7 +360,7 @@ namespace ibrcommon
 	{
 	}
 
-	void DetachedThread::start(int adj) throw (ThreadException)
+	void DetachedThread::start(int adj) noexcept (false)
 	{
 		int ret = 0;
 
@@ -443,7 +443,7 @@ namespace ibrcommon
 #endif
 	}
 
-	void DetachedThread::stop() throw (ThreadException)
+	void DetachedThread::stop() noexcept (false)
 	{
 		Thread::cancel();
 	}

--- a/ibrcommon/ibrcommon/thread/Thread.h
+++ b/ibrcommon/ibrcommon/thread/Thread.h
@@ -36,7 +36,7 @@ namespace ibrcommon
 	class ThreadException : public ibrcommon::Exception
 	{
 	public:
-		ThreadException(int err = 0, string what = "An error occured during a thread operation.") throw() : ibrcommon::Exception(what), error(err)
+		ThreadException(int err = 0, string what = "An error occured during a thread operation.") noexcept : ibrcommon::Exception(what), error(err)
 		{
 		};
 
@@ -103,7 +103,7 @@ namespace ibrcommon
 		/**
 		 * Reset this thread to initial state
 		 */
-		void reset() throw (ThreadException);
+		void reset() noexcept(false);
 
 		/**
 		 * Yield execution context of the current thread. This is a static
@@ -128,17 +128,17 @@ namespace ibrcommon
 		/**
 		 * This method is called before the run.
 		 */
-		virtual void setup(void) throw ()  { };
+		virtual void setup(void) noexcept { };
 
 		/**
 		 * Abstract interface for thread context run method.
 		 */
-		virtual void run(void) throw () = 0;
+		virtual void run(void) noexcept = 0;
 
 		/**
 		 * This method is called when the run() method finishes.
 		 */
-		virtual void finally(void) throw () { };
+		virtual void finally(void) noexcept { };
 
 		/**
 		 * Set concurrency level of process.  This is essentially a portable
@@ -149,7 +149,7 @@ namespace ibrcommon
 		/**
 		 * Returns true if this thread was started and finalized before.
 		 */
-		inline bool isFinalized(void) throw ()
+		inline bool isFinalized(void) noexcept
 			{ return _state == THREAD_FINALIZED; };
 
 		/**
@@ -170,8 +170,8 @@ namespace ibrcommon
 		/**
 		 * Cancel the running thread context.
 		 */
-		void cancel() throw ();
-		virtual void __cancellation() throw () = 0;
+		void cancel() noexcept;
+		virtual void __cancellation() noexcept = 0;
 
 		/**
 		 * Determine if two thread identifiers refer to the same thread.
@@ -184,7 +184,7 @@ namespace ibrcommon
 		/**
 		 * static execute thread method
 		 */
-		static void* __execute__(void *obj) throw ();
+		static void* __execute__(void *obj) noexcept;
 	};
 
 	/**
@@ -218,7 +218,7 @@ namespace ibrcommon
 		 * now depreciated behavior and in the future will not be supported.
 		 * Threads should always return through their run() method.
 		 */
-		void join(void) throw (ThreadException);
+		void join(void) noexcept (false);
 
 		/**
 		 * Start execution of child context.  This must be called after the
@@ -228,12 +228,12 @@ namespace ibrcommon
 		 * of the thread when it starts under realtime priority.
 		 * @param priority of child thread.
 		 */
-		void start(int priority = 0) throw (ThreadException);
+		void start(int priority = 0) noexcept (false);
 
 		/**
 		 * Stop the execution of child context.
 		 */
-		void stop() throw ();
+		void stop() noexcept;
 	};
 
 	/**
@@ -266,12 +266,12 @@ namespace ibrcommon
 		 * the new thread context, which then calls the object's run method.
 		 * @param priority to start thread with.
 		 */
-		void start(int priority = 0) throw (ThreadException);
+		void start(int priority = 0) noexcept (false);
 
 		/**
 		 * Stop the execution of child context.
 		 */
-		void stop() throw (ThreadException);
+		void stop() noexcept (false);
 	};
 }
 

--- a/ibrcommon/ibrcommon/thread/Timer.cpp
+++ b/ibrcommon/ibrcommon/thread/Timer.cpp
@@ -51,7 +51,7 @@ namespace ibrcommon
 		join();
 	}
 
-	void Timer::__cancellation() throw ()
+	void Timer::__cancellation() noexcept
 	{
 		MutexLock l(_state);
 		_state.setState(TIMER_CANCELLED);
@@ -82,7 +82,7 @@ namespace ibrcommon
 		return _timeout / 1000;
 	}
 
-	void Timer::run() throw ()
+	void Timer::run() noexcept
 	{
 		MutexLock l(_state);
 		_state.setState(TIMER_RUNNING);

--- a/ibrcommon/ibrcommon/thread/Timer.h
+++ b/ibrcommon/ibrcommon/thread/Timer.h
@@ -81,8 +81,8 @@ namespace ibrcommon
 		size_t getTimeout() const;
 
 	protected:
-		void run() throw ();
-		void __cancellation() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
 
 	private:
 		enum TIMER_STATE

--- a/ibrcommon/tests/Makefile.am
+++ b/ibrcommon/tests/Makefile.am
@@ -1,5 +1,6 @@
 ## Source directory
 
+AUTOMAKE_OPTIONS = subdir-objects
 SUBDIRS=unittests stress
 
 h_sources = \

--- a/ibrcommon/tests/net/tcpstreamtest.cpp
+++ b/ibrcommon/tests/net/tcpstreamtest.cpp
@@ -93,17 +93,17 @@ void tcpstreamtest::runTest()
 	};
 }
 
-void tcpstreamtest::StreamChecker::__cancellation() throw ()
+void tcpstreamtest::StreamChecker::__cancellation() noexcept
 {
 	_running = false;
 	_sock.down();
 }
 
-void tcpstreamtest::StreamChecker::setup() throw () {
+void tcpstreamtest::StreamChecker::setup() noexcept {
 	_running = true;
 }
 
-void tcpstreamtest::StreamChecker::run() throw ()
+void tcpstreamtest::StreamChecker::run() noexcept
 {
 	try {
 		char values[10] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' };

--- a/ibrcommon/tests/net/tcpstreamtest.h
+++ b/ibrcommon/tests/net/tcpstreamtest.h
@@ -39,9 +39,9 @@ class tcpstreamtest : public CPPUNIT_NS :: TestFixture
 		StreamChecker(int port, int chars = 10);
 		~StreamChecker();
 
-		virtual void setup() throw ();
-		virtual void run() throw ();
-		virtual void __cancellation() throw ();
+		virtual void setup() noexcept;
+		virtual void run() noexcept;
+		virtual void __cancellation() noexcept;
 
 		bool _error;
 

--- a/ibrcommon/tests/stress/StressBLOB.cpp
+++ b/ibrcommon/tests/stress/StressBLOB.cpp
@@ -108,7 +108,7 @@ bool StressBLOB::BLOBWorker::check()
 	return true;
 }
 
-void StressBLOB::BLOBWorker::run() throw ()
+void StressBLOB::BLOBWorker::run() noexcept
 {
 	for (unsigned int i = 0; i < _count; ++i)
 	{
@@ -131,6 +131,6 @@ void StressBLOB::BLOBWorker::run() throw ()
 	}
 }
 
-void StressBLOB::BLOBWorker::__cancellation() throw ()
+void StressBLOB::BLOBWorker::__cancellation() noexcept
 {
 }

--- a/ibrcommon/tests/stress/StressBLOB.h
+++ b/ibrcommon/tests/stress/StressBLOB.h
@@ -46,9 +46,9 @@ private:
 		BLOBWorker(const size_t count, const size_t size);
 		virtual ~BLOBWorker();
 
-		void run() throw ();
+		void run() noexcept;
 		bool check();
-		void __cancellation() throw ();
+		void __cancellation() noexcept;
 
 	private:
 		size_t _count;

--- a/ibrcommon/tests/thread/MutexTests.cpp
+++ b/ibrcommon/tests/thread/MutexTests.cpp
@@ -46,13 +46,13 @@ MutexTests::TestThread::~TestThread()
 	join();
 }
 
-void MutexTests::TestThread::run() throw ()
+void MutexTests::TestThread::run() noexcept
 {
 	ibrcommon::MutexLock l(_m);
 	_var = _value;
 }
 
-void MutexTests::TestThread::__cancellation() throw ()
+void MutexTests::TestThread::__cancellation() noexcept
 {
 }
 

--- a/ibrcommon/tests/thread/MutexTests.h
+++ b/ibrcommon/tests/thread/MutexTests.h
@@ -49,8 +49,8 @@ protected:
 		TestThread(ibrcommon::Mutex &m, bool &var, const bool value);
 		~TestThread();
 
-		void run() throw ();
-		void __cancellation() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
 
 	private:
 		ibrcommon::Mutex &_m;

--- a/ibrcommon/tests/thread/QueueTest.cpp
+++ b/ibrcommon/tests/thread/QueueTest.cpp
@@ -44,7 +44,7 @@ QueueTest::TestThread::~TestThread()
 	join();
 }
 
-void QueueTest::TestThread::run() throw ()
+void QueueTest::TestThread::run() noexcept
 {
 	try {
 		while (true)
@@ -61,12 +61,12 @@ void QueueTest::TestThread::run() throw ()
 	}
 }
 
-void QueueTest::TestThread::__cancellation() throw ()
+void QueueTest::TestThread::__cancellation() noexcept
 {
 	_queue.abort();
 }
 
-void QueueTest::TestThread::finally() throw ()
+void QueueTest::TestThread::finally() noexcept
 {
 }
 

--- a/ibrcommon/tests/thread/QueueTest.h
+++ b/ibrcommon/tests/thread/QueueTest.h
@@ -48,10 +48,10 @@ public:
 		TestThread(size_t time = 0, size_t max = 0);
 		~TestThread();
 
-		void run() throw ();
-		virtual void __cancellation() throw ();
+		void run() noexcept;
+		virtual void __cancellation() noexcept;
 
-		void finally() throw ();
+		void finally() noexcept;
 
 		size_t _count;
 		size_t _time;

--- a/ibrcommon/tests/thread/ThreadTest.cpp
+++ b/ibrcommon/tests/thread/ThreadTest.cpp
@@ -45,7 +45,7 @@ ThreadTest::DetachedTestThread::~DetachedTestThread()
 
 }
 
-void ThreadTest::DetachedTestThread::run() throw ()
+void ThreadTest::DetachedTestThread::run() noexcept
 {
 	// set run to true
 	{
@@ -59,11 +59,11 @@ void ThreadTest::DetachedTestThread::run() throw ()
 	}
 }
 
-void ThreadTest::DetachedTestThread::finally() throw ()
+void ThreadTest::DetachedTestThread::finally() noexcept
 {
 }
 
-void ThreadTest::DetachedTestThread::__cancellation() throw ()
+void ThreadTest::DetachedTestThread::__cancellation() noexcept
 {
 	ibrcommon::MutexLock l(_cond);
 	_run = false;
@@ -80,12 +80,12 @@ ThreadTest::TestThread::~TestThread()
 	join();
 }
 
-void ThreadTest::TestThread::__cancellation() throw ()
+void ThreadTest::TestThread::__cancellation() noexcept
 {
 	_running = false;
 }
 
-void ThreadTest::TestThread::run() throw ()
+void ThreadTest::TestThread::run() noexcept
 {
 	if (_time == 0)
 	{
@@ -98,7 +98,7 @@ void ThreadTest::TestThread::run() throw ()
 	}
 }
 
-void ThreadTest::TestThread::finally() throw ()
+void ThreadTest::TestThread::finally() noexcept
 {
 	_finally++;
 }

--- a/ibrcommon/tests/thread/ThreadTest.h
+++ b/ibrcommon/tests/thread/ThreadTest.h
@@ -45,9 +45,9 @@ public:
 		TestThread(size_t time = 0);
 		~TestThread();
 
-		void run() throw ();
-		void __cancellation() throw ();
-		void finally() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
+		void finally() noexcept;
 
 		bool _running;
 		size_t _finally;
@@ -60,9 +60,9 @@ public:
 		DetachedTestThread(ibrcommon::Conditional &cond, bool &run, size_t time = 0);
 		~DetachedTestThread();
 
-		void run() throw ();
-		void __cancellation() throw ();
-		void finally() throw ();
+		void run() noexcept;
+		void __cancellation() noexcept;
+		void finally() noexcept;
 
 	private:
 		ibrcommon::Conditional &_cond;

--- a/ibrdtn/daemon/src/Component.cpp
+++ b/ibrdtn/daemon/src/Component.cpp
@@ -40,7 +40,7 @@ namespace dtn
 			join();
 		}
 
-		void IndependentComponent::initialize() throw ()
+		void IndependentComponent::initialize() noexcept
 		{
 			// reset thread if necessary
 			if (JoinableThread::isFinalized()) JoinableThread::reset();
@@ -48,7 +48,7 @@ namespace dtn
 			componentUp();
 		}
 
-		void IndependentComponent::startup() throw ()
+		void IndependentComponent::startup() noexcept
 		{
 			try {
 				JoinableThread::start();
@@ -57,13 +57,13 @@ namespace dtn
 			}
 		}
 
-		void IndependentComponent::terminate() throw ()
+		void IndependentComponent::terminate() noexcept
 		{
 			componentDown();
 			JoinableThread::stop();
 		}
 
-		void IndependentComponent::run() throw ()
+		void IndependentComponent::run() noexcept
 		{
 			componentRun();
 		}
@@ -76,17 +76,17 @@ namespace dtn
 		{
 		}
 
-		void IntegratedComponent::initialize() throw ()
+		void IntegratedComponent::initialize() noexcept
 		{
 			componentUp();
 		}
 
-		void IntegratedComponent::startup() throw ()
+		void IntegratedComponent::startup() noexcept
 		{
 			// nothing to do
 		}
 
-		void IntegratedComponent::terminate() throw ()
+		void IntegratedComponent::terminate() noexcept
 		{
 			componentDown();
 		}

--- a/ibrdtn/daemon/src/Component.h
+++ b/ibrdtn/daemon/src/Component.h
@@ -43,19 +43,19 @@ namespace dtn
 			 * Set up the component.
 			 * At this stage no other components should be used.
 			 */
-			virtual void initialize() throw () = 0;
+			virtual void initialize() noexcept = 0;
 
 			/**
 			 * Start up the component.
 			 * At this stage all other components are ready.
 			 */
-			virtual void startup() throw () = 0;
+			virtual void startup() noexcept = 0;
 
 			/**
 			 * Terminate the component and do some cleanup stuff.
 			 * All other components still exists, but may not serve signals.
 			 */
-			virtual void terminate() throw () = 0;
+			virtual void terminate() noexcept = 0;
 
 			/**
 			 * Return an identifier for this component
@@ -73,37 +73,37 @@ namespace dtn
 			IndependentComponent();
 			virtual ~IndependentComponent();
 
-			virtual void initialize() throw ();
-			virtual void startup() throw ();
-			virtual void terminate() throw ();
+			virtual void initialize() noexcept;
+			virtual void startup() noexcept;
+			virtual void terminate() noexcept;
 
 		protected:
-			void run() throw ();
+			void run() noexcept;
 
 			/**
 			 * This method is called after componentDown() and should
 			 * should guarantee that blocking calls in componentRun()
 			 * will unblock.
 			 */
-			virtual void __cancellation() throw () = 0;
+			virtual void __cancellation() noexcept = 0;
 
 			/**
 			 * Is called in preparation of the component.
 			 * Before componentRun() is called.
 			 */
-			virtual void componentUp() throw () = 0;
+			virtual void componentUp() noexcept = 0;
 
 			/**
 			 * This is the run method. The component should loop in there
 			 * until componentDown() or __cancellation() is called.
 			 */
-			virtual void componentRun() throw () = 0;
+			virtual void componentRun() noexcept = 0;
 
 			/**
 			 * This method is called if the component should stop. Clean-up
 			 * code should be inserted here.
 			 */
-			virtual void componentDown() throw () = 0;
+			virtual void componentDown() noexcept = 0;
 		};
 
 		class IntegratedComponent : public Component
@@ -112,13 +112,13 @@ namespace dtn
 			IntegratedComponent();
 			virtual ~IntegratedComponent();
 
-			virtual void initialize() throw ();
-			virtual void startup() throw ();
-			virtual void terminate() throw ();
+			virtual void initialize() noexcept;
+			virtual void startup() noexcept;
+			virtual void terminate() noexcept;
 
 		protected:
-			virtual void componentUp() throw () = 0;
-			virtual void componentDown() throw () = 0;
+			virtual void componentUp() noexcept = 0;
+			virtual void componentDown() noexcept = 0;
 		};
 	}
 }

--- a/ibrdtn/daemon/src/Configuration.cpp
+++ b/ibrdtn/daemon/src/Configuration.cpp
@@ -598,7 +598,7 @@ namespace dtn
 			return _interfaces;
 		}
 
-		const std::set<ibrcommon::vaddress> Configuration::Discovery::address() const throw (ParameterNotFoundException)
+		const std::set<ibrcommon::vaddress> Configuration::Discovery::address() const noexcept (false)
 		{
 			std::set<ibrcommon::vaddress> ret;
 

--- a/ibrdtn/daemon/src/Configuration.h
+++ b/ibrdtn/daemon/src/Configuration.h
@@ -51,7 +51,7 @@ namespace dtn
 		public:
 			class OnChangeListener {
 			public:
-				virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) throw () = 0;
+				virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) noexcept = 0;
 			};
 
 			class NetConfig
@@ -182,7 +182,7 @@ namespace dtn
 				bool announce() const;
 				bool shortbeacon() const;
 				int version() const;
-				const std::set<ibrcommon::vaddress> address() const throw (ParameterNotFoundException);
+				const std::set<ibrcommon::vaddress> address() const noexcept (false);
 				int port() const;
 				unsigned int interval() const;
 				bool enableCrosslayer() const;

--- a/ibrdtn/daemon/src/DTNTPWorker.cpp
+++ b/ibrdtn/daemon/src/DTNTPWorker.cpp
@@ -185,7 +185,7 @@ namespace dtn
 			return stream;
 		}
 
-		void DTNTPWorker::raiseEvent(const dtn::core::TimeEvent &t) throw ()
+		void DTNTPWorker::raiseEvent(const dtn::core::TimeEvent &t) noexcept
 		{
 			if (t.getAction() != dtn::core::TIME_SECOND_TICK) return;
 
@@ -380,7 +380,7 @@ namespace dtn
 			}
 		}
 
-		void DTNTPWorker::onUpdateBeacon(const ibrcommon::vinterface&, DiscoveryBeacon &announcement) throw (NoServiceHereException)
+		void DTNTPWorker::onUpdateBeacon(const ibrcommon::vinterface&, DiscoveryBeacon &announcement) noexcept (false)
 		{
 			if (!_announce_rating) throw NoServiceHereException("Discovery of time sync mechanisms disabled.");
 

--- a/ibrdtn/daemon/src/DTNTPWorker.h
+++ b/ibrdtn/daemon/src/DTNTPWorker.h
@@ -56,7 +56,7 @@ namespace dtn
 			 * This method is called by the EventSwitch.
 			 * @param evt
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
 
 			/**
 			 * This message is called by the discovery module.

--- a/ibrdtn/daemon/src/NativeDaemon.cpp
+++ b/ibrdtn/daemon/src/NativeDaemon.cpp
@@ -154,7 +154,7 @@ namespace dtn
 		{
 		}
 
-		std::vector<std::string> NativeDaemon::getVersion() const throw ()
+		std::vector<std::string> NativeDaemon::getVersion() const noexcept
 		{
 			std::vector<std::string> ret;
 			ret.push_back(VERSION);
@@ -162,22 +162,22 @@ namespace dtn
 			return ret;
 		}
 
-		void NativeDaemon::clearStorage() const throw ()
+		void NativeDaemon::clearStorage() const noexcept
 		{
 			dtn::core::BundleCore::getInstance().getStorage().clear();
 		}
 
-		void NativeDaemon::setLeMode(bool low_energy) const throw ()
+		void NativeDaemon::setLeMode(bool low_energy) const noexcept
 		{
 			dtn::core::GlobalEvent::raise(low_energy ? dtn::core::GlobalEvent::GLOBAL_LOW_ENERGY : dtn::core::GlobalEvent::GLOBAL_NORMAL);
 		}
 
-		void NativeDaemon::startDiscovery() const throw ()
+		void NativeDaemon::startDiscovery() const noexcept
 		{
 			dtn::core::GlobalEvent::raise(dtn::core::GlobalEvent::GLOBAL_START_DISCOVERY);
 		}
 
-		void NativeDaemon::stopDiscovery() const throw ()
+		void NativeDaemon::stopDiscovery() const noexcept
 		{
 			dtn::core::GlobalEvent::raise(dtn::core::GlobalEvent::GLOBAL_STOP_DISCOVERY);
 		}
@@ -277,7 +277,7 @@ namespace dtn
 			}
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::core::NodeEvent &node) throw ()
+		void NativeDaemon::raiseEvent(const dtn::core::NodeEvent &node) noexcept
 		{
 			const std::string event = node.getName();
 			std::string action;
@@ -309,7 +309,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::core::GlobalEvent &global) throw ()
+		void NativeDaemon::raiseEvent(const dtn::core::GlobalEvent &global) noexcept
 		{
 			const std::string event = global.getName();
 			std::string action;
@@ -356,7 +356,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::net::BundleReceivedEvent &received) throw ()
+		void NativeDaemon::raiseEvent(const dtn::net::BundleReceivedEvent &received) noexcept
 		{
 			const std::string event = received.getName();
 			std::string action;
@@ -375,7 +375,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::core::CustodyEvent &custody) throw ()
+		void NativeDaemon::raiseEvent(const dtn::core::CustodyEvent &custody) noexcept
 		{
 			const std::string event = custody.getName();
 			std::string action;
@@ -401,7 +401,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) throw ()
+		void NativeDaemon::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) noexcept
 		{
 			const std::string event = aborted.getName();
 			std::string action;
@@ -419,7 +419,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::net::TransferCompletedEvent &completed) throw ()
+		void NativeDaemon::raiseEvent(const dtn::net::TransferCompletedEvent &completed) noexcept
 		{
 			const std::string event = completed.getName();
 			std::string action;
@@ -437,7 +437,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::net::ConnectionEvent &connection) throw ()
+		void NativeDaemon::raiseEvent(const dtn::net::ConnectionEvent &connection) noexcept
 		{
 			const std::string event = connection.getName();
 			std::string action;
@@ -469,7 +469,7 @@ namespace dtn
 			_eventcb->eventRaised(event, action, data);
 		}
 
-		void NativeDaemon::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void NativeDaemon::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			const std::string event = queued.getName();
 			std::string action;
@@ -486,7 +486,7 @@ namespace dtn
 		}
 
 #ifdef IBRDTN_SUPPORT_BSP
-		void NativeDaemon::raiseEvent(const dtn::security::KeyExchangeEvent &keyExchange) throw ()
+		void NativeDaemon::raiseEvent(const dtn::security::KeyExchangeEvent &keyExchange) noexcept
 		{
 			const std::string event = keyExchange.getName();
 			std::string action;
@@ -533,12 +533,12 @@ namespace dtn
 		}
 #endif
 
-		std::string NativeDaemon::getLocalUri() const throw ()
+		std::string NativeDaemon::getLocalUri() const noexcept
 		{
 			return dtn::core::BundleCore::local.getString();
 		}
 
-		NativeStats NativeDaemon::getStats() throw ()
+		NativeStats NativeDaemon::getStats() noexcept
 		{
 			NativeStats ret;
 
@@ -573,7 +573,7 @@ namespace dtn
 			return ret;
 		}
 
-		NativeNode NativeDaemon::getInfo(const std::string &neighbor_eid) const throw (NativeDaemonException)
+		NativeNode NativeDaemon::getInfo(const std::string &neighbor_eid) const noexcept (false)
 		{
 			NativeNode nn(neighbor_eid);
 
@@ -617,7 +617,7 @@ namespace dtn
 			return nn;
 		}
 
-		std::vector<std::string> NativeDaemon::getNeighbors() const throw ()
+		std::vector<std::string> NativeDaemon::getNeighbors() const noexcept
 		{
 			std::vector<std::string> ret;
 
@@ -632,7 +632,7 @@ namespace dtn
 			return ret;
 		}
 
-		void NativeDaemon::addConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local) const throw ()
+		void NativeDaemon::addConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local) const noexcept
 		{
 			dtn::core::Node n(eid);
 			dtn::core::Node::Type t = dtn::core::Node::NODE_STATIC_GLOBAL;
@@ -658,7 +658,7 @@ namespace dtn
 			}
 		}
 
-		void NativeDaemon::removeConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local) const throw ()
+		void NativeDaemon::removeConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local) const noexcept
 		{
 			dtn::core::Node n(eid);
 			dtn::core::Node::Type t = dtn::core::Node::NODE_STATIC_GLOBAL;
@@ -731,7 +731,7 @@ namespace dtn
 #endif
 		}
 
-		NativeKeyInfo NativeDaemon::getKeyInfo(std::string eid) const throw (NativeDaemonException)
+		NativeKeyInfo NativeDaemon::getKeyInfo(std::string eid) const noexcept (false)
 		{
 #ifdef IBRDTN_SUPPORT_BSP
 			try {
@@ -757,7 +757,7 @@ namespace dtn
 #endif
 		}
 
-		void NativeDaemon::removeKey(std::string eid) const throw (NativeDaemonException)
+		void NativeDaemon::removeKey(std::string eid) const noexcept (false)
 		{
 #ifdef IBRDTN_SUPPORT_BSP
 			try {
@@ -775,7 +775,7 @@ namespace dtn
 #endif
 		}
 
-		void NativeDaemon::setLogging(const std::string &defaultTag, int logLevel) const throw ()
+		void NativeDaemon::setLogging(const std::string &defaultTag, int logLevel) const noexcept
 		{
 			/**
 			 * setup logging capabilities
@@ -827,7 +827,7 @@ namespace dtn
 		/**
 		 * Set the path to the log file
 		 */
-		void NativeDaemon::setLogFile(const std::string &path, int logLevel) const throw ()
+		void NativeDaemon::setLogFile(const std::string &path, int logLevel) const noexcept
 		{
 			// logging options
 			unsigned char logopts = ibrcommon::Logger::LOG_DATETIME | ibrcommon::Logger::LOG_LEVEL | ibrcommon::Logger::LOG_TAG;
@@ -860,12 +860,12 @@ namespace dtn
 			ibrcommon::Logger::setLogfile(lf, logsys, logopts);
 		}
 
-		DaemonRunLevel NativeDaemon::getRunLevel() const throw ()
+		DaemonRunLevel NativeDaemon::getRunLevel() const noexcept
 		{
 			return _runlevel;
 		}
 
-		void NativeDaemon::init(DaemonRunLevel rl) throw (NativeDaemonException)
+		void NativeDaemon::init(DaemonRunLevel rl) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_runlevel_cond);
 			if (_runlevel < rl) {
@@ -881,7 +881,7 @@ namespace dtn
 			}
 		}
 
-		void NativeDaemon::init_up(DaemonRunLevel rl) throw (NativeDaemonException)
+		void NativeDaemon::init_up(DaemonRunLevel rl) noexcept (false)
 		{
 			switch (rl) {
 			case RUNLEVEL_ZERO:
@@ -937,7 +937,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeDaemon::TAG, 5) << "runlevel " << rl << " reached" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeDaemon::init_down(DaemonRunLevel rl) throw (NativeDaemonException)
+		void NativeDaemon::init_down(DaemonRunLevel rl) noexcept (false)
 		{
 			/**
 			 * shutdown all components of this runlevel
@@ -994,7 +994,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeDaemon::TAG, 5) << "runlevel " << (rl-1) << " reached" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeDaemon::wait(DaemonRunLevel rl) throw ()
+		void NativeDaemon::wait(DaemonRunLevel rl) noexcept
 		{
 			try {
 				ibrcommon::MutexLock l(_runlevel_cond);
@@ -1004,7 +1004,7 @@ namespace dtn
 			}
 		}
 
-		void NativeDaemon::init_core() throw (NativeDaemonException)
+		void NativeDaemon::init_core() noexcept (false)
 		{
 			// enable link manager
 			ibrcommon::LinkManager::initialize();
@@ -1074,7 +1074,7 @@ namespace dtn
 #endif
 		}
 
-		void NativeDaemon::shutdown_core() throw (NativeDaemonException)
+		void NativeDaemon::shutdown_core() noexcept (false)
 		{
 			// shutdown the event switch
 			_event_loop->stop();
@@ -1101,7 +1101,7 @@ namespace dtn
 #endif
 		}
 
-		void NativeDaemon::init_storage() throw (NativeDaemonException)
+		void NativeDaemon::init_storage() noexcept (false)
 		{
 			dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
 
@@ -1227,7 +1227,7 @@ namespace dtn
 			} catch (const dtn::daemon::Configuration::ParameterNotSetException&) { }
 		}
 
-		void NativeDaemon::shutdown_storage() const throw (NativeDaemonException)
+		void NativeDaemon::shutdown_storage() const noexcept (false)
 		{
 			// reset BLOB provider to memory based
 			ibrcommon::BLOB::changeProvider(new ibrcommon::MemoryBLOBProvider(), true);
@@ -1239,7 +1239,7 @@ namespace dtn
 			dtn::core::BundleCore::getInstance().setStorage(NULL);
 		}
 
-		void NativeDaemon::init_routing() throw (NativeDaemonException)
+		void NativeDaemon::init_routing() noexcept (false)
 		{
 			// create the base router
 			dtn::routing::BaseRouter *router = new dtn::routing::BaseRouter();
@@ -1248,11 +1248,11 @@ namespace dtn
 			_components[RUNLEVEL_ROUTING].push_back(router);
 		}
 
-		void NativeDaemon::shutdown_routing() const throw (NativeDaemonException)
+		void NativeDaemon::shutdown_routing() const noexcept (false)
 		{
 		}
 
-		void NativeDaemon::init_api() throw (NativeDaemonException)
+		void NativeDaemon::init_api() noexcept (false)
 		{
 			dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
 
@@ -1319,7 +1319,7 @@ namespace dtn
 #endif
 		}
 
-		void NativeDaemon::shutdown_api() throw (NativeDaemonException)
+		void NativeDaemon::shutdown_api() noexcept (false)
 		{
 			for (app_list::iterator it = _apps.begin(); it != _apps.end(); ++it)
 			{
@@ -1328,7 +1328,7 @@ namespace dtn
 			_apps.clear();
 		}
 
-		void NativeDaemon::init_network() throw (NativeDaemonException)
+		void NativeDaemon::init_network() noexcept (false)
 		{
 			dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
 			dtn::core::BundleCore &core = dtn::core::BundleCore::getInstance();
@@ -1589,7 +1589,7 @@ namespace dtn
 			}
 		}
 
-		void NativeDaemon::shutdown_network() throw (NativeDaemonException)
+		void NativeDaemon::shutdown_network() noexcept (false)
 		{
 			dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
 			dtn::core::BundleCore &core = dtn::core::BundleCore::getInstance();
@@ -1617,7 +1617,7 @@ namespace dtn
 			}
 		}
 
-		void NativeDaemon::init_routing_extensions() throw (NativeDaemonException)
+		void NativeDaemon::init_routing_extensions() noexcept (false)
 		{
 			dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
 			dtn::routing::BaseRouter &router = dtn::core::BundleCore::getInstance().getRouter();
@@ -1691,7 +1691,7 @@ namespace dtn
 			router.extensionsUp();
 		}
 
-		void NativeDaemon::shutdown_routing_extensions() const throw (NativeDaemonException)
+		void NativeDaemon::shutdown_routing_extensions() const noexcept (false)
 		{
 			dtn::routing::BaseRouter &router = dtn::core::BundleCore::getInstance().getRouter();
 
@@ -1705,7 +1705,7 @@ namespace dtn
 		/**
 		 * Generate a reload signal
 		 */
-		void NativeDaemon::reload() throw ()
+		void NativeDaemon::reload() noexcept
 		{
 			// reload logger
 			ibrcommon::Logger::reload();
@@ -1717,7 +1717,7 @@ namespace dtn
 		/**
 		 * Enable / disable debugging at runtime
 		 */
-		void NativeDaemon::setDebug(int level) throw ()
+		void NativeDaemon::setDebug(int level) noexcept
 		{
 			// activate debugging
 			ibrcommon::Logger::setVerbosity(level);
@@ -1733,7 +1733,7 @@ namespace dtn
 		{
 		}
 
-		void NativeEventLoop::run(void) throw ()
+		void NativeEventLoop::run(void) noexcept
 		{
 			dtn::daemon::Configuration &conf = dtn::daemon::Configuration::getInstance();
 
@@ -1754,7 +1754,7 @@ namespace dtn
 			esw.terminate();
 		}
 
-		void NativeEventLoop::__cancellation() throw ()
+		void NativeEventLoop::__cancellation() noexcept
 		{
 			dtn::core::GlobalEvent::raise(dtn::core::GlobalEvent::GLOBAL_SHUTDOWN);
 			dtn::core::EventSwitch::getInstance().shutdown();

--- a/ibrdtn/daemon/src/NativeDaemon.h
+++ b/ibrdtn/daemon/src/NativeDaemon.h
@@ -67,14 +67,14 @@ namespace dtn
 
 			virtual ~NativeDaemonCallback() = 0;
 
-			virtual void levelChanged(DaemonRunLevel level) throw () = 0;
+			virtual void levelChanged(DaemonRunLevel level) noexcept = 0;
 		};
 
 		class NativeEventCallback {
 		public:
 			virtual ~NativeEventCallback() = 0;
 
-			virtual void eventRaised(const std::string &event, const std::string &action, const std::vector<std::string> &data) throw () = 0;
+			virtual void eventRaised(const std::string &event, const std::string &action, const std::vector<std::string> &data) noexcept = 0;
 		};
 
 		class NativeNode {
@@ -155,7 +155,7 @@ namespace dtn
 		class NativeDaemonException : public ibrcommon::Exception
 		{
 		public:
-			NativeDaemonException(std::string what = "An error happened.") throw() : ibrcommon::Exception(what)
+			NativeDaemonException(std::string what = "An error happened.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -191,37 +191,37 @@ namespace dtn
 			/**
 			 * Get the current runlevel
 			 */
-			DaemonRunLevel getRunLevel() const throw ();
+			DaemonRunLevel getRunLevel() const noexcept;
 
 			/**
 			 * Switch the runlevel of the daemon
 			 */
-			void init(DaemonRunLevel rl) throw (NativeDaemonException);
+			void init(DaemonRunLevel rl) noexcept (false);
 
 			/**
 			 * Wait until the runlevel is reached
 			 */
-			void wait(DaemonRunLevel rl) throw ();
+			void wait(DaemonRunLevel rl) noexcept;
 
 			/**
 			 * Generate a reload signal
 			 */
-			void reload() throw ();
+			void reload() noexcept;
 
 			/**
 			 * Enable / disable debugging at runtime
 			 */
-			void setDebug(int level) throw ();
+			void setDebug(int level) noexcept;
 
 			/**
 			 * Set the config file and enable default logging capabilities
 			 */
-			void setLogging(const std::string &defaultTag, int logLevel) const throw ();
+			void setLogging(const std::string &defaultTag, int logLevel) const noexcept;
 
 			/**
 			 * Set the path to the log file
 			 */
-			void setLogFile(const std::string &path, int logLevel) const throw ();
+			void setLogFile(const std::string &path, int logLevel) const noexcept;
 
 			/**
 			 * Set the daemon configuration
@@ -233,32 +233,32 @@ namespace dtn
 			/**
 			 * Get the local EID of this node
 			 */
-			std::string getLocalUri() const throw ();
+			std::string getLocalUri() const noexcept;
 
 			/**
 			 * Get the neighbors
 			 */
-			std::vector<std::string> getNeighbors() const throw ();
+			std::vector<std::string> getNeighbors() const noexcept;
 
 			/**
 			 * Get neighbor info
 			 */
-			NativeNode getInfo(const std::string &neighbor_eid) const throw (NativeDaemonException);
+			NativeNode getInfo(const std::string &neighbor_eid) const noexcept (false);
 
 			/**
 			 * Get statistical data
 			 */
-			NativeStats getStats() throw ();
+			NativeStats getStats() noexcept;
 
 			/**
 			 * Add a static connection to the neighbor with the given EID
 			 */
-			void addConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local = false) const throw ();
+			void addConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local = false) const noexcept;
 
 			/**
 			 * Remove a static connection of the neighbor with the given EID
 			 */
-			void removeConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local = false) const throw ();
+			void removeConnection(std::string eid, std::string protocol, std::string address, std::string service, bool local = false) const noexcept;
 
 			/**
 			 * initiate a connection to a given neighbor
@@ -283,57 +283,57 @@ namespace dtn
 			/**
 			 * Returns security key data
 			 */
-			NativeKeyInfo getKeyInfo(std::string eid) const throw (NativeDaemonException);
+			NativeKeyInfo getKeyInfo(std::string eid) const noexcept (false);
 
 			/**
 			 * Remove an existing key
 			 */
-			void removeKey(std::string eid) const throw (NativeDaemonException);
+			void removeKey(std::string eid) const noexcept (false);
 
 			/**
 			 * @see dtn::core::EventReceiver::raiseEvent()
 			 */
-			virtual void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::core::GlobalEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::core::CustodyEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::net::BundleReceivedEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::net::TransferAbortedEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::net::TransferCompletedEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::net::ConnectionEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
+			virtual void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::core::GlobalEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::core::CustodyEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::net::BundleReceivedEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::net::TransferAbortedEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::net::TransferCompletedEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::net::ConnectionEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
 
 #ifdef IBRDTN_SUPPORT_BSP
-			virtual void raiseEvent(const dtn::security::KeyExchangeEvent &evt) throw ();
+			virtual void raiseEvent(const dtn::security::KeyExchangeEvent &evt) noexcept;
 #endif
 
 			/**
 			 * Returns version information about the native daemon
 			 */
-			std::vector<std::string> getVersion() const throw ();
+			std::vector<std::string> getVersion() const noexcept;
 
 			/**
 			 * Delete all bundles in the storage
 			 */
-			void clearStorage() const throw ();
+			void clearStorage() const noexcept;
 
 			/**
 			 * Enable discovery mechanisms IPND beacons
 			 */
-			void startDiscovery() const throw ();
+			void startDiscovery() const noexcept;
 
 			/**
 			 * Disable discovery mechanism like IPND beacons
 			 */
-			void stopDiscovery() const throw ();
+			void stopDiscovery() const noexcept;
 
 			/**
 			 * Control the Low-energy mode of the daemon
 			 */
-			void setLeMode(bool low_energy) const throw ();
+			void setLeMode(bool low_energy) const noexcept;
 
 		private:
-			void init_up(DaemonRunLevel rl) throw (NativeDaemonException);
-			void init_down(DaemonRunLevel rl) throw (NativeDaemonException);
+			void init_up(DaemonRunLevel rl) noexcept (false);
+			void init_down(DaemonRunLevel rl) noexcept (false);
 
 			void addEventData(const dtn::data::Bundle &b, std::vector<std::string> &data) const;
 			void addEventData(const dtn::data::MetaBundle &b, std::vector<std::string> &data) const;
@@ -345,39 +345,39 @@ namespace dtn
 			/**
 			 * routines to init/shutdown the daemon core
 			 */
-			void init_core() throw (NativeDaemonException);
-			void shutdown_core() throw (NativeDaemonException);
+			void init_core() noexcept (false);
+			void shutdown_core() noexcept (false);
 
 			/**
 			 * routines to init/shutdown the storage subsystem
 			 */
-			void init_storage() throw (NativeDaemonException);
-			void shutdown_storage() const throw (NativeDaemonException);
+			void init_storage() noexcept (false);
+			void shutdown_storage() const noexcept (false);
 
 			/**
 			 * routines to init/shutdown the base router
 			 */
-			void init_routing() throw (NativeDaemonException);
-			void shutdown_routing() const throw (NativeDaemonException);
+			void init_routing() noexcept (false);
+			void shutdown_routing() const noexcept (false);
 
 			/**
 			 * routines to init/shutdown the API modules and embedded
 			 * Apps
 			 */
-			void init_api() throw (NativeDaemonException);
-			void shutdown_api() throw (NativeDaemonException);
+			void init_api() noexcept (false);
+			void shutdown_api() noexcept (false);
 
 			/**
 			 * routines to init/shutdown the networking stack
 			 */
-			void init_network() throw (NativeDaemonException);
-			void shutdown_network() throw (NativeDaemonException);
+			void init_network() noexcept (false);
+			void shutdown_network() noexcept (false);
 
 			/**
 			 * routines to init/shutdown the extended routing modules
 			 */
-			void init_routing_extensions() throw (NativeDaemonException);
-			void shutdown_routing_extensions() const throw (NativeDaemonException);
+			void init_routing_extensions() noexcept (false);
+			void shutdown_routing_extensions() const noexcept (false);
 
 			// conditional
 			ibrcommon::Conditional _runlevel_cond;
@@ -404,8 +404,8 @@ namespace dtn
 		public:
 			NativeEventLoop(NativeDaemon &daemon);
 			~NativeEventLoop();
-			virtual void run(void) throw ();
-			virtual void __cancellation() throw ();
+			virtual void run(void) noexcept;
+			virtual void __cancellation() noexcept;
 
 		private:
 			NativeDaemon &_daemon;

--- a/ibrdtn/daemon/src/api/ApiP2PExtensionHandler.cpp
+++ b/ibrdtn/daemon/src/api/ApiP2PExtensionHandler.cpp
@@ -65,7 +65,7 @@ namespace dtn
 			dtn::core::BundleCore::getInstance().getConnectionManager().add(this);
 		}
 
-		void ApiP2PExtensionHandler::__cancellation() throw ()
+		void ApiP2PExtensionHandler::__cancellation() noexcept
 		{
 		}
 

--- a/ibrdtn/daemon/src/api/ApiP2PExtensionHandler.h
+++ b/ibrdtn/daemon/src/api/ApiP2PExtensionHandler.h
@@ -32,7 +32,7 @@ namespace dtn
 			virtual void run();
 			virtual void finally();
 			virtual void setup();
-			virtual void __cancellation() throw ();
+			virtual void __cancellation() noexcept;
 
 			/**
 			 * Provides the extension tag used in the node URIs.

--- a/ibrdtn/daemon/src/api/ApiServer.cpp
+++ b/ibrdtn/daemon/src/api/ApiServer.cpp
@@ -102,15 +102,15 @@ namespace dtn
 			_sockets.destroy();
 		}
 
-		void ApiServer::__cancellation() throw ()
+		void ApiServer::__cancellation() noexcept
 		{
 			// shut-down all server sockets
 			_sockets.down();
 		}
 
-		void ApiServer::componentUp() throw ()
+		void ApiServer::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// bring up all server sockets
 				_sockets.up();
@@ -122,7 +122,7 @@ namespace dtn
 			startGarbageCollector();
 		}
 
-		void ApiServer::componentRun() throw ()
+		void ApiServer::componentRun() noexcept
 		{
 			try {
 				while (!_shutdown)
@@ -213,7 +213,7 @@ namespace dtn
 			}
 		}
 
-		void ApiServer::componentDown() throw ()
+		void ApiServer::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::routing::QueueBundleEvent>::remove(this);
 
@@ -350,7 +350,7 @@ namespace dtn
 			}
 		}
 
-		void ApiServer::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void ApiServer::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			// ignore fragments - we can not deliver them directly to the client
 			if (queued.bundle.isFragment()) return;

--- a/ibrdtn/daemon/src/api/ApiServer.h
+++ b/ibrdtn/daemon/src/api/ApiServer.h
@@ -56,7 +56,7 @@ namespace dtn
 
 			void freeRegistration(Registration &reg);
 
-			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
+			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
 
 			/**
 			 * retrieve a registration for a given handle from the ApiServers registration list
@@ -77,14 +77,14 @@ namespace dtn
 			virtual size_t timeout(ibrcommon::Timer*);
 
 		protected:
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
 			virtual void connectionUp(ClientHandler *conn);
 			virtual void connectionDown(ClientHandler *conn);
 
-			void componentUp() throw ();
-			void componentRun() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentRun() noexcept;
+			void componentDown() noexcept;
 
 		private:
 

--- a/ibrdtn/daemon/src/api/BinaryStreamClient.cpp
+++ b/ibrdtn/daemon/src/api/BinaryStreamClient.cpp
@@ -50,19 +50,19 @@ namespace dtn
 			return _eid;
 		}
 
-		void BinaryStreamClient::eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) throw ()
+		void BinaryStreamClient::eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) noexcept
 		{
 		}
 
-		void BinaryStreamClient::eventTimeout() throw ()
+		void BinaryStreamClient::eventTimeout() noexcept
 		{
 		}
 
-		void BinaryStreamClient::eventError() throw ()
+		void BinaryStreamClient::eventError() noexcept
 		{
 		}
 
-		void BinaryStreamClient::eventConnectionUp(const dtn::streams::StreamContactHeader &header) throw ()
+		void BinaryStreamClient::eventConnectionUp(const dtn::streams::StreamContactHeader &header) noexcept
 		{
 			Registration &reg = _client.getRegistration();
 
@@ -83,7 +83,7 @@ namespace dtn
 			reg.subscribe(_eid);
 		}
 
-		void BinaryStreamClient::eventConnectionDown() throw ()
+		void BinaryStreamClient::eventConnectionDown() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("BinaryStreamClient", 40) << "BinaryStreamClient::eventConnectionDown()" << IBRCOMMON_LOGGER_ENDL;
 
@@ -97,7 +97,7 @@ namespace dtn
 			}
 		}
 
-		void BinaryStreamClient::eventBundleRefused() throw ()
+		void BinaryStreamClient::eventBundleRefused() noexcept
 		{
 			try {
 				const dtn::data::Bundle bundle = _sentqueue.take();
@@ -110,7 +110,7 @@ namespace dtn
 			}
 		}
 
-		void BinaryStreamClient::eventBundleForwarded() throw ()
+		void BinaryStreamClient::eventBundleForwarded() noexcept
 		{
 			try {
 				const dtn::data::Bundle bundle = _sentqueue.take();
@@ -126,12 +126,12 @@ namespace dtn
 			}
 		}
 
-		void BinaryStreamClient::eventBundleAck(const dtn::data::Length &ack) throw ()
+		void BinaryStreamClient::eventBundleAck(const dtn::data::Length &ack) noexcept
 		{
 			_lastack = ack;
 		}
 
-		void BinaryStreamClient::__cancellation() throw ()
+		void BinaryStreamClient::__cancellation() noexcept
 		{
 			// shutdown
 			_connection.shutdown(dtn::streams::StreamConnection::CONNECTION_SHUTDOWN_ERROR);
@@ -211,7 +211,7 @@ namespace dtn
 			ibrcommon::JoinableThread::join();
 		}
 
-		void BinaryStreamClient::Sender::__cancellation() throw ()
+		void BinaryStreamClient::Sender::__cancellation() noexcept
 		{
 			// cancel the main thread in here
 			this->abort();
@@ -220,7 +220,7 @@ namespace dtn
 			_client._client.getRegistration().abort();
 		}
 
-		void BinaryStreamClient::Sender::run() throw ()
+		void BinaryStreamClient::Sender::run() noexcept
 		{
 			Registration &reg = _client._client.getRegistration();
 

--- a/ibrdtn/daemon/src/api/BinaryStreamClient.h
+++ b/ibrdtn/daemon/src/api/BinaryStreamClient.h
@@ -36,15 +36,15 @@ namespace dtn
 				BinaryStreamClient(ClientHandler &client, ibrcommon::socketstream &stream);
 				virtual ~BinaryStreamClient();
 
-				virtual void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases csc) throw ();
-				virtual void eventTimeout() throw ();
-				virtual void eventError() throw ();
-				virtual void eventConnectionDown() throw ();
-				virtual void eventConnectionUp(const dtn::streams::StreamContactHeader &header) throw ();
+				virtual void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases csc) noexcept;
+				virtual void eventTimeout() noexcept;
+				virtual void eventError() noexcept;
+				virtual void eventConnectionDown() noexcept;
+				virtual void eventConnectionUp(const dtn::streams::StreamContactHeader &header) noexcept;
 
-				virtual void eventBundleRefused() throw ();
-				virtual void eventBundleForwarded() throw ();
-				virtual void eventBundleAck(const dtn::data::Length &ack) throw ();
+				virtual void eventBundleRefused() noexcept;
+				virtual void eventBundleForwarded() noexcept;
+				virtual void eventBundleAck(const dtn::data::Length &ack) noexcept;
 
 				const dtn::data::EID& getPeer() const;
 
@@ -53,7 +53,7 @@ namespace dtn
 				void received(const dtn::streams::StreamContactHeader &h);
 				void run();
 				void finally();
-				void __cancellation() throw ();
+				void __cancellation() noexcept;
 				bool good() const;
 
 			private:
@@ -64,8 +64,8 @@ namespace dtn
 					virtual ~Sender();
 
 				protected:
-					void run() throw ();
-					void __cancellation() throw ();
+					void run() noexcept;
+					void __cancellation() noexcept;
 
 					void received(const dtn::streams::StreamContactHeader &h);
 					bool good() const;

--- a/ibrdtn/daemon/src/api/ClientHandler.cpp
+++ b/ibrdtn/daemon/src/api/ClientHandler.cpp
@@ -74,11 +74,11 @@ namespace dtn
 			_registration = &reg;
 		}
 
-		void ClientHandler::setup() throw ()
+		void ClientHandler::setup() noexcept
 		{
 		}
 
-		void ClientHandler::run() throw ()
+		void ClientHandler::run() noexcept
 		{
 			try {
 				// signal the active connection to the server
@@ -191,13 +191,13 @@ namespace dtn
 			(*_stream) << code << " " << msg << std::endl;
 		}
 
-		void ClientHandler::__cancellation() throw ()
+		void ClientHandler::__cancellation() noexcept
 		{
 			// close the stream
 			(*_stream).close();
 		}
 
-		void ClientHandler::finally() throw ()
+		void ClientHandler::finally() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("ClientHandler", 60) << "ApiConnection down" << IBRCOMMON_LOGGER_ENDL;
 
@@ -221,9 +221,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return 0; };
+				virtual dtn::data::Size limit() const noexcept { return 0; };
 
-				virtual bool shouldAdd(const dtn::data::MetaBundle&) const throw (dtn::storage::BundleSelectorException)
+				virtual bool shouldAdd(const dtn::data::MetaBundle&) const noexcept (false)
 				{
 					return true;
 				}

--- a/ibrdtn/daemon/src/api/ClientHandler.h
+++ b/ibrdtn/daemon/src/api/ClientHandler.h
@@ -44,7 +44,7 @@ namespace dtn
 			virtual void run() = 0;
 			virtual void finally() = 0;
 			virtual void setup() {};
-			virtual void __cancellation() throw () = 0;
+			virtual void __cancellation() noexcept = 0;
 
 		protected:
 			ProtocolHandler(ClientHandler &client, ibrcommon::socketstream &stream);
@@ -88,10 +88,10 @@ namespace dtn
 			void switchRegistration(Registration &reg);
 
 		protected:
-			void run() throw ();
-			void finally() throw ();
-			void setup() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void finally() noexcept;
+			void setup() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			void error(STATUS_CODES code, const std::string &msg);

--- a/ibrdtn/daemon/src/api/EventConnection.cpp
+++ b/ibrdtn/daemon/src/api/EventConnection.cpp
@@ -37,7 +37,7 @@ namespace dtn
 		{
 		}
 
-		void EventConnection::raiseEvent(const dtn::core::NodeEvent &node) throw ()
+		void EventConnection::raiseEvent(const dtn::core::NodeEvent &node) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -73,7 +73,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::core::GlobalEvent &global) throw ()
+		void EventConnection::raiseEvent(const dtn::core::GlobalEvent &global) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -123,7 +123,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::net::BundleReceivedEvent &received) throw ()
+		void EventConnection::raiseEvent(const dtn::net::BundleReceivedEvent &received) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -154,7 +154,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::core::CustodyEvent &custody) throw ()
+		void EventConnection::raiseEvent(const dtn::core::CustodyEvent &custody) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -196,7 +196,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) throw ()
+		void EventConnection::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -221,7 +221,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::net::TransferCompletedEvent &completed) throw ()
+		void EventConnection::raiseEvent(const dtn::net::TransferCompletedEvent &completed) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -251,7 +251,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::net::ConnectionEvent &connection) throw ()
+		void EventConnection::raiseEvent(const dtn::net::ConnectionEvent &connection) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -286,7 +286,7 @@ namespace dtn
 			_stream << std::endl;
 		}
 
-		void EventConnection::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void EventConnection::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_running) return;
@@ -368,7 +368,7 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::routing::QueueBundleEvent>::remove(this);
 		}
 
-		void EventConnection::__cancellation() throw ()
+		void EventConnection::__cancellation() noexcept
 		{
 		}
 	} /* namespace api */

--- a/ibrdtn/daemon/src/api/EventConnection.h
+++ b/ibrdtn/daemon/src/api/EventConnection.h
@@ -55,16 +55,16 @@ namespace dtn
 			void run();
 			void finally();
 			void setup();
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
-			void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
-			void raiseEvent(const dtn::core::GlobalEvent &evt) throw ();
-			void raiseEvent(const dtn::core::CustodyEvent &evt) throw ();
-			void raiseEvent(const dtn::net::BundleReceivedEvent &evt) throw ();
-			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) throw ();
-			void raiseEvent(const dtn::net::TransferCompletedEvent &evt) throw ();
-			void raiseEvent(const dtn::net::ConnectionEvent &evt) throw ();
-			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
+			void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::GlobalEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::CustodyEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::BundleReceivedEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::TransferCompletedEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::ConnectionEvent &evt) noexcept;
+			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
 
 		private:
 			ibrcommon::Mutex _mutex;

--- a/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
+++ b/ibrdtn/daemon/src/api/ExtendedApiHandler.cpp
@@ -63,7 +63,7 @@ namespace dtn
 			return _stream.good();
 		}
 
-		void ExtendedApiHandler::__cancellation() throw ()
+		void ExtendedApiHandler::__cancellation() noexcept
 		{
 			// close the stream
 			_stream.close();
@@ -848,17 +848,17 @@ namespace dtn
 			ibrcommon::JoinableThread::join();
 		}
 
-		void ExtendedApiHandler::Sender::__cancellation() throw ()
+		void ExtendedApiHandler::Sender::__cancellation() noexcept
 		{
 			// abort all blocking calls on the registration object
 			_handler._client.getRegistration().abort();
 		}
 
-		void ExtendedApiHandler::Sender::finally() throw ()
+		void ExtendedApiHandler::Sender::finally() noexcept
 		{
 		}
 
-		void ExtendedApiHandler::Sender::run() throw ()
+		void ExtendedApiHandler::Sender::run() noexcept
 		{
 			Registration &reg = _handler._client.getRegistration();
 			try{

--- a/ibrdtn/daemon/src/api/ExtendedApiHandler.h
+++ b/ibrdtn/daemon/src/api/ExtendedApiHandler.h
@@ -55,7 +55,7 @@ namespace dtn
 
 			virtual void run();
 			virtual void finally();
-			virtual void __cancellation() throw ();
+			virtual void __cancellation() noexcept;
 
 			bool good() const;
 
@@ -67,9 +67,9 @@ namespace dtn
 				virtual ~Sender();
 
 			protected:
-				void run() throw ();
-				void finally() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void finally() noexcept;
+				void __cancellation() noexcept;
 
 			private:
 				ExtendedApiHandler &_handler;

--- a/ibrdtn/daemon/src/api/ManagementConnection.cpp
+++ b/ibrdtn/daemon/src/api/ManagementConnection.cpp
@@ -108,7 +108,7 @@ namespace dtn
 		{
 		}
 
-		void ManagementConnection::__cancellation() throw ()
+		void ManagementConnection::__cancellation() noexcept
 		{
 		}
 
@@ -122,9 +122,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return 0; };
+				virtual dtn::data::Size limit() const noexcept { return 0; };
 
-				virtual bool shouldAdd(const dtn::data::MetaBundle&) const throw (dtn::storage::BundleSelectorException)
+				virtual bool shouldAdd(const dtn::data::MetaBundle&) const noexcept (false)
 				{
 					return true;
 				}

--- a/ibrdtn/daemon/src/api/ManagementConnection.h
+++ b/ibrdtn/daemon/src/api/ManagementConnection.h
@@ -37,7 +37,7 @@ namespace dtn
 			void run();
 			void finally();
 			void setup();
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
 		private:
 			void processCommand(const std::vector<std::string> &cmd);

--- a/ibrdtn/daemon/src/api/NativeSerializerCallback.h
+++ b/ibrdtn/daemon/src/api/NativeSerializerCallback.h
@@ -33,13 +33,13 @@ namespace dtn
 		public:
 			virtual ~NativeSerializerCallback() = 0;
 
-			virtual void beginBundle(const dtn::data::PrimaryBlock &block) throw () = 0;
-			virtual void endBundle() throw () = 0;
+			virtual void beginBundle(const dtn::data::PrimaryBlock &block) noexcept = 0;
+			virtual void endBundle() noexcept = 0;
 
-			virtual void beginBlock(const dtn::data::Block &block, const size_t payload_length) throw () = 0;
-			virtual void endBlock() throw () = 0;
+			virtual void beginBlock(const dtn::data::Block &block, const size_t payload_length) noexcept = 0;
+			virtual void endBlock() noexcept = 0;
 
-			virtual void payload(const char *buf, const size_t len) throw () = 0;
+			virtual void payload(const char *buf, const size_t len) noexcept = 0;
 		};
 	}
 }

--- a/ibrdtn/daemon/src/api/NativeSession.cpp
+++ b/ibrdtn/daemon/src/api/NativeSession.cpp
@@ -76,7 +76,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 15) << "Session destroyed" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::destroy() throw ()
+		void NativeSession::destroy() noexcept
 		{
 			// un-listen from QueueBundleEvents
 			dtn::core::EventDispatcher<dtn::routing::QueueBundleEvent>::remove(&_receiver);
@@ -84,33 +84,33 @@ namespace dtn
 			_registration.abort();
 		}
 
-		const dtn::data::EID& NativeSession::getNodeEID() const throw ()
+		const dtn::data::EID& NativeSession::getNodeEID() const noexcept
 		{
 			return dtn::core::BundleCore::local;
 		}
 
-		void NativeSession::fireNotificationBundle(const dtn::data::BundleID &id) throw ()
+		void NativeSession::fireNotificationBundle(const dtn::data::BundleID &id) noexcept
 		{
 			ibrcommon::MutexLock l(_cb_mutex);
 			if (_session_cb == NULL) return;
 			_session_cb->notifyBundle(id);
 		}
 
-		void NativeSession::fireNotificationStatusReport(const dtn::data::EID &source, const dtn::data::StatusReportBlock &report) throw ()
+		void NativeSession::fireNotificationStatusReport(const dtn::data::EID &source, const dtn::data::StatusReportBlock &report) noexcept
 		{
 			ibrcommon::MutexLock l(_cb_mutex);
 			if (_session_cb == NULL) return;
 			_session_cb->notifyStatusReport(source, report);
 		}
 
-		void NativeSession::fireNotificationCustodySignal(const dtn::data::EID &source, const dtn::data::CustodySignalBlock &custody) throw ()
+		void NativeSession::fireNotificationCustodySignal(const dtn::data::EID &source, const dtn::data::CustodySignalBlock &custody) noexcept
 		{
 			ibrcommon::MutexLock l(_cb_mutex);
 			if (_session_cb == NULL) return;
 			_session_cb->notifyCustodySignal(source, custody);
 		}
 
-		void NativeSession::setEndpoint(const std::string &suffix) throw (NativeSessionException)
+		void NativeSession::setEndpoint(const std::string &suffix) noexcept (false)
 		{
 			// error checking
 			if (suffix.length() <= 0)
@@ -132,7 +132,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Endpoint set to " << _endpoint.getString() << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::resetEndpoint() throw ()
+		void NativeSession::resetEndpoint() noexcept
 		{
 			_registration.unsubscribe(_endpoint);
 			_endpoint = _registration.getDefaultEID();
@@ -141,7 +141,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Endpoint set to " << _endpoint.getString() << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::addEndpoint(const std::string &suffix) throw (NativeSessionException)
+		void NativeSession::addEndpoint(const std::string &suffix) noexcept (false)
 		{
 			// error checking
 			if (suffix.length() <= 0)
@@ -158,7 +158,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Endpoint " << suffix << " added" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::removeEndpoint(const std::string &suffix) throw (NativeSessionException)
+		void NativeSession::removeEndpoint(const std::string &suffix) noexcept (false)
 		{
 			// error checking
 			if (suffix.length() <= 0)
@@ -175,7 +175,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Endpoint " << suffix << " removed" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::addRegistration(const dtn::data::EID &eid) throw (NativeSessionException)
+		void NativeSession::addRegistration(const dtn::data::EID &eid) noexcept (false)
 		{
 			// error checking
 			if (eid == dtn::data::EID())
@@ -190,7 +190,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Registration " << eid.getString() << " added" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::removeRegistration(const dtn::data::EID &eid) throw (NativeSessionException)
+		void NativeSession::removeRegistration(const dtn::data::EID &eid) noexcept (false)
 		{
 			// error checking
 			if (eid == dtn::data::EID())
@@ -205,7 +205,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Registration " << eid.getString() << " removed" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::clearRegistration() throw ()
+		void NativeSession::clearRegistration() noexcept
 		{
 			resetEndpoint();
 
@@ -220,7 +220,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 20) << "Registrations cleared" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		std::vector<std::string> NativeSession::getSubscriptions() throw ()
+		std::vector<std::string> NativeSession::getSubscriptions() noexcept
 		{
 			const std::set<dtn::data::EID> subs = _registration.getSubscriptions();
 			std::vector<std::string> ret;
@@ -230,7 +230,7 @@ namespace dtn
 			return ret;
 		}
 
-		void NativeSession::next(RegisterIndex ri) throw (BundleNotFoundException)
+		void NativeSession::next(RegisterIndex ri) noexcept (false)
 		{
 			try {
 				const dtn::data::BundleID id = _bundle_queue.take();
@@ -244,7 +244,7 @@ namespace dtn
 			}
 		}
 
-		void NativeSession::load(RegisterIndex ri, const dtn::data::BundleID &id) throw (BundleNotFoundException)
+		void NativeSession::load(RegisterIndex ri, const dtn::data::BundleID &id) noexcept (false)
 		{
 			// load the bundle
 			try {
@@ -266,7 +266,7 @@ namespace dtn
 			}
 		}
 
-		void NativeSession::get(RegisterIndex ri) throw ()
+		void NativeSession::get(RegisterIndex ri) noexcept
 		{
 			ibrcommon::MutexLock l(_cb_mutex);
 			if (_serializer_cb == NULL) return;
@@ -279,7 +279,7 @@ namespace dtn
 			}
 		}
 
-		void NativeSession::getInfo(RegisterIndex ri) throw ()
+		void NativeSession::getInfo(RegisterIndex ri) noexcept
 		{
 			ibrcommon::MutexLock l(_cb_mutex);
 			if (_serializer_cb == NULL) return;
@@ -292,7 +292,7 @@ namespace dtn
 			}
 		}
 
-		void NativeSession::free(RegisterIndex ri) throw (BundleNotFoundException)
+		void NativeSession::free(RegisterIndex ri) noexcept (false)
 		{
 			try {
 				dtn::core::BundleCore::getInstance().getStorage().remove(_bundle[ri]);
@@ -302,12 +302,12 @@ namespace dtn
 			}
 		}
 
-		void NativeSession::clear(RegisterIndex ri) throw ()
+		void NativeSession::clear(RegisterIndex ri) noexcept
 		{
 			_bundle[ri] = dtn::data::Bundle();
 		}
 
-		void NativeSession::delivered(const dtn::data::BundleID &id) const throw (BundleNotFoundException)
+		void NativeSession::delivered(const dtn::data::BundleID &id) const noexcept (false)
 		{
 			try {
 				// announce this bundle as delivered
@@ -320,7 +320,7 @@ namespace dtn
 			}
 		}
 
-		dtn::data::BundleID NativeSession::send(RegisterIndex ri) throw ()
+		dtn::data::BundleID NativeSession::send(RegisterIndex ri) noexcept
 		{
 			// forward the bundle to the storage processing
 			dtn::api::Registration::processIncomingBundle(_endpoint, _bundle[ri]);
@@ -330,13 +330,13 @@ namespace dtn
 			return _bundle[ri];
 		}
 
-		void NativeSession::put(RegisterIndex ri, const dtn::data::Bundle &b) throw ()
+		void NativeSession::put(RegisterIndex ri, const dtn::data::Bundle &b) noexcept
 		{
 			// Copy the given bundle into the local register
 			_bundle[ri] = b;
 		}
 
-		void NativeSession::put(RegisterIndex ri, const dtn::data::PrimaryBlock &p) throw ()
+		void NativeSession::put(RegisterIndex ri, const dtn::data::PrimaryBlock &p) noexcept
 		{
 			// clear all blocks in the register
 			_bundle[ri].clear();
@@ -345,7 +345,7 @@ namespace dtn
 			((dtn::data::PrimaryBlock&)_bundle[ri]) = p;
 		}
 
-		void NativeSession::write(RegisterIndex ri, const char *buf, const size_t len, const size_t offset) throw ()
+		void NativeSession::write(RegisterIndex ri, const char *buf, const size_t len, const size_t offset) noexcept
 		{
 			try {
 				dtn::data::PayloadBlock &payload = _bundle[ri].find<dtn::data::PayloadBlock>();
@@ -383,7 +383,7 @@ namespace dtn
 			IBRCOMMON_LOGGER_DEBUG_TAG(NativeSession::TAG, 25) << len << " bytes added to the payload" << IBRCOMMON_LOGGER_ENDL;
 		}
 
-		void NativeSession::read(RegisterIndex ri, char *buf, size_t &len, const size_t offset) throw ()
+		void NativeSession::read(RegisterIndex ri, char *buf, size_t &len, const size_t offset) noexcept
 		{
 			try {
 				dtn::data::PayloadBlock &payload = _bundle[ri].find<dtn::data::PayloadBlock>();
@@ -410,7 +410,7 @@ namespace dtn
 		{
 		}
 
-		void NativeSession::BundleReceiver::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void NativeSession::BundleReceiver::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			// ignore fragments - we can not deliver them directly to the client
 			if (queued.bundle.isFragment()) return;
@@ -421,7 +421,7 @@ namespace dtn
 			}
 		}
 
-		void NativeSession::receive() throw (NativeSessionException)
+		void NativeSession::receive() noexcept (false)
 		{
 			Registration &reg = _registration;
 			try {

--- a/ibrdtn/daemon/src/api/NativeSession.h
+++ b/ibrdtn/daemon/src/api/NativeSession.h
@@ -42,7 +42,7 @@ namespace dtn
 		class NativeSessionException : public ibrcommon::Exception
 		{
 		public:
-			NativeSessionException(string what = "An error happened.") throw() : ibrcommon::Exception(what)
+			NativeSessionException(string what = "An error happened.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -50,7 +50,7 @@ namespace dtn
 		class BundleNotFoundException : public ibrcommon::Exception
 		{
 		public:
-			BundleNotFoundException(string what = "Bundle not found.") throw() : ibrcommon::Exception(what)
+			BundleNotFoundException(string what = "Bundle not found.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -67,19 +67,19 @@ namespace dtn
 			 * in the registration. Then this bundle may loaded into the
 			 * local register using the load() method.
 			 */
-			virtual void notifyBundle(const dtn::data::BundleID &id) throw () = 0;
+			virtual void notifyBundle(const dtn::data::BundleID &id) noexcept = 0;
 
 			/**
 			 * Notifies the session callback if a new status report has
 			 * been received.
 			 */
-			virtual void notifyStatusReport(const dtn::data::EID &source, const dtn::data::StatusReportBlock &report) throw () = 0;
+			virtual void notifyStatusReport(const dtn::data::EID &source, const dtn::data::StatusReportBlock &report) noexcept = 0;
 
 			/**
 			 * Notifies the session callback if a new custody signal has
 			 * been received.
 			 */
-			virtual void notifyCustodySignal(const dtn::data::EID &source, const dtn::data::CustodySignalBlock &custody) throw () = 0;
+			virtual void notifyCustodySignal(const dtn::data::EID &source, const dtn::data::CustodySignalBlock &custody) noexcept = 0;
 		};
 
 		class NativeSession {
@@ -112,106 +112,106 @@ namespace dtn
 			 * Destroy this session and block until
 			 * this process is done
 			 */
-			void destroy() throw ();
+			void destroy() noexcept;
 
 			/**
 			 * Returns the node EID of this device
 			 */
-			const dtn::data::EID& getNodeEID() const throw ();
+			const dtn::data::EID& getNodeEID() const noexcept;
 
 			/**
 			 * Set the default application endpoint suffix of this
 			 * registration
 			 */
-			void setEndpoint(const std::string &suffix) throw (NativeSessionException);
+			void setEndpoint(const std::string &suffix) noexcept (false);
 
 			/**
 			 * Resets the default endpoint to the unique registration
 			 * identifier
 			 */
-			void resetEndpoint() throw ();
+			void resetEndpoint() noexcept;
 
 			/**
 			 * Add an application endpoint suffix to the registration
 			 */
-			void addEndpoint(const std::string &suffix) throw (NativeSessionException);
+			void addEndpoint(const std::string &suffix) noexcept (false);
 
 			/**
 			 * Remove an application endpoint suffix from the registration
 			 */
-			void removeEndpoint(const std::string &suffix) throw (NativeSessionException);
+			void removeEndpoint(const std::string &suffix) noexcept (false);
 
 			/**
 			 * Add an endpoint identifier to the registration
 			 * (commonly used for group endpoints)
 			 */
-			void addRegistration(const dtn::data::EID &eid) throw (NativeSessionException);
+			void addRegistration(const dtn::data::EID &eid) noexcept (false);
 
 			/**
 			 * Remove an endpoint identifier from the registration
 			 */
-			void removeRegistration(const dtn::data::EID &eid) throw (NativeSessionException);
+			void removeRegistration(const dtn::data::EID &eid) noexcept (false);
 
 			/**
 			 * Removes all registrations and reset the default endpoint to the unique registration identifier
 			 */
-			void clearRegistration() throw ();
+			void clearRegistration() noexcept;
 
 			/**
 			 * Retrieve all registered endpoints
 			 */
-			std::vector<std::string> getSubscriptions() throw ();
+			std::vector<std::string> getSubscriptions() noexcept;
 
 			/**
 			 * Loads the next bundle in the queue into the local
 			 * register
 			 */
-			void next(RegisterIndex ri) throw (BundleNotFoundException);
+			void next(RegisterIndex ri) noexcept (false);
 
 			/**
 			 * Load a bundle into the local register
 			 */
-			void load(RegisterIndex ri, const dtn::data::BundleID &id) throw (BundleNotFoundException);
+			void load(RegisterIndex ri, const dtn::data::BundleID &id) noexcept (false);
 
 			/**
 			 * Return the bundle in the register using the given callback
 			 */
-			void get(RegisterIndex ri) throw ();
+			void get(RegisterIndex ri) noexcept;
 
 			/**
 			 * Return the bundle skeleton in the register using the given callback
 			 */
-			void getInfo(RegisterIndex ri) throw ();
+			void getInfo(RegisterIndex ri) noexcept;
 
 			/**
 			 * Delete the bundle in the local register from the storage
 			 */
-			void free(RegisterIndex ri) throw (BundleNotFoundException);
+			void free(RegisterIndex ri) noexcept (false);
 
 			/**
 			 * Clear the local register
 			 */
-			void clear(RegisterIndex ri) throw ();
+			void clear(RegisterIndex ri) noexcept;
 
 			/**
 			 * Mark the bundle with the given ID as delivered.
 			 */
-			void delivered(const dtn::data::BundleID &id) const throw (BundleNotFoundException);
+			void delivered(const dtn::data::BundleID &id) const noexcept (false);
 
 			/**
 			 * Send the bundle in the local register
 			 */
-			dtn::data::BundleID send(RegisterIndex ri) throw ();
+			dtn::data::BundleID send(RegisterIndex ri) noexcept;
 
 			/**
 			 * Copy the given bundle into the local register
 			 */
-			void put(RegisterIndex ri, const dtn::data::Bundle &b) throw ();
+			void put(RegisterIndex ri, const dtn::data::Bundle &b) noexcept;
 
 			/**
 			 * Copy the PrimaryBlock into the local register
 			 */
-			void put(RegisterIndex ri, const dtn::data::PrimaryBlock &b) throw ();
+			void put(RegisterIndex ri, const dtn::data::PrimaryBlock &b) noexcept;
 
 			/**
 			 * Write byte into the payload block of the bundle in the
@@ -222,7 +222,7 @@ namespace dtn
 			 * @param len The number of bytes to copy.
 			 * @param offset Start here to write.
 			 */
-			void write(RegisterIndex ri, const char *buf, const size_t len, const size_t offset = std::string::npos) throw ();
+			void write(RegisterIndex ri, const char *buf, const size_t len, const size_t offset = std::string::npos) noexcept;
 
 			/**
 			 * Read max. <len> bytes from the payload block in the bundle. If there
@@ -233,13 +233,13 @@ namespace dtn
 			 * @param len The size of the buf array. After the call it contains the number of bytes in the buffer.
 			 * @param offset Start here to read.
 			 */
-			void read(RegisterIndex ri, char *buf, size_t &len, const size_t offset = 0) throw ();
+			void read(RegisterIndex ri, char *buf, size_t &len, const size_t offset = 0) noexcept;
 
 			/**
 			 * Receives one bundle and returns. If there is no bundle this call will
 			 * block until a bundle is available or destroy() has been called.
 			 */
-			void receive() throw (NativeSessionException);
+			void receive() noexcept (false);
 
 			/**
 			 * Return the handle of this session
@@ -256,7 +256,7 @@ namespace dtn
 				BundleReceiver(NativeSession &session);
 				virtual ~BundleReceiver();
 
-				void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
+				void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
 
 			private:
 				NativeSession &_session;
@@ -265,7 +265,7 @@ namespace dtn
 			/**
 			 * Push out an notification to the native session callback.
 			 */
-			void fireNotificationBundle(const dtn::data::BundleID &id) throw ();
+			void fireNotificationBundle(const dtn::data::BundleID &id) noexcept;
 
 			/**
 			 * Push out an notification to the native session callback.
@@ -275,12 +275,12 @@ namespace dtn
 			/**
 			 * Push out an notification to the native session callback.
 			 */
-			void fireNotificationStatusReport(const dtn::data::EID &source, const dtn::data::StatusReportBlock &report) throw ();
+			void fireNotificationStatusReport(const dtn::data::EID &source, const dtn::data::StatusReportBlock &report) noexcept;
 
 			/**
 			 * Push out an notification to the native session callback.
 			 */
-			void fireNotificationCustodySignal(const dtn::data::EID &source, const dtn::data::CustodySignalBlock &custody) throw ();
+			void fireNotificationCustodySignal(const dtn::data::EID &source, const dtn::data::CustodySignalBlock &custody) noexcept;
 
 			// callback
 			ibrcommon::RWMutex _cb_mutex;

--- a/ibrdtn/daemon/src/api/OrderedStreamHandler.cpp
+++ b/ibrdtn/daemon/src/api/OrderedStreamHandler.cpp
@@ -109,7 +109,7 @@ namespace dtn
 			return bundle;
 		}
 
-		void OrderedStreamHandler::__cancellation() throw ()
+		void OrderedStreamHandler::__cancellation() noexcept
 		{
 			// close the stream
 			_stream.close();
@@ -242,18 +242,18 @@ namespace dtn
 			ibrcommon::JoinableThread::join();
 		}
 
-		void OrderedStreamHandler::Sender::__cancellation() throw ()
+		void OrderedStreamHandler::Sender::__cancellation() noexcept
 		{
 			// cancel the main thread in here
 			_handler._client.getRegistration().abort();
 		}
 
-		void OrderedStreamHandler::Sender::finally() throw ()
+		void OrderedStreamHandler::Sender::finally() noexcept
 		{
 			_handler._client.getRegistration().abort();
 		}
 
-		void OrderedStreamHandler::Sender::run() throw ()
+		void OrderedStreamHandler::Sender::run() noexcept
 		{
 			try {
 				_handler._stream << _handler._bundlestream.rdbuf() << std::flush;

--- a/ibrdtn/daemon/src/api/OrderedStreamHandler.h
+++ b/ibrdtn/daemon/src/api/OrderedStreamHandler.h
@@ -40,7 +40,7 @@ namespace dtn
 
 			virtual void run();
 			virtual void finally();
-			virtual void __cancellation() throw ();
+			virtual void __cancellation() noexcept;
 
 			virtual void put(dtn::data::Bundle &b);
 			virtual dtn::data::MetaBundle get(const dtn::data::Timeout timeout = 0);
@@ -54,9 +54,9 @@ namespace dtn
 				virtual ~Sender();
 
 			protected:
-				void run() throw ();
-				void finally() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void finally() noexcept;
+				void __cancellation() noexcept;
 
 			private:
 				OrderedStreamHandler &_handler;

--- a/ibrdtn/daemon/src/api/Registration.cpp
+++ b/ibrdtn/daemon/src/api/Registration.cpp
@@ -171,7 +171,7 @@ namespace dtn
 			}
 		}
 
-		dtn::data::Bundle Registration::receive() throw (dtn::storage::NoBundleFoundException)
+		dtn::data::Bundle Registration::receive() noexcept (false)
 		{
 			// get the global storage
 			dtn::storage::BundleStorage &storage = dtn::core::BundleCore::getInstance().getStorage();
@@ -183,7 +183,7 @@ namespace dtn
 			return storage.get(b);
 		}
 
-		dtn::data::MetaBundle Registration::receiveMetaBundle() throw (dtn::storage::NoBundleFoundException)
+		dtn::data::MetaBundle Registration::receiveMetaBundle() noexcept (false)
 		{
 			ibrcommon::MutexLock l(_receive_lock);
 
@@ -232,9 +232,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return dtn::core::BundleCore::max_bundles_in_transit; };
+				virtual dtn::data::Size limit() const noexcept { return dtn::core::BundleCore::max_bundles_in_transit; };
 
-				virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// filter fragments if requested
 					if (meta.isFragment() && _fragment_filter)
@@ -267,7 +267,7 @@ namespace dtn
 				};
 
 #ifdef HAVE_SQLITE
-				const std::string getWhere() const throw ()
+				const std::string getWhere() const noexcept
 				{
 					if (_endpoints.size() > 1)
 					{
@@ -290,7 +290,7 @@ namespace dtn
 					}
 				};
 
-				int bind(sqlite3_stmt *st, int offset) const throw ()
+				int bind(sqlite3_stmt *st, int offset) const noexcept
 				{
 					int o = offset;
 
@@ -332,7 +332,7 @@ namespace dtn
 		{
 		}
 
-		void Registration::RegistrationQueue::put(const dtn::data::MetaBundle &bundle) throw ()
+		void Registration::RegistrationQueue::put(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			try {
 				_queue.push(bundle);
@@ -344,29 +344,29 @@ namespace dtn
 			} catch (const ibrcommon::Exception&) { }
 		}
 
-		dtn::data::MetaBundle Registration::RegistrationQueue::pop() throw (const ibrcommon::QueueUnblockedException)
+		dtn::data::MetaBundle Registration::RegistrationQueue::pop() noexcept (false)
 		{
 			return _queue.take();
 		}
 
-		bool Registration::RegistrationQueue::has(const dtn::data::BundleID &bundle) const throw ()
+		bool Registration::RegistrationQueue::has(const dtn::data::BundleID &bundle) const noexcept
 		{
 			ibrcommon::MutexLock l(const_cast<ibrcommon::Mutex&>(_lock));
 			return _recv_bundles.has(bundle);
 		}
 
-		void Registration::RegistrationQueue::expire(const dtn::data::Timestamp &timestamp) throw ()
+		void Registration::RegistrationQueue::expire(const dtn::data::Timestamp &timestamp) noexcept
 		{
 			ibrcommon::MutexLock l(_lock);
 			_recv_bundles.expire(timestamp);
 		}
 
-		void Registration::RegistrationQueue::abort() throw ()
+		void Registration::RegistrationQueue::abort() noexcept
 		{
 			_queue.abort();
 		}
 
-		void Registration::RegistrationQueue::reset() throw ()
+		void Registration::RegistrationQueue::reset() noexcept
 		{
 			_queue.reset();
 		}

--- a/ibrdtn/daemon/src/api/Registration.h
+++ b/ibrdtn/daemon/src/api/Registration.h
@@ -52,7 +52,7 @@ namespace dtn
 			class RegistrationException : public ibrcommon::Exception
 			{
 			public:
-				RegistrationException(string what = "") throw() : Exception(what)
+				RegistrationException(string what = "") noexcept : Exception(what)
 				{
 				}
 			};
@@ -60,7 +60,7 @@ namespace dtn
 			class AlreadyAttachedException : public RegistrationException
 			{
 			public:
-				AlreadyAttachedException(string what = "") throw() : RegistrationException(what)
+				AlreadyAttachedException(string what = "") noexcept : RegistrationException(what)
 				{
 				}
 			};
@@ -68,7 +68,7 @@ namespace dtn
 			class NotFoundException : public RegistrationException
 			{
 			public:
-				NotFoundException(string what = "") throw() : RegistrationException(what)
+				NotFoundException(string what = "") noexcept : RegistrationException(what)
 				{
 				}
 			};
@@ -76,7 +76,7 @@ namespace dtn
 			class NotPersistentException : public RegistrationException
 			{
 			public:
-				NotPersistentException(string what = "") throw() : RegistrationException(what)
+				NotPersistentException(string what = "") noexcept : RegistrationException(what)
 				{
 				}
 			};
@@ -156,9 +156,9 @@ namespace dtn
 			 * and the queue is empty an exception is thrown.
 			 * @return
 			 */
-			dtn::data::Bundle receive() throw (dtn::storage::NoBundleFoundException);
+			dtn::data::Bundle receive() noexcept (false);
 
-			dtn::data::MetaBundle receiveMetaBundle() throw (dtn::storage::NoBundleFoundException);
+			dtn::data::MetaBundle receiveMetaBundle() noexcept (false);
 
 			/**
 			 * notify a bundle as delivered (and delete it if singleton destination)
@@ -263,34 +263,34 @@ namespace dtn
 				 * This method is used by the storage.
 				 * @see dtn::storage::BundleResult::put()
 				 */
-				virtual void put(const dtn::data::MetaBundle &bundle) throw ();
+				virtual void put(const dtn::data::MetaBundle &bundle) noexcept;
 
 				/**
 				 * Get the next bundle of the queue.
 				 * An exception is thrown if the queue is empty or the queue has been aborted
 				 * before.
 				 */
-				dtn::data::MetaBundle pop() throw (const ibrcommon::QueueUnblockedException);
+				dtn::data::MetaBundle pop() noexcept (false);
 
 				/**
 				 * Expire bundles in the received bundle set
 				 */
-				void expire(const dtn::data::Timestamp &timestamp) throw ();
+				void expire(const dtn::data::Timestamp &timestamp) noexcept;
 
 				/**
 				 * Abort all blocking call on the queue
 				 */
-				void abort() throw ();
+				void abort() noexcept;
 
 				/**
 				 * Reset the queue state. If called, blocking calls are allowed again.
 				 */
-				void reset() throw ();
+				void reset() noexcept;
 
 				/**
 				 * Check if a bundle has been received before
 				 */
-				bool has(const dtn::data::BundleID &bundle) const throw ();
+				bool has(const dtn::data::BundleID &bundle) const noexcept;
 
 			private:
 				// protect variables against concurrent altering

--- a/ibrdtn/daemon/src/core/AbstractWorker.cpp
+++ b/ibrdtn/daemon/src/core/AbstractWorker.cpp
@@ -45,7 +45,7 @@ namespace dtn
 			shutdown();
 		}
 
-		void AbstractWorker::AbstractWorkerAsync::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void AbstractWorker::AbstractWorkerAsync::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			// ignore fragments - we can not deliver them directly to the client
 			if (queued.bundle.isFragment()) return;
@@ -89,7 +89,7 @@ namespace dtn
 			join();
 		}
 
-		void AbstractWorker::AbstractWorkerAsync::run() throw ()
+		void AbstractWorker::AbstractWorkerAsync::run() noexcept
 		{
 			dtn::storage::BundleStorage &storage = BundleCore::getInstance().getStorage();
 
@@ -135,7 +135,7 @@ namespace dtn
 			}
 		}
 
-		void AbstractWorker::AbstractWorkerAsync::__cancellation() throw ()
+		void AbstractWorker::AbstractWorkerAsync::__cancellation() noexcept
 		{
 			// cancel the main thread in here
 			_receive_bundles.abort();

--- a/ibrdtn/daemon/src/core/AbstractWorker.h
+++ b/ibrdtn/daemon/src/core/AbstractWorker.h
@@ -52,11 +52,11 @@ namespace dtn
 				void initialize();
 				void shutdown();
 
-				virtual void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
+				virtual void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
 
 			protected:
-				void run() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void __cancellation() noexcept;
 
 			private:
 				AbstractWorker &_worker;

--- a/ibrdtn/daemon/src/core/BundleCore.cpp
+++ b/ibrdtn/daemon/src/core/BundleCore.cpp
@@ -102,9 +102,9 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::net::TransferAbortedEvent>::remove(this);
 		}
 
-		void BundleCore::componentUp() throw ()
+		void BundleCore::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			onConfigurationChanged(dtn::daemon::Configuration::getInstance());
 
 			// initialize connection manager
@@ -123,7 +123,7 @@ namespace dtn
 			_disco_agent.startup();
 		}
 
-		void BundleCore::componentDown() throw ()
+		void BundleCore::componentDown() noexcept
 		{
 			ibrcommon::LinkManager::getInstance().removeEventListener(this);
 
@@ -137,7 +137,7 @@ namespace dtn
 			_clock.terminate();
 		}
 
-		void BundleCore::onConfigurationChanged(const dtn::daemon::Configuration &config) throw ()
+		void BundleCore::onConfigurationChanged(const dtn::daemon::Configuration &config) noexcept
 		{
 			// set local eid
 			dtn::core::BundleCore::local = config.getNodename();
@@ -282,7 +282,7 @@ namespace dtn
 			return _globally_connected;
 		}
 
-		void BundleCore::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void BundleCore::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			try {
 				// get reference to the meta data of the bundle
@@ -341,7 +341,7 @@ namespace dtn
 			}
 		}
 
-		void BundleCore::raiseEvent(const dtn::net::TransferCompletedEvent &completed) throw ()
+		void BundleCore::raiseEvent(const dtn::net::TransferCompletedEvent &completed) noexcept
 		{
 			const dtn::data::MetaBundle &meta = completed.getBundle();
 			const dtn::data::EID &peer = completed.getPeer();
@@ -360,7 +360,7 @@ namespace dtn
 			}
 		}
 
-		void BundleCore::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) throw ()
+		void BundleCore::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) noexcept
 		{
 			if (aborted.reason != dtn::net::TransferAbortedEvent::REASON_REFUSED) return;
 
@@ -382,7 +382,7 @@ namespace dtn
 			} catch (const dtn::storage::NoBundleFoundException&) { };
 		}
 
-		void BundleCore::raiseEvent(const dtn::core::BundlePurgeEvent &purge) throw ()
+		void BundleCore::raiseEvent(const dtn::core::BundlePurgeEvent &purge) noexcept
 		{
 			// get the global storage
 			dtn::storage::BundleStorage &storage = dtn::core::BundleCore::getInstance().getStorage();
@@ -393,7 +393,7 @@ namespace dtn
 			} catch (const dtn::storage::NoBundleFoundException&) { };
 		}
 
-		void BundleCore::validate(const dtn::data::MetaBundle &obj) const throw (dtn::data::Validator::RejectedException)
+		void BundleCore::validate(const dtn::data::MetaBundle &obj) const noexcept (false)
 		{
 			if (dtn::utils::Clock::isExpired(obj)) {
 				// ... bundle is expired
@@ -435,7 +435,7 @@ namespace dtn
 				throw dtn::data::Validator::RejectedException("rejected by filter");
 		}
 
-		void BundleCore::validate(const dtn::data::PrimaryBlock &p) const throw (dtn::data::Validator::RejectedException)
+		void BundleCore::validate(const dtn::data::PrimaryBlock &p) const noexcept (false)
 		{
 			// check if the bundle is expired
 			if (dtn::utils::Clock::isExpired(p.timestamp, p.lifetime))
@@ -495,7 +495,7 @@ namespace dtn
 				throw dtn::data::Validator::RejectedException("rejected by filter");
 		}
 
-		void BundleCore::validate(const dtn::data::Block& block, const dtn::data::Number& size) const throw (dtn::data::Validator::RejectedException)
+		void BundleCore::validate(const dtn::data::Block& block, const dtn::data::Number& size) const noexcept (false)
 		{
 			// check for the size of the block
 			// reject a block if it exceeds the payload limit
@@ -514,7 +514,7 @@ namespace dtn
 				throw dtn::data::Validator::RejectedException("rejected by filter");
 		}
 
-		void BundleCore::validate(const dtn::data::PrimaryBlock &bundle, const dtn::data::Block& block, const dtn::data::Number& size) const throw (RejectedException)
+		void BundleCore::validate(const dtn::data::PrimaryBlock &bundle, const dtn::data::Block& block, const dtn::data::Number& size) const noexcept (false)
 		{
 			// check for the size of the foreign block
 			// reject a block if it exceeds the payload limit
@@ -550,7 +550,7 @@ namespace dtn
 				throw dtn::data::Validator::RejectedException("rejected by filter");
 		}
 
-		void BundleCore::validate(const dtn::data::Bundle &b) const throw (dtn::data::Validator::RejectedException)
+		void BundleCore::validate(const dtn::data::Bundle &b) const noexcept (false)
 		{
 			// reject bundles without destination
 			if (b.destination.isNone())
@@ -800,7 +800,7 @@ namespace dtn
 			_globally_connected = val;
 		}
 
-		void BundleCore::check_connection_state() throw ()
+		void BundleCore::check_connection_state() noexcept
 		{
 			const std::set<ibrcommon::vinterface> &global_nets = dtn::daemon::Configuration::getInstance().getNetwork().getInternetDevices();
 
@@ -817,7 +817,7 @@ namespace dtn
 			}
 		}
 
-		void BundleCore::reload_filter_tables() throw ()
+		void BundleCore::reload_filter_tables() noexcept
 		{
 			ibrcommon::RWLock l(_filter_mutex);
 

--- a/ibrdtn/daemon/src/core/BundleCore.h
+++ b/ibrdtn/daemon/src/core/BundleCore.h
@@ -61,7 +61,7 @@ namespace dtn
 		class P2PDialupException : public ibrcommon::Exception
 		{
 			public:
-				P2PDialupException(string what = "No path known except of dial-up connections.") throw() : Exception(what)
+				P2PDialupException(string what = "No path known except of dial-up connections.") noexcept : Exception(what)
 				{
 				};
 		};
@@ -82,7 +82,7 @@ namespace dtn
 
 			WallClock& getClock();
 
-			virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) throw ();
+			virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) noexcept;
 
 			void setStorage(dtn::storage::BundleStorage *storage);
 			dtn::storage::BundleStorage& getStorage();
@@ -125,16 +125,16 @@ namespace dtn
 			 */
 			bool isGloballyConnected() const;
 
-			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
-			void raiseEvent(const dtn::core::BundlePurgeEvent &evt) throw ();
-			void raiseEvent(const dtn::net::TransferCompletedEvent &evt) throw ();
-			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) throw ();
+			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::BundlePurgeEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::TransferCompletedEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) noexcept;
 
-			virtual void validate(const dtn::data::PrimaryBlock &obj) const throw (RejectedException);
-			virtual void validate(const dtn::data::Block &obj, const dtn::data::Number&) const throw (RejectedException);
-			virtual void validate(const dtn::data::PrimaryBlock &bundle, const dtn::data::Block &obj, const dtn::data::Number&) const throw (RejectedException);
-			virtual void validate(const dtn::data::Bundle &obj) const throw (RejectedException);
-			virtual void validate(const dtn::data::MetaBundle &obj) const throw (RejectedException);
+			virtual void validate(const dtn::data::PrimaryBlock &obj) const noexcept (false);
+			virtual void validate(const dtn::data::Block &obj, const dtn::data::Number&) const noexcept (false);
+			virtual void validate(const dtn::data::PrimaryBlock &bundle, const dtn::data::Block &obj, const dtn::data::Number&) const noexcept (false);
+			virtual void validate(const dtn::data::Bundle &obj) const noexcept (false);
+			virtual void validate(const dtn::data::MetaBundle &obj) const noexcept (false);
 
 			/**
 			 * Pass a bundle with a context through the desired table. The bundle may be modified during
@@ -195,8 +195,8 @@ namespace dtn
 			static void inject(const dtn::data::EID &source, dtn::data::Bundle &bundle);
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 		private:
 			/**
@@ -212,12 +212,12 @@ namespace dtn
 			/**
 			 * Check if we are connected to the internet.
 			 */
-			void check_connection_state() throw ();
+			void check_connection_state() noexcept;
 
 			/**
 			 * reload filtering tables
 			 */
-			void reload_filter_tables() throw ();
+			void reload_filter_tables() noexcept;
 
 			/**
 			 * Forbidden copy constructor

--- a/ibrdtn/daemon/src/core/BundleFilter.cpp
+++ b/ibrdtn/daemon/src/core/BundleFilter.cpp
@@ -42,7 +42,7 @@ namespace dtn
 			_metabundle = &data;
 		}
 
-		const dtn::data::MetaBundle& FilterContext::getMetaBundle() const throw (FilterException)
+		const dtn::data::MetaBundle& FilterContext::getMetaBundle() const noexcept (false)
 		{
 			if (_metabundle == NULL) throw FilterException("attribute not present in this context");
 			return *_metabundle;
@@ -54,13 +54,13 @@ namespace dtn
 			_primaryblock = &data;
 		}
 
-		const dtn::data::Bundle& FilterContext::getBundle() const throw (FilterException)
+		const dtn::data::Bundle& FilterContext::getBundle() const noexcept (false)
 		{
 			if (_bundle == NULL) throw FilterException("attribute not present in this context");
 			return *_bundle;
 		}
 
-		const dtn::data::BundleID& FilterContext::getBundleID() const throw (FilterException)
+		const dtn::data::BundleID& FilterContext::getBundleID() const noexcept (false)
 		{
 			if (_metabundle != NULL) return *_metabundle;
 			if (_primaryblock != NULL) return *_primaryblock;
@@ -72,7 +72,7 @@ namespace dtn
 			_primaryblock = &data;
 		}
 
-		const dtn::data::PrimaryBlock& FilterContext::getPrimaryBlock() const throw (FilterException)
+		const dtn::data::PrimaryBlock& FilterContext::getPrimaryBlock() const noexcept (false)
 		{
 			if (_primaryblock == NULL) throw FilterException("attribute not present in this context");
 			return *_primaryblock;
@@ -84,13 +84,13 @@ namespace dtn
 			_block_length = size;
 		}
 
-		const dtn::data::Block& FilterContext::getBlock() const throw (FilterException)
+		const dtn::data::Block& FilterContext::getBlock() const noexcept (false)
 		{
 			if (_block == NULL) throw FilterException("attribute not present in this context");
 			return *_block;
 		}
 
-		dtn::data::Number FilterContext::getBlockLength() const throw (FilterException)
+		dtn::data::Number FilterContext::getBlockLength() const noexcept (false)
 		{
 			if (_block == NULL) throw FilterException("attribute not present in this context");
 			return _block_length;
@@ -101,7 +101,7 @@ namespace dtn
 			_peer = &endpoint;
 		}
 
-		const dtn::data::EID& FilterContext::setPeer() const throw (FilterException)
+		const dtn::data::EID& FilterContext::setPeer() const noexcept (false)
 		{
 			if (_peer == NULL) throw FilterException("attribute not present in this context");
 			return *_peer;
@@ -112,7 +112,7 @@ namespace dtn
 			_protocol = protocol;
 		}
 
-		dtn::core::Node::Protocol FilterContext::getProtocol() const throw (FilterException)
+		dtn::core::Node::Protocol FilterContext::getProtocol() const noexcept (false)
 		{
 			if (_protocol == dtn::core::Node::CONN_UNDEFINED) throw FilterException("attribute not present in this context");
 			return _protocol;
@@ -123,7 +123,7 @@ namespace dtn
 			_routing = &routing;
 		}
 
-		const std::string FilterContext::getRoutingTag() const throw (FilterException)
+		const std::string FilterContext::getRoutingTag() const noexcept (false)
 		{
 			if (_routing == NULL) throw FilterException("attribute not present in this context");
 			return _routing->getTag();
@@ -149,12 +149,12 @@ namespace dtn
 			return this;
 		}
 
-		BundleFilter::ACTION BundleFilter::evaluate(const FilterContext &context) const throw ()
+		BundleFilter::ACTION BundleFilter::evaluate(const FilterContext &context) const noexcept
 		{
 			return (_next == NULL) ? BundleFilter::PASS : _next->evaluate(context);
 		}
 
-		BundleFilter::ACTION BundleFilter::filter(const FilterContext &context, dtn::data::Bundle &bundle) const throw ()
+		BundleFilter::ACTION BundleFilter::filter(const FilterContext &context, dtn::data::Bundle &bundle) const noexcept
 		{
 			return (_next == NULL) ? BundleFilter::PASS : _next->filter(context, bundle);
 		}

--- a/ibrdtn/daemon/src/core/BundleFilter.h
+++ b/ibrdtn/daemon/src/core/BundleFilter.h
@@ -37,7 +37,7 @@ namespace dtn
 		class FilterException : public ibrcommon::Exception
 		{
 		public:
-			FilterException(std::string what) throw () : ibrcommon::Exception(what)
+			FilterException(std::string what) noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -48,28 +48,28 @@ namespace dtn
 			virtual ~FilterContext();
 
 			void setMetaBundle(const dtn::data::MetaBundle &data);
-			const dtn::data::MetaBundle& getMetaBundle() const throw (FilterException);
+			const dtn::data::MetaBundle& getMetaBundle() const noexcept (false);
 
 			void setBundle(const dtn::data::Bundle &data);
-			const dtn::data::Bundle& getBundle() const throw (FilterException);
+			const dtn::data::Bundle& getBundle() const noexcept (false);
 
 			void setPrimaryBlock(const dtn::data::PrimaryBlock &data);
-			const dtn::data::PrimaryBlock& getPrimaryBlock() const throw (FilterException);
+			const dtn::data::PrimaryBlock& getPrimaryBlock() const noexcept (false);
 
-			const dtn::data::BundleID& getBundleID() const throw (FilterException);
+			const dtn::data::BundleID& getBundleID() const noexcept (false);
 
 			void setBlock(const dtn::data::Block &block, const dtn::data::Number &size);
-			const dtn::data::Block& getBlock() const throw (FilterException);
-			dtn::data::Number getBlockLength() const throw (FilterException);
+			const dtn::data::Block& getBlock() const noexcept (false);
+			dtn::data::Number getBlockLength() const noexcept (false);
 
 			void setPeer(const dtn::data::EID &endpoint);
-			const dtn::data::EID& setPeer() const throw (FilterException);
+			const dtn::data::EID& setPeer() const noexcept (false);
 
 			void setProtocol(const dtn::core::Node::Protocol &protocol);
-			dtn::core::Node::Protocol getProtocol() const throw (FilterException);
+			dtn::core::Node::Protocol getProtocol() const noexcept (false);
 
 			void setRouting(const dtn::routing::RoutingExtension &routing);
-			const std::string getRoutingTag() const throw (FilterException);
+			const std::string getRoutingTag() const noexcept (false);
 
 		private:
 			const dtn::data::MetaBundle *_metabundle;
@@ -104,13 +104,13 @@ namespace dtn
 			/**
 			 * Evaluates a context and results in ACCEPT, REJECT, or DROP directive
 			 */
-			virtual ACTION evaluate(const FilterContext &context) const throw ();
+			virtual ACTION evaluate(const FilterContext &context) const noexcept;
 
 			/**
 			 * Filters a bundle with a context. The bundle may be modified during
 			 * the processing.
 			 */
-			virtual ACTION filter(const FilterContext &context, dtn::data::Bundle &bundle) const throw ();
+			virtual ACTION filter(const FilterContext &context, dtn::data::Bundle &bundle) const noexcept;
 
 			/**
 			 * append a bundle filter at the end of the chain
@@ -125,24 +125,24 @@ namespace dtn
 		{
 		public:
 			virtual ~AcceptFilter() {};
-			virtual ACTION evaluate(const FilterContext&) const throw () { return ACCEPT; };
-			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const throw () { return ACCEPT; };
+			virtual ACTION evaluate(const FilterContext&) const noexcept { return ACCEPT; };
+			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const noexcept { return ACCEPT; };
 		};
 
 		class DropFilter : public BundleFilter
 		{
 		public:
 			virtual ~DropFilter() {};
-			virtual ACTION evaluate(const FilterContext&) const throw () { return DROP; };
-			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const throw () { return DROP; };
+			virtual ACTION evaluate(const FilterContext&) const noexcept { return DROP; };
+			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const noexcept { return DROP; };
 		};
 
 		class RejectFilter : public BundleFilter
 		{
 		public:
 			virtual ~RejectFilter() {};
-			virtual ACTION evaluate(const FilterContext&) const throw () { return REJECT; };
-			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const throw () { return REJECT; };
+			virtual ACTION evaluate(const FilterContext&) const noexcept { return REJECT; };
+			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const noexcept { return REJECT; };
 		};
 	} /* namespace core */
 } /* namespace dtn */

--- a/ibrdtn/daemon/src/core/BundleFilterTable.cpp
+++ b/ibrdtn/daemon/src/core/BundleFilterTable.cpp
@@ -64,7 +64,7 @@ namespace dtn
 			_chain.clear();
 		}
 
-		BundleFilter::ACTION BundleFilterTable::evaluate(const FilterContext &context) const throw ()
+		BundleFilter::ACTION BundleFilterTable::evaluate(const FilterContext &context) const noexcept
 		{
 			for (chain::const_iterator it = _chain.begin(); it != _chain.end(); ++it)
 			{
@@ -75,7 +75,7 @@ namespace dtn
 			return ACCEPT;
 		}
 
-		BundleFilter::ACTION BundleFilterTable::filter(const FilterContext &context, dtn::data::Bundle &bundle) const throw ()
+		BundleFilter::ACTION BundleFilterTable::filter(const FilterContext &context, dtn::data::Bundle &bundle) const noexcept
 		{
 			for (chain::const_iterator it = _chain.begin(); it != _chain.end(); ++it)
 			{

--- a/ibrdtn/daemon/src/core/BundleFilterTable.h
+++ b/ibrdtn/daemon/src/core/BundleFilterTable.h
@@ -53,13 +53,13 @@ namespace dtn
 			/**
 			 * Evaluates a context and results in ACCEPT, REJECT, or DROP directive
 			 */
-			virtual ACTION evaluate(const FilterContext &context) const throw ();
+			virtual ACTION evaluate(const FilterContext &context) const noexcept;
 
 			/**
 			 * Filters a bundle with a context. The bundle may be modified during
 			 * the processing.
 			 */
-			virtual ACTION filter(const FilterContext &context, dtn::data::Bundle &bundle) const throw ();
+			virtual ACTION filter(const FilterContext &context, dtn::data::Bundle &bundle) const noexcept;
 
 		private:
 			typedef std::list<BundleFilter*> chain;

--- a/ibrdtn/daemon/src/core/EventReceiver.h
+++ b/ibrdtn/daemon/src/core/EventReceiver.h
@@ -33,7 +33,7 @@ namespace dtn
 		{
 		public:
 			virtual ~EventReceiver() { };
-			virtual void raiseEvent(const E &evt) throw () = 0;
+			virtual void raiseEvent(const E &evt) noexcept = 0;
 		};
 	}
 }

--- a/ibrdtn/daemon/src/core/EventSwitch.cpp
+++ b/ibrdtn/daemon/src/core/EventSwitch.cpp
@@ -45,9 +45,9 @@ namespace dtn
 			componentDown();
 		}
 
-		void EventSwitch::componentUp() throw ()
+		void EventSwitch::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 
 			// clear all queues
 			_queue = std::queue<Task*>();
@@ -62,7 +62,7 @@ namespace dtn
 			_queue_cond.reset();
 		}
 
-		void EventSwitch::componentDown() throw ()
+		void EventSwitch::componentDown() noexcept
 		{
 			try {
 				ibrcommon::MutexLock l(_queue_cond);
@@ -284,7 +284,7 @@ namespace dtn
 			return (_tm.getMilliseconds() > 5000);
 		}
 
-		void EventSwitch::Worker::run() throw ()
+		void EventSwitch::Worker::run() noexcept
 		{
 			try {
 				while (_running)
@@ -292,7 +292,7 @@ namespace dtn
 			} catch (const ibrcommon::Conditional::ConditionalAbortException&) { };
 		}
 
-		void EventSwitch::Worker::__cancellation() throw ()
+		void EventSwitch::Worker::__cancellation() noexcept
 		{
 			_running = false;
 		}
@@ -321,7 +321,7 @@ namespace dtn
 			JoinableThread::stop();
 		}
 
-		void EventSwitch::WatchDog::run() throw ()
+		void EventSwitch::WatchDog::run() noexcept
 		{
 			try {
 				ibrcommon::MutexLock l(_cond);
@@ -352,7 +352,7 @@ namespace dtn
 			} catch (const ibrcommon::Conditional::ConditionalAbortException&) { };
 		}
 
-		void EventSwitch::WatchDog::__cancellation() throw ()
+		void EventSwitch::WatchDog::__cancellation() noexcept
 		{
 			ibrcommon::MutexLock l(_cond);
 			_running = false;

--- a/ibrdtn/daemon/src/core/EventSwitch.h
+++ b/ibrdtn/daemon/src/core/EventSwitch.h
@@ -70,8 +70,8 @@ namespace dtn
 				bool isStalled();
 
 			protected:
-				void run() throw ();
-				virtual void __cancellation() throw ();
+				void run() noexcept;
+				virtual void __cancellation() noexcept;
 
 			private:
 				EventSwitch &_switch;
@@ -91,8 +91,8 @@ namespace dtn
 				void down();
 
 			protected:
-				void run() throw ();
-				virtual void __cancellation() throw ();
+				void run() noexcept;
+				virtual void __cancellation() noexcept;
 
 			private:
 				EventSwitch &_switch;
@@ -116,8 +116,8 @@ namespace dtn
 			void process(ibrcommon::TimeMeasurement &tm, bool &inprogress, bool profiling);
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 			bool isStalled();
 

--- a/ibrdtn/daemon/src/core/FragmentManager.cpp
+++ b/ibrdtn/daemon/src/core/FragmentManager.cpp
@@ -59,20 +59,20 @@ namespace dtn
 			return "FragmentManager";
 		}
 
-		void FragmentManager::__cancellation() throw ()
+		void FragmentManager::__cancellation() noexcept
 		{
 			_running = false;
 			_incoming.abort();
 		}
 
-		void FragmentManager::componentUp() throw ()
+		void FragmentManager::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::routing::QueueBundleEvent>::add(this);
 			_running = true;
 		}
 
-		void FragmentManager::componentRun() throw ()
+		void FragmentManager::componentRun() noexcept
 		{
 			// get reference to the storage
 			dtn::storage::BundleStorage &storage = dtn::core::BundleCore::getInstance().getStorage();
@@ -166,7 +166,7 @@ namespace dtn
 			} catch (const ibrcommon::QueueUnblockedException&) { }
 		}
 
-		void FragmentManager::componentDown() throw ()
+		void FragmentManager::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::routing::QueueBundleEvent>::remove(this);
 
@@ -174,7 +174,7 @@ namespace dtn
 			join();
 		}
 
-		void FragmentManager::raiseEvent(const dtn::routing::QueueBundleEvent &queued) throw ()
+		void FragmentManager::raiseEvent(const dtn::routing::QueueBundleEvent &queued) noexcept
 		{
 			// process fragments
 			if (!queued.bundle.isFragment()) return;
@@ -204,9 +204,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return 0; };
+				virtual dtn::data::Size limit() const noexcept { return 0; };
 
-				virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// fragments only
 					if (!meta.isFragment()) return false;
@@ -232,7 +232,7 @@ namespace dtn
 			} catch (const dtn::storage::NoBundleFoundException&) { }
 		}
 
-		void FragmentManager::setOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) throw ()
+		void FragmentManager::setOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) noexcept
 		{
 			try {
 				Transmission t;
@@ -254,7 +254,7 @@ namespace dtn
 			} catch (const dtn::storage::NoBundleFoundException&) { };
 		}
 
-		dtn::data::Length FragmentManager::getOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id) throw ()
+		dtn::data::Length FragmentManager::getOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id) noexcept
 		{
 			ibrcommon::MutexLock l(_offsets_mutex);
 			for (std::set<Transmission>::const_iterator iter = _offsets.begin(); iter != _offsets.end(); ++iter)
@@ -268,7 +268,7 @@ namespace dtn
 			return 0;
 		}
 
-		dtn::data::Length FragmentManager::get_payload_offset(const dtn::data::Bundle &bundle, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) throw ()
+		dtn::data::Length FragmentManager::get_payload_offset(const dtn::data::Bundle &bundle, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) noexcept
 		{
 			try {
 				// build the dictionary for EID lookup
@@ -320,7 +320,7 @@ namespace dtn
 			}
 		}
 
-		void FragmentManager::split(const dtn::data::Bundle &bundle, const dtn::data::Length &maxPayloadLength, std::list<dtn::data::Bundle> &fragments) throw (FragmentationAbortedException)
+		void FragmentManager::split(const dtn::data::Bundle &bundle, const dtn::data::Length &maxPayloadLength, std::list<dtn::data::Bundle> &fragments) noexcept (false)
 		{
 			// get bundle DONT_FRAGMENT Flag
 			if (bundle.get(dtn::data::PrimaryBlock::DONT_FRAGMENT))

--- a/ibrdtn/daemon/src/core/FragmentManager.h
+++ b/ibrdtn/daemon/src/core/FragmentManager.h
@@ -39,7 +39,7 @@ namespace dtn
 		class FragmentationAbortedException : public ibrcommon::Exception
 		{
 		public:
-			FragmentationAbortedException(string what = "Fragmentation aborted.") throw() : ibrcommon::Exception(what)
+			FragmentationAbortedException(string what = "Fragmentation aborted.") noexcept : ibrcommon::Exception(what)
 			{
 			}
 		};
@@ -47,7 +47,7 @@ namespace dtn
 		class FragmentationProhibitedException : public FragmentationAbortedException
 		{
 		public:
-			FragmentationProhibitedException(string what = "Fragmentation is prohibited.") throw() : FragmentationAbortedException(what)
+			FragmentationProhibitedException(string what = "Fragmentation is prohibited.") noexcept : FragmentationAbortedException(what)
 			{
 			}
 		};
@@ -55,7 +55,7 @@ namespace dtn
 		class FragmentationNotNecessaryException : public FragmentationAbortedException
 		{
 		public:
-			FragmentationNotNecessaryException(string what = "Fragmentation is not necessary.") throw() : FragmentationAbortedException(what)
+			FragmentationNotNecessaryException(string what = "Fragmentation is not necessary.") noexcept : FragmentationAbortedException(what)
 			{
 			}
 		};
@@ -68,13 +68,13 @@ namespace dtn
 			FragmentManager();
 			virtual ~FragmentManager();
 
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
-			void componentUp() throw ();
-			void componentRun() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentRun() noexcept;
+			void componentDown() noexcept;
 
-			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
+			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
 
 			const std::string getName() const;
 
@@ -84,7 +84,7 @@ namespace dtn
 			 * @param id
 			 * @param offset
 			 */
-			static void setOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) throw ();
+			static void setOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) noexcept;
 
 			/**
 			 * Get the offset of a transmission
@@ -92,7 +92,7 @@ namespace dtn
 			 * @param id
 			 * @return
 			 */
-			static dtn::data::Length getOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id) throw ();
+			static dtn::data::Length getOffset(const dtn::data::EID &peer, const dtn::data::BundleID &id) noexcept;
 
 			/**
 			 * Split-up a bundle into several pieces
@@ -100,7 +100,7 @@ namespace dtn
 			 * @param maxPayloadLength payload length maximum per fragment
 			 * @param fragments list of all fragments
 			 */
-			static void split(const dtn::data::Bundle &bundle, const dtn::data::Length &maxPayloadLength, std::list<dtn::data::Bundle> &fragments) throw (FragmentationAbortedException);
+			static void split(const dtn::data::Bundle &bundle, const dtn::data::Length &maxPayloadLength, std::list<dtn::data::Bundle> &fragments) noexcept (false);
 
 		private:
 			class Transmission
@@ -119,7 +119,7 @@ namespace dtn
 			};
 
 			static void expire_offsets(const dtn::data::Timestamp &timestamp);
-			static dtn::data::Length get_payload_offset(const dtn::data::Bundle &bundle, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) throw ();
+			static dtn::data::Length get_payload_offset(const dtn::data::Bundle &bundle, const dtn::data::Length &abs_offset, const dtn::data::Length &frag_offset) noexcept;
 
 			/**
 			 * adds all necessary blocks from the bundle to the fragment

--- a/ibrdtn/daemon/src/core/Node.cpp
+++ b/ibrdtn/daemon/src/core/Node.cpp
@@ -305,7 +305,7 @@ namespace dtn
 			_attr_list.clear();
 		}
 
-		dtn::data::Size Node::size() const throw ()
+		dtn::data::Size Node::size() const noexcept
 		{
 			return _uri_list.size() + _attr_list.size();
 		}
@@ -403,7 +403,7 @@ namespace dtn
 			return ret;
 		}
 
-		const dtn::data::EID& Node::getEID() const throw ()
+		const dtn::data::EID& Node::getEID() const noexcept
 		{
 			return _id;
 		}
@@ -523,7 +523,7 @@ namespace dtn
 			_connect_immediately = val;
 		}
 
-		bool Node::isAvailable() const throw ()
+		bool Node::isAvailable() const noexcept
 		{
 			if (dtn::core::BundleCore::getInstance().isGloballyConnected()) {
 				return !_uri_list.empty();
@@ -546,7 +546,7 @@ namespace dtn
 			return false;
 		}
 
-		bool Node::isAvailable(const Node::URI &uri) const throw ()
+		bool Node::isAvailable(const Node::URI &uri) const noexcept
 		{
 			if (dtn::core::BundleCore::getInstance().isGloballyConnected()) {
 				return true;
@@ -571,12 +571,12 @@ namespace dtn
 			}
 		}
 
-		void Node::setAnnounced(bool val) throw ()
+		void Node::setAnnounced(bool val) noexcept
 		{
 			_announced_mark = val;
 		}
 
-		bool Node::isAnnounced() const throw ()
+		bool Node::isAnnounced() const noexcept
 		{
 			return _announced_mark;
 		}

--- a/ibrdtn/daemon/src/core/Node.h
+++ b/ibrdtn/daemon/src/core/Node.h
@@ -168,7 +168,7 @@ namespace dtn
 			/**
 			 * Get the number of entries (URI + Attributes)
 			 */
-			dtn::data::Size size() const throw ();
+			dtn::data::Size size() const noexcept;
 
 			/**
 			 * Returns a list of URIs matching the given protocol
@@ -200,7 +200,7 @@ namespace dtn
 			 * Return the EID of this node.
 			 * @return The EID of this node.
 			 */
-			const dtn::data::EID& getEID() const throw ();
+			const dtn::data::EID& getEID() const noexcept;
 
 			/**
 			 * remove expired service descriptors
@@ -229,22 +229,22 @@ namespace dtn
 			/**
 			 * @return true, if at least one connection is available
 			 */
-			bool isAvailable() const throw ();
+			bool isAvailable() const noexcept;
 
 			/**
 			 * @return true, if this node has been announced before
 			 */
-			bool isAnnounced() const throw ();
+			bool isAnnounced() const noexcept;
 
 			/**
 			 * Mark this node as announced or not
 			 */
-			void setAnnounced(bool val) throw ();
+			void setAnnounced(bool val) noexcept;
 
 			friend std::ostream& operator<<(std::ostream&, const Node&);
 
 		private:
-			bool isAvailable(const Node::URI &uri) const throw ();
+			bool isAvailable(const Node::URI &uri) const noexcept;
 
 			bool _connect_immediately;
 			dtn::data::EID _id;

--- a/ibrdtn/daemon/src/core/StatusReportGenerator.cpp
+++ b/ibrdtn/daemon/src/core/StatusReportGenerator.cpp
@@ -104,7 +104,7 @@ namespace dtn
 			dtn::core::BundleCore::inject(dtn::core::BundleCore::local, bundle);
 		}
 
-		void StatusReportGenerator::raiseEvent(const dtn::core::BundleEvent &bundleevent) throw ()
+		void StatusReportGenerator::raiseEvent(const dtn::core::BundleEvent &bundleevent) noexcept
 		{
 			const dtn::data::MetaBundle &b = bundleevent.getBundle();
 

--- a/ibrdtn/daemon/src/core/StatusReportGenerator.h
+++ b/ibrdtn/daemon/src/core/StatusReportGenerator.h
@@ -38,7 +38,7 @@ namespace dtn
 			StatusReportGenerator();
 			virtual ~StatusReportGenerator();
 
-			void raiseEvent(const dtn::core::BundleEvent &evt) throw ();
+			void raiseEvent(const dtn::core::BundleEvent &evt) noexcept;
 
 		private:
 			/**

--- a/ibrdtn/daemon/src/core/WallClock.cpp
+++ b/ibrdtn/daemon/src/core/WallClock.cpp
@@ -47,9 +47,9 @@ namespace dtn
 			}
 		}
 
-		void WallClock::componentUp() throw ()
+		void WallClock::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			if(_timer.isRunning())
 			{
 				_timer.reset();
@@ -64,7 +64,7 @@ namespace dtn
 			}
 		}
 
-		void WallClock::componentDown() throw ()
+		void WallClock::componentDown() noexcept
 		{
 			_timer.pause();
 		}

--- a/ibrdtn/daemon/src/core/WallClock.h
+++ b/ibrdtn/daemon/src/core/WallClock.h
@@ -59,8 +59,8 @@ namespace dtn
 			virtual const std::string getName() const;
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 		private:
 			dtn::data::Timeout _frequency;

--- a/ibrdtn/daemon/src/core/filter/LogFilter.cpp
+++ b/ibrdtn/daemon/src/core/filter/LogFilter.cpp
@@ -41,7 +41,7 @@ namespace dtn
 		{
 		}
 
-		void LogFilter::log(const FilterContext &context) const throw ()
+		void LogFilter::log(const FilterContext &context) const noexcept
 		{
 			try {
 				switch (_level)
@@ -83,7 +83,7 @@ namespace dtn
 			}
 		}
 
-		BundleFilter::ACTION LogFilter::evaluate(const FilterContext &context) const throw ()
+		BundleFilter::ACTION LogFilter::evaluate(const FilterContext &context) const noexcept
 		{
 			// print logging
 			log(context);
@@ -92,7 +92,7 @@ namespace dtn
 			return BundleFilter::evaluate(context);
 		}
 
-		BundleFilter::ACTION LogFilter::filter(const FilterContext &context, dtn::data::Bundle &bundle) const throw ()
+		BundleFilter::ACTION LogFilter::filter(const FilterContext &context, dtn::data::Bundle &bundle) const noexcept
 		{
 			// print logging
 			log(context);

--- a/ibrdtn/daemon/src/core/filter/LogFilter.h
+++ b/ibrdtn/daemon/src/core/filter/LogFilter.h
@@ -35,11 +35,11 @@ namespace dtn
 			LogFilter(const ibrcommon::LogLevel::Level level, const std::string &msg);
 			LogFilter(const int debug_level, const std::string &msg);
 			virtual ~LogFilter();
-			virtual ACTION evaluate(const FilterContext&) const throw ();
-			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const throw ();
+			virtual ACTION evaluate(const FilterContext&) const noexcept;
+			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const noexcept;
 
 		private:
-			void log(const FilterContext &context) const throw ();
+			void log(const FilterContext &context) const noexcept;
 
 			const static std::string TAG;
 			const ibrcommon::LogLevel::Level _level;

--- a/ibrdtn/daemon/src/core/filter/SecurityFilter.cpp
+++ b/ibrdtn/daemon/src/core/filter/SecurityFilter.cpp
@@ -42,7 +42,7 @@ namespace dtn
 		{
 		}
 
-		BundleFilter::ACTION SecurityFilter::evaluate(const FilterContext &context) const throw ()
+		BundleFilter::ACTION SecurityFilter::evaluate(const FilterContext &context) const noexcept
 		{
 #ifdef IBRDTN_SUPPORT_BSP
 			switch (_mode)
@@ -122,7 +122,7 @@ namespace dtn
 			return BundleFilter::evaluate(context);
 		}
 
-		BundleFilter::ACTION SecurityFilter::filter(const FilterContext &context, dtn::data::Bundle &bundle) const throw ()
+		BundleFilter::ACTION SecurityFilter::filter(const FilterContext &context, dtn::data::Bundle &bundle) const noexcept
 		{
 #ifdef IBRDTN_SUPPORT_BSP
 			switch (_mode)

--- a/ibrdtn/daemon/src/core/filter/SecurityFilter.h
+++ b/ibrdtn/daemon/src/core/filter/SecurityFilter.h
@@ -43,8 +43,8 @@ namespace dtn
 			SecurityFilter(MODE mode, BundleFilter::ACTION positive = BundleFilter::PASS, BundleFilter::ACTION negative = BundleFilter::PASS);
 			virtual ~SecurityFilter();
 
-			virtual ACTION evaluate(const FilterContext&) const throw ();
-			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const throw ();
+			virtual ACTION evaluate(const FilterContext&) const noexcept;
+			virtual ACTION filter(const FilterContext&, dtn::data::Bundle&) const noexcept;
 
 		private:
 			const MODE _mode;

--- a/ibrdtn/daemon/src/net/ConnectionManager.cpp
+++ b/ibrdtn/daemon/src/net/ConnectionManager.cpp
@@ -54,9 +54,9 @@ namespace dtn
 		{
 		}
 
-		void ConnectionManager::componentUp() throw ()
+		void ConnectionManager::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::core::NodeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::net::ConnectionEvent>::add(this);
@@ -70,7 +70,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::componentDown() throw ()
+		void ConnectionManager::componentDown() noexcept
 		{
 			{
 				ibrcommon::MutexLock l(_cl_lock);
@@ -93,7 +93,7 @@ namespace dtn
 			dtn::core::EventDispatcher<GlobalEvent>::remove(this);
 		}
 
-		void ConnectionManager::raiseEvent(const dtn::core::NodeEvent &nodeevent) throw ()
+		void ConnectionManager::raiseEvent(const dtn::core::NodeEvent &nodeevent) noexcept
 		{
 			ibrcommon::MutexLock l(_node_lock);
 			const Node &n = nodeevent.getNode();
@@ -117,7 +117,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::raiseEvent(const dtn::core::TimeEvent &timeevent) throw ()
+		void ConnectionManager::raiseEvent(const dtn::core::TimeEvent &timeevent) noexcept
 		{
 			if (timeevent.getAction() == TIME_SECOND_TICK)
 			{
@@ -126,7 +126,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::raiseEvent(const dtn::net::ConnectionEvent &connection) throw ()
+		void ConnectionManager::raiseEvent(const dtn::net::ConnectionEvent &connection) noexcept
 		{
 			switch (connection.getState())
 			{
@@ -147,7 +147,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::raiseEvent(const dtn::core::GlobalEvent &global) throw ()
+		void ConnectionManager::raiseEvent(const dtn::core::GlobalEvent &global) noexcept
 		{
 			switch (global.getAction()) {
 			case GlobalEvent::GLOBAL_INTERNET_AVAILABLE:
@@ -163,7 +163,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::add(const dtn::core::Node &n) throw ()
+		void ConnectionManager::add(const dtn::core::Node &n) noexcept
 		{
 			// If node contains MCL
 			if(n.has(Node::CONN_EMAIL) && !n.getEID().getScheme().compare("mail") == 0)
@@ -225,7 +225,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::remove(const dtn::core::Node &n) throw ()
+		void ConnectionManager::remove(const dtn::core::Node &n) noexcept
 		{
 			ibrcommon::MutexLock l(_node_lock);
 			try {
@@ -307,7 +307,7 @@ namespace dtn
 			add(node);
 		}
 
-		bool ConnectionManager::isReachable(const dtn::core::Node &node) throw ()
+		bool ConnectionManager::isReachable(const dtn::core::Node &node) noexcept
 		{
 			const std::list<Node::URI> urilist = node.getAll();
 
@@ -446,7 +446,7 @@ namespace dtn
 			}
 		}
 
-		void ConnectionManager::open(const dtn::core::Node &node) throw (ibrcommon::Exception)
+		void ConnectionManager::open(const dtn::core::Node &node) noexcept (false)
 		{
 			const std::list<Node::URI> urilist = node.getAll();
 
@@ -557,14 +557,14 @@ namespace dtn
 			}
 		}
 
-		const ConnectionManager::protocol_set ConnectionManager::getSupportedProtocols() throw ()
+		const ConnectionManager::protocol_set ConnectionManager::getSupportedProtocols() noexcept
 		{
 			// lock convergence layers
 			ibrcommon::MutexLock l(_cl_lock);
 			return _cl_protocols;
 		}
 
-		const ConnectionManager::protocol_list ConnectionManager::getSupportedProtocols(const dtn::data::EID &peer) throw (NodeNotAvailableException)
+		const ConnectionManager::protocol_list ConnectionManager::getSupportedProtocols(const dtn::data::EID &peer) noexcept (false)
 		{
 			protocol_list ret;
 
@@ -601,7 +601,7 @@ namespace dtn
 			return ret;
 		}
 
-		const dtn::core::Node ConnectionManager::getNeighbor(const dtn::data::EID &eid) throw (NodeNotAvailableException)
+		const dtn::core::Node ConnectionManager::getNeighbor(const dtn::data::EID &eid) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_node_lock);
 			const Node &n = getNode(eid);
@@ -610,7 +610,7 @@ namespace dtn
 			throw dtn::net::NodeNotAvailableException("Node is not reachable or not available.");
 		}
 
-		bool ConnectionManager::isNeighbor(const dtn::core::Node &node) throw ()
+		bool ConnectionManager::isNeighbor(const dtn::core::Node &node) noexcept
 		{
 			try {
 				ibrcommon::MutexLock l(_node_lock);
@@ -631,7 +631,7 @@ namespace dtn
 			return "ConnectionManager";
 		}
 
-		dtn::core::Node& ConnectionManager::getNode(const dtn::data::EID &eid) throw (NodeNotAvailableException)
+		dtn::core::Node& ConnectionManager::getNode(const dtn::data::EID &eid) noexcept (false)
 		{
 			nodemap::iterator iter = _nodes.find(eid);
 			if (iter == _nodes.end()) throw NodeNotAvailableException("node not found");

--- a/ibrdtn/daemon/src/net/ConnectionManager.h
+++ b/ibrdtn/daemon/src/net/ConnectionManager.h
@@ -46,7 +46,7 @@ namespace dtn
 		class NodeNotAvailableException : public ibrcommon::Exception
 		{
 		public:
-			NodeNotAvailableException(string what = "The requested node is not a neighbor.") throw() : ibrcommon::Exception(what)
+			NodeNotAvailableException(string what = "The requested node is not a neighbor.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -54,7 +54,7 @@ namespace dtn
 		class ConnectionNotAvailableException : public ibrcommon::Exception
 		{
 		public:
-			ConnectionNotAvailableException(string what = "The requested connection is not available.") throw() : ibrcommon::Exception(what)
+			ConnectionNotAvailableException(string what = "The requested connection is not available.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -67,8 +67,8 @@ namespace dtn
 			ConnectionManager();
 			virtual ~ConnectionManager();
 
-			void add(const dtn::core::Node &n) throw ();
-			void remove(const dtn::core::Node &n) throw ();
+			void add(const dtn::core::Node &n) noexcept;
+			void remove(const dtn::core::Node &n) noexcept;
 
 			/**
 			 * Add a convergence layer
@@ -98,20 +98,20 @@ namespace dtn
 			/**
 			 * method to receive new events from the EventSwitch
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
-			void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
-			void raiseEvent(const dtn::net::ConnectionEvent &evt) throw ();
-			void raiseEvent(const dtn::core::GlobalEvent &evt) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::ConnectionEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::GlobalEvent &evt) noexcept;
 
 			class ShutdownException : public ibrcommon::Exception
 			{
 			public:
-				ShutdownException(string what = "System shutdown") throw() : ibrcommon::Exception(what)
+				ShutdownException(string what = "System shutdown") noexcept : ibrcommon::Exception(what)
 				{
 				};
 			};
 
-			void open(const dtn::core::Node &node) throw (ibrcommon::Exception);
+			void open(const dtn::core::Node &node) noexcept (false);
 
 
 			typedef std::set<dtn::core::Node::Protocol> protocol_set;
@@ -120,12 +120,12 @@ namespace dtn
 			/**
 			 * Returns a list of all supported protocols
 			 */
-			const protocol_set getSupportedProtocols() throw ();
+			const protocol_set getSupportedProtocols() noexcept;
 
 			/**
 			 * Returns a list of protocol supported by both, local BPA and the peer
 			 */
-			const protocol_list getSupportedProtocols(const dtn::data::EID &eid) throw (NodeNotAvailableException);
+			const protocol_list getSupportedProtocols(const dtn::data::EID &eid) noexcept (false);
 
 			/**
 			 * get a set with all neighbors
@@ -138,7 +138,7 @@ namespace dtn
 			 * @param
 			 * @return
 			 */
-			bool isNeighbor(const dtn::core::Node&) throw ();
+			bool isNeighbor(const dtn::core::Node&) noexcept;
 
 			/**
 			 * Get the neighbor with the given EID.
@@ -146,7 +146,7 @@ namespace dtn
 			 * @param eid The EID of the neighbor.
 			 * @return A node object with all neighbor data.
 			 */
-			const dtn::core::Node getNeighbor(const dtn::data::EID &eid) throw (NodeNotAvailableException);
+			const dtn::core::Node getNeighbor(const dtn::data::EID &eid) noexcept (false);
 
 			/**
 			 * Add collected data about a neighbor to the neighbor database.
@@ -172,8 +172,8 @@ namespace dtn
 			 */
 			void discovered(const dtn::core::Node &node);
 
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 		private:
 			/**
@@ -194,12 +194,12 @@ namespace dtn
 			/**
 			 * check if the node is reachable by any convergence-layer
 			 */
-			bool isReachable(const dtn::core::Node &node) throw ();
+			bool isReachable(const dtn::core::Node &node) noexcept;
 
 			/**
 			 * get node
 			 */
-			dtn::core::Node& getNode(const dtn::data::EID &eid) throw (NodeNotAvailableException);
+			dtn::core::Node& getNode(const dtn::data::EID &eid) noexcept (false);
 
 			// mutex for the list of convergence layers
 			ibrcommon::Mutex _cl_lock;

--- a/ibrdtn/daemon/src/net/ConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/ConvergenceLayer.h
@@ -39,7 +39,7 @@ namespace dtn
 		class NoAddressFoundException : public ibrcommon::Exception
 		{
 		public:
-			NoAddressFoundException(std::string what = "There is no address available for this peer.") throw() : ibrcommon::Exception(what)
+			NoAddressFoundException(std::string what = "There is no address available for this peer.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};

--- a/ibrdtn/daemon/src/net/DHTNameService.cpp
+++ b/ibrdtn/daemon/src/net/DHTNameService.cpp
@@ -54,7 +54,7 @@ const std::string dtn::dht::DHTNameService::getName() const {
 	return "DHT Naming Service";
 }
 
-void dtn::dht::DHTNameService::__cancellation() throw () {
+void dtn::dht::DHTNameService::__cancellation() noexcept {
 }
 
 bool dtn::dht::DHTNameService::setNonBlockingInterruptPipe() {
@@ -72,7 +72,7 @@ bool dtn::dht::DHTNameService::setNonBlockingInterruptPipe() {
 	return true;
 }
 
-void dtn::dht::DHTNameService::componentUp() throw () {
+void dtn::dht::DHTNameService::componentUp() noexcept {
 	// register as discovery beacon handler
 	dtn::core::BundleCore::getInstance().getDiscoveryAgent().registerService(this);
 
@@ -190,7 +190,7 @@ void dtn::dht::DHTNameService::componentUp() throw () {
 	}
 }
 
-void dtn::dht::DHTNameService::componentRun() throw () {
+void dtn::dht::DHTNameService::componentRun() noexcept {
 	if (!this->_initialized) {
 		IBRCOMMON_LOGGER_TAG("DHTNameService", error) << "DHT is not initialized"
 					<<IBRCOMMON_LOGGER_ENDL;
@@ -437,7 +437,7 @@ void dtn::dht::DHTNameService::componentRun() throw () {
 	::close(_interrupt_pipe[1]);
 }
 
-void dtn::dht::DHTNameService::componentDown() throw () {
+void dtn::dht::DHTNameService::componentDown() noexcept {
 	// un-register as discovery beacon handler
 	dtn::core::BundleCore::getInstance().getDiscoveryAgent().unregisterService(this);
 
@@ -568,7 +568,7 @@ std::string dtn::dht::DHTNameService::getConvergenceLayerName(
 	return cltype_;
 }
 
-void dtn::dht::DHTNameService::raiseEvent(const dtn::routing::QueueBundleEvent &event) throw ()
+void dtn::dht::DHTNameService::raiseEvent(const dtn::routing::QueueBundleEvent &event) noexcept
 {
 	if (!event.bundle.destination.sameHost(dtn::core::BundleCore::local)
 			&& !event.bundle.destination.isNone()) {
@@ -576,7 +576,7 @@ void dtn::dht::DHTNameService::raiseEvent(const dtn::routing::QueueBundleEvent &
 	}
 }
 
-void dtn::dht::DHTNameService::raiseEvent(const dtn::core::NodeEvent &nodeevent) throw ()
+void dtn::dht::DHTNameService::raiseEvent(const dtn::core::NodeEvent &nodeevent) noexcept
 {
 	const dtn::core::Node &n = nodeevent.getNode();
 	if (!n.getEID().sameHost(dtn::core::BundleCore::local)) {
@@ -804,7 +804,7 @@ void dtn::dht::DHTNameService::bootstrappingIPs() {
 // TODO Nur für Interfaces zulassen, auf denen ich gebunden bin!
 
 void dtn::dht::DHTNameService::onUpdateBeacon(const ibrcommon::vinterface&, DiscoveryBeacon &beacon)
-		throw (dtn::net::DiscoveryBeaconHandler::NoServiceHereException) {
+		noexcept (false) {
 	if (this->_initialized) {
 		stringstream service;
 		service << "port=" << this->_context.port << ";";

--- a/ibrdtn/daemon/src/net/DHTNameService.h
+++ b/ibrdtn/daemon/src/net/DHTNameService.h
@@ -149,37 +149,37 @@ public:
 	 * 	dtn::routing::QueueBundleEvent
 	 * 	dtn::core::NodeEvent
 	 */
-	void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
-	void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
+	void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
+	void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
 	/**
 	 * this method updates the given values for discovery service
 	 * It publishes the port number of the DHT instance
 	 */
 	void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon)
-			throw (dtn::net::DiscoveryBeaconHandler::NoServiceHereException);
+			noexcept (false);
 
 
 protected:
 	/**
 	 * returns true
 	 */
-	void __cancellation() throw ();
+	void __cancellation() noexcept;
 	/**
 	 * Reads the configured settings for the DHT and
 	 * initializes all needed sockets(IPv4&IPv6) for the DHT
 	 */
-	void componentUp() throw ();
+	void componentUp() noexcept;
 	/**
 	 * Runs the bootstrapping method and starts the DHT.
 	 * Executes the main loop with dtn_dht_periodic.
 	 * After exiting the main loop, the DHT is shut down.
 	 */
-	void componentRun() throw ();
+	void componentRun() noexcept;
 	/**
 	 * Calls the interrupt pipe to exit the main loop.
 	 * And so ends up the main loop indirectly
 	 */
-	void componentDown() throw ();
+	void componentDown() noexcept;
 };
 }
 }

--- a/ibrdtn/daemon/src/net/DatagramConnection.cpp
+++ b/ibrdtn/daemon/src/net/DatagramConnection.cpp
@@ -67,7 +67,7 @@ namespace dtn
 			__cancellation();
 		}
 
-		void DatagramConnection::__cancellation() throw ()
+		void DatagramConnection::__cancellation() noexcept
 		{
 			// close the stream
 			try {
@@ -75,7 +75,7 @@ namespace dtn
 			} catch (const ibrcommon::Exception&) { };
 		}
 
-		void DatagramConnection::run() throw ()
+		void DatagramConnection::run() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(DatagramConnection::TAG, 40) << "run()" << IBRCOMMON_LOGGER_ENDL;
 
@@ -130,7 +130,7 @@ namespace dtn
 			}
 		}
 
-		void DatagramConnection::setup() throw ()
+		void DatagramConnection::setup() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(DatagramConnection::TAG, 40) << "setup()" << IBRCOMMON_LOGGER_ENDL;
 
@@ -138,7 +138,7 @@ namespace dtn
 			_sender.start();
 		}
 
-		void DatagramConnection::finally() throw ()
+		void DatagramConnection::finally() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(DatagramConnection::TAG, 40) << "finally()" << IBRCOMMON_LOGGER_ENDL;
 
@@ -275,7 +275,7 @@ namespace dtn
 			}
 		}
 
-		void DatagramConnection::stream_send(const char *buf, const dtn::data::Length &len, bool last) throw (DatagramException)
+		void DatagramConnection::stream_send(const char *buf, const dtn::data::Length &len, bool last) noexcept (false)
 		{
 			// build the right flags
 			char flags = 0;
@@ -610,7 +610,7 @@ namespace dtn
 		{
 		}
 
-		void DatagramConnection::Stream::queue(const char *buf, const dtn::data::Length &len, bool isFirst) throw (DatagramException)
+		void DatagramConnection::Stream::queue(const char *buf, const dtn::data::Length &len, bool isFirst) noexcept (false)
 		{
 			try {
 				ibrcommon::MutexLock l(_queue_buf_cond);
@@ -773,14 +773,14 @@ namespace dtn
 		{
 		}
 
-		void DatagramConnection::Sender::skip() throw ()
+		void DatagramConnection::Sender::skip() noexcept
 		{
 			// skip all data of the current transmission
 			_skip = true;
 			_stream.skip();
 		}
 
-		void DatagramConnection::Sender::run() throw ()
+		void DatagramConnection::Sender::run() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(DatagramConnection::TAG, 40) << "Sender::run()"<< IBRCOMMON_LOGGER_ENDL;
 
@@ -848,11 +848,11 @@ namespace dtn
 			}
 		}
 
-		void DatagramConnection::Sender::finally() throw ()
+		void DatagramConnection::Sender::finally() noexcept
 		{
 		}
 
-		void DatagramConnection::Sender::__cancellation() throw ()
+		void DatagramConnection::Sender::__cancellation() noexcept
 		{
 			// abort all blocking operations on the stream
 			_stream.close();

--- a/ibrdtn/daemon/src/net/DatagramConnection.h
+++ b/ibrdtn/daemon/src/net/DatagramConnection.h
@@ -43,9 +43,9 @@ namespace dtn
 		{
 		public:
 			virtual ~DatagramConnectionCallback() {};
-			virtual void callback_send(DatagramConnection &connection, const char &flags, const unsigned int &seqno, const std::string &destination, const char *buf, const dtn::data::Length &len) throw (DatagramException) = 0;
-			virtual void callback_ack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) throw (DatagramException) = 0;
-			virtual void callback_nack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) throw (DatagramException) = 0;
+			virtual void callback_send(DatagramConnection &connection, const char &flags, const unsigned int &seqno, const std::string &destination, const char *buf, const dtn::data::Length &len) noexcept (false) = 0;
+			virtual void callback_ack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) noexcept (false) = 0;
+			virtual void callback_nack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) noexcept (false) = 0;
 
 			virtual void connectionUp(const DatagramConnection *conn) = 0;
 			virtual void connectionDown(const DatagramConnection *conn) = 0;
@@ -64,11 +64,11 @@ namespace dtn
 			DatagramConnection(const std::string &identifier, const DatagramService::Parameter &params, DatagramConnectionCallback &callback);
 			virtual ~DatagramConnection();
 
-			void run() throw ();
-			void setup() throw ();
-			void finally() throw ();
+			void run() noexcept;
+			void setup() noexcept;
+			void finally() noexcept;
 
-			virtual void __cancellation() throw ();
+			virtual void __cancellation() noexcept;
 
 			void shutdown();
 
@@ -135,7 +135,7 @@ namespace dtn
 				 * @param buf Buffer with received data
 				 * @param len Length of the buffer
 				 */
-				void queue(const char *buf, const dtn::data::Length &len, bool isFirst) throw (DatagramException);
+				void queue(const char *buf, const dtn::data::Length &len, bool isFirst) noexcept (false);
 
 				/**
 				 * Close the stream to terminate all blocking
@@ -217,11 +217,11 @@ namespace dtn
 				/**
 				 * skip the current bundle
 				 */
-				void skip() throw ();
+				void skip() noexcept;
 
-				void run() throw ();
-				void finally() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void finally() noexcept;
+				void __cancellation() noexcept;
 
 				ibrcommon::Queue<dtn::net::BundleTransfer> queue;
 
@@ -237,7 +237,7 @@ namespace dtn
 			/**
 			 * Send a new frame
 			 */
-			void stream_send(const char *buf, const dtn::data::Length &len, bool last) throw (DatagramException);
+			void stream_send(const char *buf, const dtn::data::Length &len, bool last) noexcept (false);
 
 			/**
 			 * Adjust the average RTT by the new measured value

--- a/ibrdtn/daemon/src/net/DatagramConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/DatagramConvergenceLayer.cpp
@@ -60,7 +60,7 @@ namespace dtn
 			delete _service;
 		}
 
-		void DatagramConvergenceLayer::raiseEvent(const dtn::core::NodeEvent &event) throw ()
+		void DatagramConvergenceLayer::raiseEvent(const dtn::core::NodeEvent &event) noexcept
 		{
 			if (event.getAction() == NODE_UNAVAILABLE)
 			{
@@ -115,7 +115,7 @@ namespace dtn
 			return _service->getProtocol();
 		}
 
-		void DatagramConvergenceLayer::callback_send(DatagramConnection&, const char &flags, const unsigned int &seqno, const std::string &destination, const char *buf, const dtn::data::Length &len) throw (DatagramException)
+		void DatagramConvergenceLayer::callback_send(DatagramConnection&, const char &flags, const unsigned int &seqno, const std::string &destination, const char *buf, const dtn::data::Length &len) noexcept (false)
 		{
 			// only on sender at once
 			ibrcommon::MutexLock l(_send_lock);
@@ -127,7 +127,7 @@ namespace dtn
 			_stats_out += len;
 		}
 
-		void DatagramConvergenceLayer::callback_ack(DatagramConnection&, const unsigned int &seqno, const std::string &destination) throw (DatagramException)
+		void DatagramConvergenceLayer::callback_ack(DatagramConnection&, const unsigned int &seqno, const std::string &destination) noexcept (false)
 		{
 			// only on sender at once
 			ibrcommon::MutexLock l(_send_lock);
@@ -136,7 +136,7 @@ namespace dtn
 			_service->send(HEADER_ACK, 0, seqno, destination, NULL, 0);
 		}
 
-		void DatagramConvergenceLayer::callback_nack(DatagramConnection&, const unsigned int &seqno, const std::string &destination) throw (DatagramException)
+		void DatagramConvergenceLayer::callback_nack(DatagramConnection&, const unsigned int &seqno, const std::string &destination) noexcept (false)
 		{
 			// only on sender at once
 			ibrcommon::MutexLock l(_send_lock);
@@ -165,7 +165,7 @@ namespace dtn
 			_action_queue.push( queue );
 		}
 
-		DatagramConnection& DatagramConvergenceLayer::getConnection(const std::string &identifier, bool create) throw (ConnectionNotAvailableException)
+		DatagramConnection& DatagramConvergenceLayer::getConnection(const std::string &identifier, bool create) noexcept (false)
 		{
 			DatagramConnection *connection = NULL;
 
@@ -221,9 +221,9 @@ namespace dtn
 			_action_queue.push(cd);
 		}
 
-		void DatagramConvergenceLayer::componentUp() throw ()
+		void DatagramConvergenceLayer::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				_service->bind();
 			} catch (const std::exception &e) {
@@ -240,7 +240,7 @@ namespace dtn
 			_running = true;
 		}
 
-		void DatagramConvergenceLayer::componentDown() throw ()
+		void DatagramConvergenceLayer::componentDown() noexcept
 		{
 			// un-register for discovery beacon handling
 			dtn::core::BundleCore::getInstance().getDiscoveryAgent().unregisterService(_service->getInterface(), this);
@@ -251,7 +251,7 @@ namespace dtn
 			_action_queue.push(new Shutdown());
 		}
 
-		void DatagramConvergenceLayer::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ()
+		void DatagramConvergenceLayer::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept
 		{
 			// only handler beacons for this interface
 			if (iface != _service->getInterface()) return;
@@ -273,7 +273,7 @@ namespace dtn
 			};
 		}
 
-		void DatagramConvergenceLayer::receive() throw ()
+		void DatagramConvergenceLayer::receive() noexcept
 		{
 			size_t maxlen = _service->getParameter().max_msg_length;
 			std::string address;
@@ -366,7 +366,7 @@ namespace dtn
 			}
 		}
 
-		void DatagramConvergenceLayer::componentRun() throw ()
+		void DatagramConvergenceLayer::componentRun() noexcept
 		{
 			// start receiver
 			_receiver.init();
@@ -512,7 +512,7 @@ namespace dtn
 			_receiver.join();
 		}
 
-		void DatagramConvergenceLayer::__cancellation() throw ()
+		void DatagramConvergenceLayer::__cancellation() noexcept
 		{
 			_service->shutdown();
 		}
@@ -531,18 +531,18 @@ namespace dtn
 		{
 		}
 
-		void DatagramConvergenceLayer::Receiver::init() throw ()
+		void DatagramConvergenceLayer::Receiver::init() noexcept
 		{
 			// reset receiver is necessary
 			if (JoinableThread::isFinalized()) JoinableThread::reset();
 		}
 
-		void DatagramConvergenceLayer::Receiver::run() throw ()
+		void DatagramConvergenceLayer::Receiver::run() noexcept
 		{
 			_cl.receive();
 		}
 
-		void DatagramConvergenceLayer::Receiver::__cancellation() throw ()
+		void DatagramConvergenceLayer::Receiver::__cancellation() noexcept
 		{
 		}
 	} /* namespace data */

--- a/ibrdtn/daemon/src/net/DatagramConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/DatagramConvergenceLayer.h
@@ -57,7 +57,7 @@ namespace dtn
 			/**
 			 * method to receive global events
 			 */
-			void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
+			void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
 
 			/**
 			 * Returns the protocol identifier
@@ -82,13 +82,13 @@ namespace dtn
 
 			virtual void getStats(ConvergenceLayer::stats_data &data) const;
 
-			void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ();
+			void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept;
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentRun() throw ();
-			virtual void componentDown() throw ();
-			void __cancellation() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentRun() noexcept;
+			virtual void componentDown() noexcept;
+			void __cancellation() noexcept;
 			/**
 			 * callback send for connections
 			 * @param connection
@@ -96,11 +96,11 @@ namespace dtn
 			 * @param buf
 			 * @param len
 			 */
-			void callback_send(DatagramConnection &connection, const char &flags, const unsigned int &seqno, const std::string &destination, const char *buf, const dtn::data::Length &len) throw (DatagramException);
+			void callback_send(DatagramConnection &connection, const char &flags, const unsigned int &seqno, const std::string &destination, const char *buf, const dtn::data::Length &len) noexcept (false);
 
-			void callback_ack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) throw (DatagramException);
+			void callback_ack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) noexcept (false);
 
-			void callback_nack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) throw (DatagramException);
+			void callback_nack(DatagramConnection &connection, const unsigned int &seqno, const std::string &destination) noexcept (false);
 
 			void connectionUp(const DatagramConnection *conn);
 			void connectionDown(const DatagramConnection *conn);
@@ -108,7 +108,7 @@ namespace dtn
 			void reportSuccess(size_t retries, double rtt);
 			void reportFailure();
 
-			void receive() throw ();
+			void receive() noexcept;
 
 		private:
 			class ConnectionNotAvailableException : public ibrcommon::Exception {
@@ -117,7 +117,7 @@ namespace dtn
 				 : ibrcommon::Exception(what) {
 				}
 
-				virtual ~ConnectionNotAvailableException() throw () {
+				virtual ~ConnectionNotAvailableException() noexcept {
 				}
 			};
 
@@ -130,10 +130,10 @@ namespace dtn
 				Receiver(DatagramConvergenceLayer &cl);
 				virtual ~Receiver();
 
-				void init() throw ();
+				void init() noexcept;
 
-				void run() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void __cancellation() noexcept;
 
 			private:
 				DatagramConvergenceLayer &_cl;
@@ -223,7 +223,7 @@ namespace dtn
 			 * @param identifier The identifier of the connection.
 			 * @param create If this parameter is set to true a new connection is created if it does not exists.
 			 */
-			DatagramConnection& getConnection(const std::string &identifier, bool create) throw (ConnectionNotAvailableException);
+			DatagramConnection& getConnection(const std::string &identifier, bool create) noexcept (false);
 
 			// associated datagram service
 			DatagramService *_service;

--- a/ibrdtn/daemon/src/net/DatagramService.h
+++ b/ibrdtn/daemon/src/net/DatagramService.h
@@ -22,7 +22,7 @@ namespace dtn
 			DatagramException(const std::string &what) : ibrcommon::Exception(what)
 			{};
 
-			virtual ~DatagramException() throw() {};
+			virtual ~DatagramException() noexcept {};
 		};
 
 		class WrongSeqNoException : public DatagramException
@@ -32,7 +32,7 @@ namespace dtn
 			: DatagramException("Wrong sequence number received"), expected_seqno(exp_seqno)
 			{};
 
-			virtual ~WrongSeqNoException() throw() {};
+			virtual ~WrongSeqNoException() noexcept {};
 
 			const size_t expected_seqno;
 		};
@@ -79,7 +79,7 @@ namespace dtn
 			 * Bind to the local socket.
 			 * @throw If the bind fails, an DatagramException is thrown.
 			 */
-			virtual void bind() throw (DatagramException) = 0;
+			virtual void bind() noexcept (false) = 0;
 
 			/**
 			 * Shutdown the socket. Unblock all calls on the socket (recv, send, etc.)
@@ -93,7 +93,7 @@ namespace dtn
 			 * @param length The number of available bytes in the buffer.
 			 * @throw If the transmission wasn't successful this method will throw an exception.
 			 */
-			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) throw (DatagramException) = 0;
+			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) noexcept (false) = 0;
 
 			/**
 			 * Send the payload as datagram to all neighbors (broadcast)
@@ -101,7 +101,7 @@ namespace dtn
 			 * @param length The number of available bytes in the buffer.
 			 * @throw If the transmission wasn't successful this method will throw an exception.
 			 */
-			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (DatagramException) = 0;
+			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false) = 0;
 
 			/**
 			 * Receive an incoming datagram.
@@ -111,7 +111,7 @@ namespace dtn
 			 * @throw If the receive call failed for any reason, an DatagramException is thrown.
 			 * @return The number of received bytes.
 			 */
-			virtual size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (DatagramException) = 0;
+			virtual size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false) = 0;
 
 			/**
 			 * Get the tag for this service used in discovery messages.

--- a/ibrdtn/daemon/src/net/DiscoveryAgent.cpp
+++ b/ibrdtn/daemon/src/net/DiscoveryAgent.cpp
@@ -51,7 +51,7 @@ namespace dtn
 			return "DiscoveryAgent";
 		}
 
-		void DiscoveryAgent::raiseEvent(const dtn::core::TimeEvent&) throw ()
+		void DiscoveryAgent::raiseEvent(const dtn::core::TimeEvent&) noexcept
 		{
 			const dtn::data::Timestamp ts = dtn::utils::Clock::getMonotonicTimestamp();
 
@@ -64,7 +64,7 @@ namespace dtn
 			}
 		}
 
-		void DiscoveryAgent::raiseEvent(const dtn::core::GlobalEvent &global) throw ()
+		void DiscoveryAgent::raiseEvent(const dtn::core::GlobalEvent &global) noexcept
 		{
 			if (global.getAction() == dtn::core::GlobalEvent::GLOBAL_START_DISCOVERY) {
 				// start sending discovery beacons
@@ -85,7 +85,7 @@ namespace dtn
 			}
 		}
 
-		void DiscoveryAgent::componentUp() throw ()
+		void DiscoveryAgent::componentUp() noexcept
 		{
 			// listen to global events (discovery start/stop)
 			dtn::core::EventDispatcher<dtn::core::GlobalEvent>::add(this);
@@ -94,7 +94,7 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
 		}
 
-		void DiscoveryAgent::componentDown() throw ()
+		void DiscoveryAgent::componentDown() noexcept
 		{
 			// un-listen to global events (discovery start/stop)
 			dtn::core::EventDispatcher<dtn::core::GlobalEvent>::remove(this);

--- a/ibrdtn/daemon/src/net/DiscoveryAgent.h
+++ b/ibrdtn/daemon/src/net/DiscoveryAgent.h
@@ -50,8 +50,8 @@ namespace dtn
 			/**
 			 * method to receive global events
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
-			void raiseEvent(const dtn::core::GlobalEvent &evt) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::GlobalEvent &evt) noexcept;
 
 			void onBeaconReceived(const DiscoveryBeacon &beacon);
 
@@ -64,8 +64,8 @@ namespace dtn
 			DiscoveryBeacon obtainBeacon() const;
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 			virtual const std::string getName() const;
 

--- a/ibrdtn/daemon/src/net/DiscoveryBeaconHandler.cpp
+++ b/ibrdtn/daemon/src/net/DiscoveryBeaconHandler.cpp
@@ -29,11 +29,11 @@ namespace dtn
 		{
 		}
 
-		void DiscoveryBeaconHandler::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ()
+		void DiscoveryBeaconHandler::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept
 		{
 		}
 
-		void DiscoveryBeaconHandler::onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) throw (NoServiceHereException)
+		void DiscoveryBeaconHandler::onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) noexcept (false)
 		{
 			throw NoServiceHereException();
 		}

--- a/ibrdtn/daemon/src/net/DiscoveryBeaconHandler.h
+++ b/ibrdtn/daemon/src/net/DiscoveryBeaconHandler.h
@@ -36,18 +36,18 @@ namespace dtn
 			class NoServiceHereException : public ibrcommon::Exception
 			{
 			public:
-				NoServiceHereException(std::string what = "No service available.") throw() : ibrcommon::Exception(what)
+				NoServiceHereException(std::string what = "No service available.") noexcept : ibrcommon::Exception(what)
 				{
 				};
 
-				virtual ~NoServiceHereException() throw() {};
+				virtual ~NoServiceHereException() noexcept {};
 			};
 
 			virtual ~DiscoveryBeaconHandler() = 0;
 
-			virtual void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ();
+			virtual void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept;
 
-			virtual void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) throw (NoServiceHereException);
+			virtual void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) noexcept (false);
 		};
 	}
 }

--- a/ibrdtn/daemon/src/net/EMailConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/EMailConvergenceLayer.cpp
@@ -47,7 +47,7 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
 		}
 
-		void EMailConvergenceLayer::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void EMailConvergenceLayer::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			if (time.getAction() == dtn::core::TIME_SECOND_TICK)
 			{
@@ -68,7 +68,7 @@ namespace dtn
 		}
 
 		void EMailConvergenceLayer::onUpdateBeacon(const ibrcommon::vinterface&, DiscoveryBeacon &beacon)
-			throw (DiscoveryBeaconHandler::NoServiceHereException)
+			noexcept (false)
 		{
 			beacon.addService(DiscoveryService(getDiscoveryProtocol(), "email=" + _config.getOwnAddress()));
 		}
@@ -113,15 +113,15 @@ namespace dtn
 			return "EMailConvergenceLayer";
 		}
 
-		void EMailConvergenceLayer::__cancellation() throw () {}
+		void EMailConvergenceLayer::__cancellation() noexcept {}
 
-		void EMailConvergenceLayer::componentUp() throw ()
+		void EMailConvergenceLayer::componentUp() noexcept
 		{
 			// register as discovery beacon handler
 			dtn::core::BundleCore::getInstance().getDiscoveryAgent().registerService(this);
 		}
 
-		void EMailConvergenceLayer::componentDown() throw ()
+		void EMailConvergenceLayer::componentDown() noexcept
 		{
 			// un-register as discovery beacon handler
 			dtn::core::BundleCore::getInstance().getDiscoveryAgent().unregisterService(this);

--- a/ibrdtn/daemon/src/net/EMailConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/EMailConvergenceLayer.h
@@ -58,14 +58,14 @@ namespace dtn
 			 * following events:
 			 *   - dtn::core::TimeEvent
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &event) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &event) noexcept;
 
 			/**
 			 * This method updates the given values for discovery service.
 			 * It publishes the email address of the EMail Convergence Layer
 			 */
 			void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon)
-					throw (DiscoveryBeaconHandler::NoServiceHereException);
+					noexcept (false);
 
 			/**
 			 * Returns the discovery protocol type:
@@ -95,10 +95,10 @@ namespace dtn
 			virtual const std::string getName() const;
 
 		protected:
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 		private:
 			/**

--- a/ibrdtn/daemon/src/net/EMailImapService.cpp
+++ b/ibrdtn/daemon/src/net/EMailImapService.cpp
@@ -180,7 +180,7 @@ namespace dtn
 			}
 		}
 
-		void EMailImapService::run() throw ()
+		void EMailImapService::run() noexcept
 		{
 			while(true)
 			{
@@ -202,7 +202,7 @@ namespace dtn
 			}
 		}
 
-		void EMailImapService::__cancellation() throw ()
+		void EMailImapService::__cancellation() noexcept
 		{
 			_run = false;
 			disconnect();

--- a/ibrdtn/daemon/src/net/EMailImapService.h
+++ b/ibrdtn/daemon/src/net/EMailImapService.h
@@ -44,12 +44,12 @@ namespace dtn
 			/**
 			 * The run method of the thread
 			 */
-			void run() throw ();
+			void run() noexcept;
 
 			/**
 			 * The cancellation method of the thread
 			 */
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
 			/**
 			 * Stores the given tasks in a list. After each fetch this list will

--- a/ibrdtn/daemon/src/net/EMailSmtpService.cpp
+++ b/ibrdtn/daemon/src/net/EMailSmtpService.cpp
@@ -120,7 +120,7 @@ namespace dtn
 			_queue.abort();
 		}
 
-		void EMailSmtpService::run() throw ()
+		void EMailSmtpService::run() noexcept
 		{
 			while(true)
 			{
@@ -178,7 +178,7 @@ namespace dtn
 			}
 		}
 
-		void EMailSmtpService::__cancellation() throw ()
+		void EMailSmtpService::__cancellation() noexcept
 		{
 			_run = false;
 			disconnect();

--- a/ibrdtn/daemon/src/net/EMailSmtpService.h
+++ b/ibrdtn/daemon/src/net/EMailSmtpService.h
@@ -132,12 +132,12 @@ namespace dtn
 			/**
 			 * The run method of the thread
 			 */
-			void run() throw ();
+			void run() noexcept;
 
 			/**
 			 * The cancellation method of the thread
 			 */
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
 		private:
 			/**

--- a/ibrdtn/daemon/src/net/FileConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/FileConvergenceLayer.cpp
@@ -65,26 +65,26 @@ namespace dtn
 		{
 		}
 
-		void FileConvergenceLayer::componentUp() throw ()
+		void FileConvergenceLayer::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::core::NodeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
 		}
 
-		void FileConvergenceLayer::componentDown() throw ()
+		void FileConvergenceLayer::componentDown() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::core::NodeEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
 		}
 
-		void FileConvergenceLayer::__cancellation() throw ()
+		void FileConvergenceLayer::__cancellation() noexcept
 		{
 			_tasks.abort();
 		}
 
-		void FileConvergenceLayer::componentRun() throw ()
+		void FileConvergenceLayer::componentRun() noexcept
 		{
 			try {
 				while (true)
@@ -222,7 +222,7 @@ namespace dtn
 			} catch (const ibrcommon::QueueUnblockedException &ex) { };
 		}
 
-		void FileConvergenceLayer::raiseEvent(const dtn::core::NodeEvent &node) throw ()
+		void FileConvergenceLayer::raiseEvent(const dtn::core::NodeEvent &node) noexcept
 		{
 			if (node.getAction() == dtn::core::NODE_AVAILABLE)
 			{
@@ -234,7 +234,7 @@ namespace dtn
 			}
 		}
 
-		void FileConvergenceLayer::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void FileConvergenceLayer::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			if (time.getAction() == dtn::core::TIME_SECOND_TICK)
 			{

--- a/ibrdtn/daemon/src/net/FileConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/FileConvergenceLayer.h
@@ -43,8 +43,8 @@ namespace dtn
 			FileConvergenceLayer();
 			virtual ~FileConvergenceLayer();
 
-			void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
+			void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
 
 			dtn::core::Node::Protocol getDiscoveryProtocol() const;
 
@@ -54,11 +54,11 @@ namespace dtn
 			const std::string getName() const;
 
 		protected:
-			void componentUp() throw ();
-			void componentRun() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentRun() noexcept;
+			void componentDown() noexcept;
 
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
 		private:
 			class Task

--- a/ibrdtn/daemon/src/net/FileMonitor.cpp
+++ b/ibrdtn/daemon/src/net/FileMonitor.cpp
@@ -42,7 +42,7 @@ namespace dtn
 		{
 		}
 
-		void inotifysocket::up() throw (ibrcommon::socket_exception)
+		void inotifysocket::up() noexcept (false)
 		{
 			if (_state != SOCKET_DOWN)
 				throw ibrcommon::socket_exception("socket is already up");
@@ -55,7 +55,7 @@ namespace dtn
 			_state = SOCKET_UP;
 		}
 
-		void inotifysocket::down() throw (ibrcommon::socket_exception)
+		void inotifysocket::down() noexcept (false)
 		{
 			if (_state != SOCKET_UP)
 				throw ibrcommon::socket_exception("socket is not up");
@@ -74,7 +74,7 @@ namespace dtn
 			_state = SOCKET_DOWN;
 		}
 
-		void inotifysocket::watch(const ibrcommon::File &path, int opts) throw (ibrcommon::socket_exception)
+		void inotifysocket::watch(const ibrcommon::File &path, int opts) noexcept (false)
 		{
 #ifdef HAVE_SYS_INOTIFY_H
 			int wd = inotify_add_watch(this->fd(), path.getPath().c_str(), opts);
@@ -82,7 +82,7 @@ namespace dtn
 #endif
 		}
 
-		ssize_t inotifysocket::read(char *data, size_t len) throw (ibrcommon::socket_exception)
+		ssize_t inotifysocket::read(char *data, size_t len) noexcept (false)
 		{
 #ifdef HAVE_SYS_INOTIFY_H
 			return ::read(this->fd(), data, len);
@@ -118,9 +118,9 @@ namespace dtn
 			_watchset.insert(watch);
 		}
 
-		void FileMonitor::componentUp() throw ()
+		void FileMonitor::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				_socket.up();
 			} catch (const ibrcommon::socket_exception &ex) {
@@ -128,7 +128,7 @@ namespace dtn
 			}
 		}
 
-		void FileMonitor::componentRun() throw ()
+		void FileMonitor::componentRun() noexcept
 		{
 #ifdef HAVE_SYS_INOTIFY_H
 			while (_running)
@@ -163,12 +163,12 @@ namespace dtn
 #endif
 		}
 
-		void FileMonitor::componentDown() throw ()
+		void FileMonitor::componentDown() noexcept
 		{
 			_socket.down();
 		}
 
-		void FileMonitor::__cancellation() throw ()
+		void FileMonitor::__cancellation() noexcept
 		{
 			_socket.down();
 		}

--- a/ibrdtn/daemon/src/net/FileMonitor.h
+++ b/ibrdtn/daemon/src/net/FileMonitor.h
@@ -39,12 +39,12 @@ namespace dtn
 			inotifysocket();
 			virtual ~inotifysocket();
 
-			virtual void up() throw (ibrcommon::socket_exception);
-			virtual void down() throw (ibrcommon::socket_exception);
+			virtual void up() noexcept (false);
+			virtual void down() noexcept (false);
 
-			void watch(const ibrcommon::File &path, int opts) throw (ibrcommon::socket_exception);
+			void watch(const ibrcommon::File &path, int opts) noexcept (false);
 
-			ssize_t read(char *data, size_t len) throw (ibrcommon::socket_exception);
+			ssize_t read(char *data, size_t len) noexcept (false);
 
 		private:
 
@@ -63,11 +63,11 @@ namespace dtn
 			const std::string getName() const;
 
 		protected:
-			void componentUp() throw ();
-			void componentRun() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentRun() noexcept;
+			void componentDown() noexcept;
 
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
 		private:
 			void scan();

--- a/ibrdtn/daemon/src/net/HTTPConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/HTTPConvergenceLayer.cpp
@@ -143,7 +143,7 @@ namespace dtn
 		 * a BundleReceivedEvent will be raised.
 		 *
 		 */
-		void DownloadThread::run() throw ()
+		void DownloadThread::run() noexcept
 		{
 			try  {
 				// create a filter context
@@ -175,7 +175,7 @@ namespace dtn
 			}
 		}
 
-		void DownloadThread::__cancellation() throw ()
+		void DownloadThread::__cancellation() noexcept
 		{
 		}
 
@@ -310,9 +310,9 @@ namespace dtn
 		 * Method from IndependentComponent interface, this method is called before
 		 * the componentRun() method is called. At time here is nothing to do.
 		 */
-		void HTTPConvergenceLayer::componentUp() throw ()
+		void HTTPConvergenceLayer::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 		}
 
 		/**
@@ -326,7 +326,7 @@ namespace dtn
 		 * DownloadThread the iobuffer will be initialize, when disconnecting the iobuffer
 		 * will finalize.
 		 */
-		void HTTPConvergenceLayer::componentRun() throw ()
+		void HTTPConvergenceLayer::componentRun() noexcept
 		{
 
 			std::string url = _server + "?eid=" + dtn::core::BundleCore::local.getString();
@@ -403,7 +403,7 @@ namespace dtn
 		 * the IBR-DTN is shutting down. This method trys to stop the DownloadThread
 		 * and to finalize the iobuffer, for a clean shut down.
 		 */
-		void HTTPConvergenceLayer::componentDown() throw ()
+		void HTTPConvergenceLayer::componentDown() noexcept
 		{
 		}
 
@@ -411,7 +411,7 @@ namespace dtn
 		 * This method is from IndependentComponent interface. It could abort
 		 * the componentRun() thread on the hard way.
 		 */
-		void HTTPConvergenceLayer::__cancellation() throw ()
+		void HTTPConvergenceLayer::__cancellation() noexcept
 		{
 			_running = false;
 

--- a/ibrdtn/daemon/src/net/HTTPConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/HTTPConvergenceLayer.h
@@ -82,10 +82,10 @@ namespace dtn
 
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentRun() throw ();
-			virtual void componentDown() throw ();
-			void __cancellation() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentRun() noexcept;
+			virtual void componentDown() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			/** Variable contains Tomcat-Server URL, which is specified
@@ -109,8 +109,8 @@ namespace dtn
 			virtual ~DownloadThread();
 
 		protected:
-			void run() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			/** istream variable is using for reading from iobuffer */

--- a/ibrdtn/daemon/src/net/IPNDAgent.cpp
+++ b/ibrdtn/daemon/src/net/IPNDAgent.cpp
@@ -84,7 +84,7 @@ namespace dtn
 			_interfaces.insert(net);
 		}
 
-		void IPNDAgent::join(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) throw ()
+		void IPNDAgent::join(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "Join on " << iface.toString() << " (" << addr.toString() << ", family: " << addr.family() << ")" << IBRCOMMON_LOGGER_ENDL;
 
@@ -131,7 +131,7 @@ namespace dtn
 			_socket.add(msock, iface);
 		}
 
-		void IPNDAgent::leave(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) throw ()
+		void IPNDAgent::leave(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(TAG, 10) << "Leave " << iface.toString() << " (" << addr.toString() << ", family: " << addr.family() << ")" << IBRCOMMON_LOGGER_ENDL;
 
@@ -162,7 +162,7 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::leave(const ibrcommon::vinterface &iface) throw ()
+		void IPNDAgent::leave(const ibrcommon::vinterface &iface) noexcept
 		{
 			// get all sockets bound to the given interface
 			ibrcommon::socketset ifsocks = _socket.get(iface);
@@ -187,7 +187,7 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::join(const ibrcommon::vinterface &iface) throw ()
+		void IPNDAgent::join(const ibrcommon::vinterface &iface) noexcept
 		{
 			std::list<ibrcommon::vaddress> addrs = iface.getAddresses();
 
@@ -199,7 +199,7 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ()
+		void IPNDAgent::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept
 		{
 			// serialize announcement
 			stringstream ss; ss << beacon;
@@ -237,7 +237,7 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::raiseEvent(const dtn::net::P2PDialupEvent &dialup) throw ()
+		void IPNDAgent::raiseEvent(const dtn::net::P2PDialupEvent &dialup) noexcept
 		{
 			switch (dialup.type)
 			{
@@ -329,9 +329,9 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::componentUp() throw ()
+		void IPNDAgent::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 
 			try {
 				// setup the sockets
@@ -401,7 +401,7 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::componentDown() throw ()
+		void IPNDAgent::componentDown() noexcept
 		{
 			// un-listen to P2P dial-up events
 			dtn::core::EventDispatcher<dtn::net::P2PDialupEvent>::remove(this);
@@ -422,7 +422,7 @@ namespace dtn
 			ibrcommon::JoinableThread::join();
 		}
 
-		void IPNDAgent::componentRun() throw ()
+		void IPNDAgent::componentRun() noexcept
 		{
 			struct timeval tv;
 
@@ -511,7 +511,7 @@ namespace dtn
 			}
 		}
 
-		void IPNDAgent::__cancellation() throw ()
+		void IPNDAgent::__cancellation() noexcept
 		{
 			// shutdown and interrupt the receiving thread
 			_socket.down();

--- a/ibrdtn/daemon/src/net/IPNDAgent.h
+++ b/ibrdtn/daemon/src/net/IPNDAgent.h
@@ -63,25 +63,25 @@ namespace dtn
 			/**
 			 * @see EventReceiver::raiseEvent()
 			 */
-			void raiseEvent(const dtn::net::P2PDialupEvent &evt) throw ();
+			void raiseEvent(const dtn::net::P2PDialupEvent &evt) noexcept;
 
 			/**
 			 * This method is called by the DiscoveryAgent every time a beacon is ready for advertisement
 			 */
-			void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ();
+			void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept;
 
 		protected:
-			virtual void componentRun() throw ();
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
-			void __cancellation() throw ();
+			virtual void componentRun() noexcept;
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
+			void __cancellation() noexcept;
 
 		private:
-			void join(const ibrcommon::vinterface &iface) throw ();
-			void leave(const ibrcommon::vinterface &iface) throw ();
+			void join(const ibrcommon::vinterface &iface) noexcept;
+			void leave(const ibrcommon::vinterface &iface) noexcept;
 
-			void join(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) throw ();
-			void leave(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) throw ();
+			void join(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) noexcept;
+			void leave(const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr) noexcept;
 
 			void send(const DiscoveryBeacon &a, const ibrcommon::vinterface &iface, const ibrcommon::vaddress &addr);
 

--- a/ibrdtn/daemon/src/net/LOWPANConnection.cpp
+++ b/ibrdtn/daemon/src/net/LOWPANConnection.cpp
@@ -58,12 +58,12 @@ namespace dtn
 			return _stream;
 		}
 
-		void LOWPANConnection::setup() throw ()
+		void LOWPANConnection::setup() noexcept
 		{
 			_sender.start();
 		}
 
-		void LOWPANConnection::finally() throw ()
+		void LOWPANConnection::finally() noexcept
 		{
 			_sender.stop();
 			_sender.join();
@@ -72,7 +72,7 @@ namespace dtn
 			_cl.remove(this);
 		}
 
-		void LOWPANConnection::run() throw ()
+		void LOWPANConnection::run() noexcept
 		{
 			try {
 				// create a filter context
@@ -112,7 +112,7 @@ namespace dtn
 			}
 		}
 
-		void LOWPANConnection::__cancellation() throw ()
+		void LOWPANConnection::__cancellation() noexcept
 		{
 			_sender.stop();
 		}
@@ -133,7 +133,7 @@ namespace dtn
 			_queue.push(job);
 		}
 
-		void LOWPANConnectionSender::run() throw ()
+		void LOWPANConnectionSender::run() noexcept
 		{
 			try {
 				// create a filter context
@@ -176,7 +176,7 @@ namespace dtn
 			}
 		}
 
-		void LOWPANConnectionSender::__cancellation() throw ()
+		void LOWPANConnectionSender::__cancellation() noexcept
 		{
 			_queue.abort();
 		}

--- a/ibrdtn/daemon/src/net/LOWPANConnection.h
+++ b/ibrdtn/daemon/src/net/LOWPANConnection.h
@@ -44,8 +44,8 @@ namespace dtn
 				 * @param job Reference to the job conatining EID and bundle
 				 */
 				void queue(const dtn::net::BundleTransfer &job);
-				void run() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void __cancellation() noexcept;
 
 			private:
 				ibrcommon::lowpanstream &_stream;
@@ -76,10 +76,10 @@ namespace dtn
 			 */
 			ibrcommon::lowpanstream& getStream();
 
-			void run() throw ();
-			void setup() throw ();
-			void finally() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void setup() noexcept;
+			void finally() noexcept;
+			void __cancellation() noexcept;
 
 			/**
 			 * Instance of the LOWPANConnectionSender

--- a/ibrdtn/daemon/src/net/LOWPANConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/LOWPANConvergenceLayer.cpp
@@ -180,7 +180,7 @@ namespace dtn
 			}
 		}
 
-		void LOWPANConvergenceLayer::componentUp() throw ()
+		void LOWPANConvergenceLayer::componentUp() noexcept
 		{
 			try {
 				_vsocket.add(new ibrcommon::lowpansocket(_panid, _net));
@@ -196,7 +196,7 @@ namespace dtn
 			_running = true;
 		}
 
-		void LOWPANConvergenceLayer::componentDown() throw ()
+		void LOWPANConvergenceLayer::componentDown() noexcept
 		{
 			dtn::net::DiscoveryAgent &agent = dtn::core::BundleCore::getInstance().getDiscoveryAgent();
 			agent.unregisterService(_net, this);
@@ -206,7 +206,7 @@ namespace dtn
 			join();
 		}
 
-		void LOWPANConvergenceLayer::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ()
+		void LOWPANConvergenceLayer::onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept
 		{
 			if (_net != iface) return;
 
@@ -234,7 +234,7 @@ namespace dtn
 			send_cb(&ipnd_buf[0], len + 2, _addr_broadcast);
 		}
 
-		void LOWPANConvergenceLayer::componentRun() throw ()
+		void LOWPANConvergenceLayer::componentRun() noexcept
 		{
 			dtn::net::DiscoveryAgent &agent = dtn::core::BundleCore::getInstance().getDiscoveryAgent();
 
@@ -300,7 +300,7 @@ namespace dtn
 			}
 		}
 
-		void LOWPANConvergenceLayer::__cancellation() throw ()
+		void LOWPANConvergenceLayer::__cancellation() noexcept
 		{
 			_running = false;
 			_vsocket.down();

--- a/ibrdtn/daemon/src/net/LOWPANConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/LOWPANConvergenceLayer.h
@@ -54,9 +54,9 @@ namespace dtn
 			 * this method updates the given values
 			 */
 			void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &announcement)
-				throw (dtn::net::DiscoveryBeaconHandler::NoServiceHereException);
+				noexcept (false);
 
-			void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) throw ();
+			void onAdvertiseBeacon(const ibrcommon::vinterface &iface, const DiscoveryBeacon &beacon) noexcept;
 
 			dtn::core::Node::Protocol getDiscoveryProtocol() const;
 
@@ -83,10 +83,10 @@ namespace dtn
 			void remove(const LOWPANConnection *conn);
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentRun() throw ();
-			virtual void componentDown() throw ();
-			void __cancellation() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentRun() noexcept;
+			virtual void componentDown() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			static const size_t BUFF_SIZE;

--- a/ibrdtn/daemon/src/net/LOWPANDatagramService.cpp
+++ b/ibrdtn/daemon/src/net/LOWPANDatagramService.cpp
@@ -64,7 +64,7 @@ namespace dtn
 		 * Bind to the local socket.
 		 * @throw If the bind fails, an DatagramException is thrown.
 		 */
-		void LOWPANDatagramService::bind() throw (DatagramException)
+		void LOWPANDatagramService::bind() noexcept (false)
 		{
 			try {
 				_vsocket.destroy();
@@ -92,7 +92,7 @@ namespace dtn
 		 * @param buf The buffer to send.
 		 * @param length The number of available bytes in the buffer.
 		 */
-		void LOWPANDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const std::string &identifier, const char *buf, size_t length) throw (DatagramException)
+		void LOWPANDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const std::string &identifier, const char *buf, size_t length) noexcept (false)
 		{
 			try {
 				if (length > _params.max_msg_length)
@@ -149,7 +149,7 @@ namespace dtn
 		 * @param buf The buffer to send.
 		 * @param length The number of available bytes in the buffer.
 		 */
-		void LOWPANDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (DatagramException)
+		void LOWPANDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false)
 		{
 			try {
 				if (length > _params.max_msg_length)
@@ -211,7 +211,7 @@ namespace dtn
 		 * @throw If the receive call failed for any reason, an DatagramException is thrown.
 		 * @return The number of received bytes.
 		 */
-		size_t LOWPANDatagramService::recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (DatagramException)
+		size_t LOWPANDatagramService::recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false)
 		{
 			try {
 				ibrcommon::socketset readfds;

--- a/ibrdtn/daemon/src/net/LOWPANDatagramService.h
+++ b/ibrdtn/daemon/src/net/LOWPANDatagramService.h
@@ -42,7 +42,7 @@ namespace dtn
 			 * Bind to the local socket.
 			 * @throw If the bind fails, an DatagramException is thrown.
 			 */
-			virtual void bind() throw (DatagramException);
+			virtual void bind() noexcept (false);
 
 			/**
 			 * Shutdown the socket. Unblock all calls on the socket (recv, send, etc.)
@@ -55,14 +55,14 @@ namespace dtn
 			 * @param buf The buffer to send.
 			 * @param length The number of available bytes in the buffer.
 			 */
-			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) throw (DatagramException);
+			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) noexcept (false);
 
 			/**
 			 * Send the payload as datagram to all neighbors (broadcast)
 			 * @param buf The buffer to send.
 			 * @param length The number of available bytes in the buffer.
 			 */
-			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (DatagramException);
+			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false);
 
 			/**
 			 * Receive an incoming datagram.
@@ -72,7 +72,7 @@ namespace dtn
 			 * @throw If the receive call failed for any reason, an DatagramException is thrown.
 			 * @return The number of received bytes.
 			 */
-			virtual size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (DatagramException);
+			virtual size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false);
 
 			/**
 			 * Get the service description for this convergence layer. This

--- a/ibrdtn/daemon/src/net/TCPConnection.cpp
+++ b/ibrdtn/daemon/src/net/TCPConnection.cpp
@@ -111,11 +111,11 @@ namespace dtn
 			(*getProtocolStream()).reject();
 		}
 
-		void TCPConnection::eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) throw ()
+		void TCPConnection::eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) noexcept
 		{
 		}
 
-		void TCPConnection::eventTimeout() throw ()
+		void TCPConnection::eventTimeout() noexcept
 		{
 			// event
 			ConnectionEvent::raise(ConnectionEvent::CONNECTION_TIMEOUT, _node);
@@ -128,11 +128,11 @@ namespace dtn
 			}
 		}
 
-		void TCPConnection::eventError() throw ()
+		void TCPConnection::eventError() noexcept
 		{
 		}
 
-		void TCPConnection::initiateExtendedHandshake() throw (ibrcommon::Exception)
+		void TCPConnection::initiateExtendedHandshake() noexcept (false)
 		{
 #ifdef WITH_TLS
 			/* if both nodes support TLS, activate it */
@@ -190,7 +190,7 @@ namespace dtn
 #endif
 		}
 
-		void TCPConnection::eventConnectionUp(const dtn::streams::StreamContactHeader &header) throw ()
+		void TCPConnection::eventConnectionUp(const dtn::streams::StreamContactHeader &header) noexcept
 		{
 			_peer = header;
 
@@ -248,7 +248,7 @@ namespace dtn
 			ConnectionEvent::raise(ConnectionEvent::CONNECTION_UP, _node);
 		}
 
-		void TCPConnection::eventConnectionDown() throw ()
+		void TCPConnection::eventConnectionDown() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(TCPConnection::TAG, 40) << "eventConnectionDown()" << IBRCOMMON_LOGGER_ENDL;
 
@@ -269,7 +269,7 @@ namespace dtn
 			}
 		}
 
-		void TCPConnection::eventBundleRefused() throw ()
+		void TCPConnection::eventBundleRefused() noexcept
 		{
 			ibrcommon::Queue<dtn::net::BundleTransfer>::Locked l = _sentqueue.exclusive();
 
@@ -292,7 +292,7 @@ namespace dtn
 			l.pop();
 		}
 
-		void TCPConnection::eventBundleForwarded() throw ()
+		void TCPConnection::eventBundleForwarded() noexcept
 		{
 			ibrcommon::Queue<dtn::net::BundleTransfer>::Locked l = _sentqueue.exclusive();
 
@@ -315,22 +315,22 @@ namespace dtn
 			l.pop();
 		}
 
-		void TCPConnection::eventBundleAck(const dtn::data::Length &ack) throw ()
+		void TCPConnection::eventBundleAck(const dtn::data::Length &ack) noexcept
 		{
 			_lastack = ack;
 		}
 
-		void TCPConnection::addTrafficIn(size_t amount) throw ()
+		void TCPConnection::addTrafficIn(size_t amount) noexcept
 		{
 			_callback.addTrafficIn(amount);
 		}
 
-		void TCPConnection::addTrafficOut(size_t amount) throw ()
+		void TCPConnection::addTrafficOut(size_t amount) noexcept
 		{
 			_callback.addTrafficOut(amount);
 		}
 
-		void TCPConnection::initialize() throw ()
+		void TCPConnection::initialize() noexcept
 		{
 			// start the receiver for incoming bundles + handshake
 			try {
@@ -340,7 +340,7 @@ namespace dtn
 			}
 		}
 
-		void TCPConnection::shutdown() throw ()
+		void TCPConnection::shutdown() noexcept
 		{
 			try {
 				// shutdown
@@ -355,7 +355,7 @@ namespace dtn
 			}
 		}
 
-		void TCPConnection::__cancellation() throw ()
+		void TCPConnection::__cancellation() noexcept
 		{
 			// mark the connection as aborted
 			_aborted = true;
@@ -364,7 +364,7 @@ namespace dtn
 			if (_socket_stream != NULL) _socket_stream->close();
 		}
 
-		void TCPConnection::finally() throw ()
+		void TCPConnection::finally() noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG(TCPConnection::TAG, 60) << "TCPConnection down" << IBRCOMMON_LOGGER_ENDL;
 
@@ -387,7 +387,7 @@ namespace dtn
 			clearQueue();
 		}
 
-		void TCPConnection::setup() throw ()
+		void TCPConnection::setup() noexcept
 		{
 			_flags |= dtn::streams::StreamContactHeader::REQUEST_ACKNOWLEDGMENTS;
 			_flags |= dtn::streams::StreamContactHeader::REQUEST_NEGATIVE_ACKNOWLEDGMENTS;
@@ -500,7 +500,7 @@ namespace dtn
 			} catch (const bad_cast&) { };
 		}
 
-		void TCPConnection::run() throw ()
+		void TCPConnection::run() noexcept
 		{
 			try {
 				if (_socket == NULL) {
@@ -602,7 +602,7 @@ namespace dtn
 			}
 		}
 
-		TCPConnection::safe_streamconnection TCPConnection::getProtocolStream() throw (ibrcommon::Exception)
+		TCPConnection::safe_streamconnection TCPConnection::getProtocolStream() noexcept (false)
 		{
 			return safe_streamconnection(_protocol_stream, _protocol_stream_mutex);
 		}
@@ -617,7 +617,7 @@ namespace dtn
 		{
 		}
 
-		void TCPConnection::KeepaliveSender::run() throw ()
+		void TCPConnection::KeepaliveSender::run() noexcept
 		{
 			try {
 				ibrcommon::MutexLock l(_wait);
@@ -640,7 +640,7 @@ namespace dtn
 			} catch (const std::exception&) { };
 		}
 
-		void TCPConnection::KeepaliveSender::__cancellation() throw ()
+		void TCPConnection::KeepaliveSender::__cancellation() noexcept
 		{
 			ibrcommon::MutexLock l(_wait);
 			_wait.abort();
@@ -655,13 +655,13 @@ namespace dtn
 		{
 		}
 
-		void TCPConnection::Sender::__cancellation() throw ()
+		void TCPConnection::Sender::__cancellation() noexcept
 		{
 			// cancel the main thread in here
 			ibrcommon::Queue<dtn::net::BundleTransfer>::abort();
 		}
 
-		void TCPConnection::Sender::run() throw ()
+		void TCPConnection::Sender::run() noexcept
 		{
 			try {
 				dtn::storage::BundleStorage &storage = dtn::core::BundleCore::getInstance().getStorage();
@@ -802,7 +802,7 @@ namespace dtn
 			return _socket_stream->good();
 		}
 
-		void TCPConnection::Sender::finally() throw ()
+		void TCPConnection::Sender::finally() noexcept
 		{
 		}
 

--- a/ibrdtn/daemon/src/net/TCPConnection.h
+++ b/ibrdtn/daemon/src/net/TCPConnection.h
@@ -68,12 +68,12 @@ namespace dtn
 			/**
 			 * This method is called after accept()
 			 */
-			virtual void initialize() throw ();
+			virtual void initialize() noexcept;
 
 			/**
 			 * shutdown the whole tcp connection
 			 */
-			void shutdown() throw ();
+			void shutdown() noexcept;
 
 			/**
 			 * Get the header of this connection
@@ -90,18 +90,18 @@ namespace dtn
 			/**
 			 * callback methods for tcpstream
 			 */
-			virtual void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases csc) throw ();
-			virtual void eventTimeout() throw ();
-			virtual void eventError() throw ();
-			virtual void eventConnectionUp(const dtn::streams::StreamContactHeader &header) throw ();
-			virtual void eventConnectionDown() throw ();
+			virtual void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases csc) noexcept;
+			virtual void eventTimeout() noexcept;
+			virtual void eventError() noexcept;
+			virtual void eventConnectionUp(const dtn::streams::StreamContactHeader &header) noexcept;
+			virtual void eventConnectionDown() noexcept;
 
-			virtual void eventBundleRefused() throw ();
-			virtual void eventBundleForwarded() throw ();
-			virtual void eventBundleAck(const dtn::data::Length &ack) throw ();
+			virtual void eventBundleRefused() noexcept;
+			virtual void eventBundleForwarded() noexcept;
+			virtual void eventBundleAck(const dtn::data::Length &ack) noexcept;
 
-			virtual void addTrafficIn(size_t) throw ();
-			virtual void addTrafficOut(size_t) throw ();
+			virtual void addTrafficIn(size_t) noexcept;
+			virtual void addTrafficOut(size_t) noexcept;
 
 			dtn::core::Node::Protocol getDiscoveryProtocol() const;
 
@@ -125,18 +125,18 @@ namespace dtn
 		protected:
 			void rejectTransmission();
 
-			void setup() throw ();
+			void setup() noexcept;
 			void connect();
-			void run() throw ();
-			void finally() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void finally() noexcept;
+			void __cancellation() noexcept;
 
 			void clearQueue();
 
 			void keepalive();
 			bool good() const;
 
-			void initiateExtendedHandshake() throw (ibrcommon::Exception);
+			void initiateExtendedHandshake() noexcept (false);
 
 		private:
 			class KeepaliveSender : public ibrcommon::JoinableThread
@@ -148,12 +148,12 @@ namespace dtn
 				/**
 				 * run method of the thread
 				 */
-				void run() throw ();
+				void run() noexcept;
 
 				/**
 				 * soft-cancellation function
 				 */
-				void __cancellation() throw ();
+				void __cancellation() noexcept;
 
 			private:
 				ibrcommon::Conditional _wait;
@@ -168,9 +168,9 @@ namespace dtn
 				virtual ~Sender();
 
 			protected:
-				void run() throw ();
-				void finally() throw ();
-				void __cancellation() throw ();
+				void run() noexcept;
+				void finally() noexcept;
+				void __cancellation() noexcept;
 
 			private:
 				TCPConnection &_connection;
@@ -185,7 +185,7 @@ namespace dtn
 			 * Return a thread-safe reference to the protocol stream
 			 * This method will throw an exception if the stream is NULL
 			 */
-			safe_streamconnection getProtocolStream() throw (ibrcommon::Exception);
+			safe_streamconnection getProtocolStream() noexcept (false);
 
 			dtn::streams::StreamContactHeader _peer;
 			dtn::core::Node _node;

--- a/ibrdtn/daemon/src/net/TCPConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/TCPConvergenceLayer.cpp
@@ -73,7 +73,7 @@ namespace dtn
 			_vsocket.destroy();
 		}
 
-		void TCPConvergenceLayer::add(const ibrcommon::vinterface &net, int port) throw ()
+		void TCPConvergenceLayer::add(const ibrcommon::vinterface &net, int port) noexcept
 		{
 			// do not allow any futher binding if we already bound to any interface
 			if (_any_port > 0) return;
@@ -97,7 +97,7 @@ namespace dtn
 			}
 		}
 
-		void TCPConvergenceLayer::listen(const ibrcommon::vinterface &net, int port) throw ()
+		void TCPConvergenceLayer::listen(const ibrcommon::vinterface &net, int port) noexcept
 		{
 			try {
 				// add the new interface to internal data-structures
@@ -162,7 +162,7 @@ namespace dtn
 			}
 		}
 
-		void TCPConvergenceLayer::unlisten(const ibrcommon::vinterface &iface) throw ()
+		void TCPConvergenceLayer::unlisten(const ibrcommon::vinterface &iface) noexcept
 		{
 			ibrcommon::socketset socks = _vsocket.get(iface);
 			for (ibrcommon::socketset::iterator iter = socks.begin(); iter != socks.end(); ++iter) {
@@ -189,7 +189,7 @@ namespace dtn
 			return dtn::core::Node::CONN_TCPIP;
 		}
 
-		void TCPConvergenceLayer::onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) throw (dtn::net::DiscoveryBeaconHandler::NoServiceHereException)
+		void TCPConvergenceLayer::onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_interface_lock);
 
@@ -273,7 +273,7 @@ namespace dtn
 			return TCPConvergenceLayer::TAG;
 		}
 
-		void TCPConvergenceLayer::raiseEvent(const dtn::net::P2PDialupEvent &dialup) throw ()
+		void TCPConvergenceLayer::raiseEvent(const dtn::net::P2PDialupEvent &dialup) noexcept
 		{
 			switch (dialup.type)
 			{
@@ -509,19 +509,19 @@ namespace dtn
 			}
 		}
 
-		void TCPConvergenceLayer::addTrafficIn(size_t amount) throw ()
+		void TCPConvergenceLayer::addTrafficIn(size_t amount) noexcept
 		{
 			ibrcommon::MutexLock l(_stats_lock);
 			_stats_in += amount;
 		}
 
-		void TCPConvergenceLayer::addTrafficOut(size_t amount) throw ()
+		void TCPConvergenceLayer::addTrafficOut(size_t amount) noexcept
 		{
 			ibrcommon::MutexLock l(_stats_lock);
 			_stats_out += amount;
 		}
 
-		void TCPConvergenceLayer::componentRun() throw ()
+		void TCPConvergenceLayer::componentRun() noexcept
 		{
 			try {
 				while (true)
@@ -580,7 +580,7 @@ namespace dtn
 			}
 		}
 
-		void TCPConvergenceLayer::__cancellation() throw ()
+		void TCPConvergenceLayer::__cancellation() noexcept
 		{
 			_vsocket.down();
 		}
@@ -598,12 +598,12 @@ namespace dtn
 			}
 		}
 
-		void TCPConvergenceLayer::componentUp() throw ()
+		void TCPConvergenceLayer::componentUp() noexcept
 		{
 			// listen on P2P dial-up events
 			dtn::core::EventDispatcher<dtn::net::P2PDialupEvent>::add(this);
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// listen on the socket
 				_vsocket.up();
@@ -613,12 +613,12 @@ namespace dtn
 			}
 		}
 
-		void TCPConvergenceLayer::componentDown() throw ()
+		void TCPConvergenceLayer::componentDown() noexcept
 		{
 			// un-listen on P2P dial-up events
 			dtn::core::EventDispatcher<dtn::net::P2PDialupEvent>::remove(this);
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// shutdown all sockets
 				_vsocket.down();

--- a/ibrdtn/daemon/src/net/TCPConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/TCPConvergenceLayer.h
@@ -72,7 +72,7 @@ namespace dtn
 			 * @param net Interface to listen on
 			 * @param port Port to listen on
 			 */
-			void add(const ibrcommon::vinterface &net, int port) throw ();
+			void add(const ibrcommon::vinterface &net, int port) noexcept;
 
 			/**
 			 * Queue a new transmission job for this convergence layer.
@@ -101,36 +101,36 @@ namespace dtn
 			/**
 			 * this method updates the given values
 			 */
-			void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) throw (NoServiceHereException);
+			void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &beacon) noexcept (false);
 
 			void eventNotify(const ibrcommon::LinkEvent &evt);
 
 			/**
 			 * @see EventReceiver::raiseEvent()
 			 */
-			void raiseEvent(const dtn::net::P2PDialupEvent &evt) throw ();
+			void raiseEvent(const dtn::net::P2PDialupEvent &evt) noexcept;
 
 			virtual void resetStats();
 
 			virtual void getStats(ConvergenceLayer::stats_data &data) const;
 
 		protected:
-			void __cancellation() throw ();
+			void __cancellation() noexcept;
 
-			void componentUp() throw ();
-			void componentRun() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentRun() noexcept;
+			void componentDown() noexcept;
 
 		private:
 			/**
 			 * Listen to a specific interface
 			 */
-			void listen(const ibrcommon::vinterface &iface, int port) throw ();
+			void listen(const ibrcommon::vinterface &iface, int port) noexcept;
 
 			/**
 			 * Remove a specific interface
 			 */
-			void unlisten(const ibrcommon::vinterface &iface) throw ();
+			void unlisten(const ibrcommon::vinterface &iface) noexcept;
 
 			/**
 			 * closes all active tcp connections
@@ -153,12 +153,12 @@ namespace dtn
 			/**
 			 * Reports inbound traffic amount
 			 */
-			void addTrafficIn(size_t) throw ();
+			void addTrafficIn(size_t) noexcept;
 
 			/**
 			 * Reports outbound traffic amount
 			 */
-			void addTrafficOut(size_t) throw ();
+			void addTrafficOut(size_t) noexcept;
 
 			static const int DEFAULT_PORT;
 

--- a/ibrdtn/daemon/src/net/UDPConvergenceLayer.cpp
+++ b/ibrdtn/daemon/src/net/UDPConvergenceLayer.cpp
@@ -93,7 +93,7 @@ namespace dtn
 			return dtn::core::Node::CONN_UDPIP;
 		}
 
-		void UDPConvergenceLayer::onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &announcement) throw (dtn::net::DiscoveryBeaconHandler::NoServiceHereException)
+		void UDPConvergenceLayer::onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &announcement) noexcept (false)
 		{
 			// announce port only if we are bound to any interface
 			if (_net.isAny()) {
@@ -275,7 +275,7 @@ namespace dtn
 			}
 		}
 
-		void UDPConvergenceLayer::send(const ibrcommon::vaddress &addr, const std::string &data) throw (ibrcommon::socket_exception, NoAddressFoundException)
+		void UDPConvergenceLayer::send(const ibrcommon::vaddress &addr, const std::string &data) noexcept (false)
 		{
 			// set write lock
 			ibrcommon::MutexLock l(m_writelock);
@@ -299,7 +299,7 @@ namespace dtn
 			throw NoAddressFoundException("no valid address found");
 		}
 
-		void UDPConvergenceLayer::receive(dtn::data::Bundle &bundle, dtn::data::EID &sender) throw (ibrcommon::socket_exception, dtn::InvalidDataException)
+		void UDPConvergenceLayer::receive(dtn::data::Bundle &bundle, dtn::data::EID &sender) noexcept (false)
 		{
 			ibrcommon::MutexLock l(m_readlock);
 
@@ -389,9 +389,9 @@ namespace dtn
 			}
 		}
 
-		void UDPConvergenceLayer::componentUp() throw ()
+		void UDPConvergenceLayer::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// create sockets for all addresses on the interface
 				std::list<ibrcommon::vaddress> addrs = _net.getAddresses();
@@ -430,7 +430,7 @@ namespace dtn
 			}
 		}
 
-		void UDPConvergenceLayer::componentDown() throw ()
+		void UDPConvergenceLayer::componentDown() noexcept
 		{
 			// unsubscribe to NetLink events
 			ibrcommon::LinkManager::getInstance().removeEventListener(this);
@@ -443,7 +443,7 @@ namespace dtn
 			join();
 		}
 
-		void UDPConvergenceLayer::componentRun() throw ()
+		void UDPConvergenceLayer::componentRun() noexcept
 		{
 			_running = true;
 
@@ -483,7 +483,7 @@ namespace dtn
 			}
 		}
 
-		void UDPConvergenceLayer::__cancellation() throw ()
+		void UDPConvergenceLayer::__cancellation() noexcept
 		{
 			_running = false;
 			_vsocket.down();

--- a/ibrdtn/daemon/src/net/UDPConvergenceLayer.h
+++ b/ibrdtn/daemon/src/net/UDPConvergenceLayer.h
@@ -61,7 +61,7 @@ namespace dtn
 			 * this method updates the given values
 			 */
 			void onUpdateBeacon(const ibrcommon::vinterface &iface, DiscoveryBeacon &announcement)
-				throw (dtn::net::DiscoveryBeaconHandler::NoServiceHereException);
+				noexcept (false);
 
 			dtn::core::Node::Protocol getDiscoveryProtocol() const;
 
@@ -79,14 +79,14 @@ namespace dtn
 			virtual void getStats(ConvergenceLayer::stats_data &data) const;
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentRun() throw ();
-			virtual void componentDown() throw ();
-			void __cancellation() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentRun() noexcept;
+			virtual void componentDown() noexcept;
+			void __cancellation() noexcept;
 
 		private:
-			void receive(dtn::data::Bundle&, dtn::data::EID &sender) throw (ibrcommon::socket_exception, dtn::InvalidDataException);
-			void send(const ibrcommon::vaddress &addr, const std::string &data) throw (ibrcommon::socket_exception, NoAddressFoundException);
+			void receive(dtn::data::Bundle&, dtn::data::EID &sender) noexcept (false);
+			void send(const ibrcommon::vaddress &addr, const std::string &data) noexcept (false);
 
 			ibrcommon::vsocket _vsocket;
 			ibrcommon::vinterface _net;

--- a/ibrdtn/daemon/src/net/UDPDatagramService.cpp
+++ b/ibrdtn/daemon/src/net/UDPDatagramService.cpp
@@ -57,7 +57,7 @@ namespace dtn
 		 * Bind to the local socket.
 		 * @throw If the bind fails, an DatagramException is thrown.
 		 */
-		void UDPDatagramService::bind() throw (DatagramException)
+		void UDPDatagramService::bind() noexcept (false)
 		{
 			// delete all sockets
 			_vsocket.destroy();
@@ -127,7 +127,7 @@ namespace dtn
 		 * @param buf The buffer to send.
 		 * @param length The number of available bytes in the buffer.
 		 */
-		void UDPDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const std::string &identifier, const char *buf, size_t length) throw (DatagramException)
+		void UDPDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const std::string &identifier, const char *buf, size_t length) noexcept (false)
 		{
 			// decode address identifier
 			ibrcommon::vaddress destination;
@@ -142,13 +142,13 @@ namespace dtn
 		 * @param buf The buffer to send.
 		 * @param length The number of available bytes in the buffer.
 		 */
-		void UDPDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (DatagramException)
+		void UDPDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false)
 		{
 			// forward to actually send method using the broadcast address
 			send(type, flags, seqno, BROADCAST_ADDR, buf, length);
 		}
 
-		void UDPDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const ibrcommon::vaddress &destination, const char *buf, size_t length) throw (DatagramException)
+		void UDPDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const ibrcommon::vaddress &destination, const char *buf, size_t length) noexcept (false)
 		{
 			try {
 				std::vector<char> tmp(length + 2);
@@ -191,7 +191,7 @@ namespace dtn
 		 * @throw If the receive call failed for any reason, an DatagramException is thrown.
 		 * @return The number of received bytes.
 		 */
-		size_t UDPDatagramService::recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (DatagramException)
+		size_t UDPDatagramService::recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false)
 		{
 			try {
 				ibrcommon::socketset readfds;

--- a/ibrdtn/daemon/src/net/UDPDatagramService.h
+++ b/ibrdtn/daemon/src/net/UDPDatagramService.h
@@ -41,7 +41,7 @@ namespace dtn
 			 * Bind to the local socket.
 			 * @throw If the bind fails, an DatagramException is thrown.
 			 */
-			virtual void bind() throw (DatagramException);
+			virtual void bind() noexcept (false);
 
 			/**
 			 * Shutdown the socket. Unblock all calls on the socket (recv, send, etc.)
@@ -54,14 +54,14 @@ namespace dtn
 			 * @param buf The buffer to send.
 			 * @param length The number of available bytes in the buffer.
 			 */
-			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) throw (DatagramException);
+			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) noexcept (false);
 
 			/**
 			 * Send the payload as datagram to all neighbors (broadcast)
 			 * @param buf The buffer to send.
 			 * @param length The number of available bytes in the buffer.
 			 */
-			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (DatagramException);
+			virtual void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false);
 
 			/**
 			 * Receive an incoming datagram.
@@ -71,7 +71,7 @@ namespace dtn
 			 * @throw If the receive call failed for any reason, an DatagramException is thrown.
 			 * @return The number of received bytes.
 			 */
-			virtual size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (DatagramException);
+			virtual size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false);
 
 			/**
 			 * Get the service description for this convergence layer. This
@@ -99,7 +99,7 @@ namespace dtn
 			virtual const DatagramService::Parameter& getParameter() const;
 
 		private:
-			void send(const char &type, const char &flags, const unsigned int &seqno, const ibrcommon::vaddress &destination, const char *buf, size_t length) throw (DatagramException);
+			void send(const char &type, const char &flags, const unsigned int &seqno, const ibrcommon::vaddress &destination, const char *buf, size_t length) noexcept (false);
 
 			static const std::string encode(const ibrcommon::vaddress &address, const int port = 0);
 			static void decode(const std::string &identifier, ibrcommon::vaddress &address);

--- a/ibrdtn/daemon/src/net/WifiP2PManager.cpp
+++ b/ibrdtn/daemon/src/net/WifiP2PManager.cpp
@@ -45,11 +45,11 @@ namespace dtn
 			join();
 		}
 
-		void WifiP2PManager::__cancellation() throw ()
+		void WifiP2PManager::__cancellation() noexcept
 		{
 		}
 
-		void WifiP2PManager::componentUp() throw ()
+		void WifiP2PManager::componentUp() noexcept
 		{
 			IBRCOMMON_LOGGER_TAG(WifiP2PManager::TAG, info) << "initialized" << IBRCOMMON_LOGGER_ENDL;
 
@@ -59,7 +59,7 @@ namespace dtn
 			dtn::core::BundleCore::getInstance().getConnectionManager().add(this);
 		}
 
-		void WifiP2PManager::componentRun() throw ()
+		void WifiP2PManager::componentRun() noexcept
 		{
 			while (_running) {
 				try {
@@ -76,7 +76,7 @@ namespace dtn
 
 		}
 
-		void WifiP2PManager::componentDown() throw ()
+		void WifiP2PManager::componentDown() noexcept
 		{
 
 			// iterates over all connections being established

--- a/ibrdtn/daemon/src/net/WifiP2PManager.h
+++ b/ibrdtn/daemon/src/net/WifiP2PManager.h
@@ -47,22 +47,22 @@ namespace dtn
 			/**
 			 * @see Component::__cancellation()
 			 */
-			virtual void __cancellation() throw ();
+			virtual void __cancellation() noexcept;
 
 			/**
 			 * @see Component::componentUp()
 			 */
-			virtual void componentUp() throw ();
+			virtual void componentUp() noexcept;
 
 			/**
 			 * @see Component::componentRun()
 			 */
-			virtual void componentRun() throw ();
+			virtual void componentRun() noexcept;
 
 			/**
 			 * @see Component::componentDown()
 			 */
-			virtual void componentDown() throw ();
+			virtual void componentDown() noexcept;
 
 			/**
 			 * @see Component::getName()

--- a/ibrdtn/daemon/src/routing/BaseRouter.cpp
+++ b/ibrdtn/daemon/src/routing/BaseRouter.cpp
@@ -82,7 +82,7 @@ namespace dtn
 			_extensions.erase(extension);
 		}
 
-		ibrcommon::RWMutex& BaseRouter::getExtensionMutex() throw ()
+		ibrcommon::RWMutex& BaseRouter::getExtensionMutex() noexcept
 		{
 			return _extensions_mutex;
 		}
@@ -105,7 +105,7 @@ namespace dtn
 			_extensions.clear();
 		}
 
-		void BaseRouter::extensionsUp() throw ()
+		void BaseRouter::extensionsUp() noexcept
 		{
 			ibrcommon::MutexLock l(_extensions_mutex);
 
@@ -132,7 +132,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::extensionsDown() throw ()
+		void BaseRouter::extensionsDown() noexcept
 		{
 			ibrcommon::MutexLock l(_extensions_mutex);
 
@@ -209,9 +209,9 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::componentUp() throw ()
+		void BaseRouter::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::net::TransferAbortedEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::net::TransferCompletedEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::net::BundleReceivedEvent>::add(this);
@@ -222,9 +222,9 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::core::BundlePurgeEvent>::add(this);
 		}
 
-		void BaseRouter::componentDown() throw ()
+		void BaseRouter::componentDown() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::net::TransferAbortedEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::net::TransferCompletedEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::net::BundleReceivedEvent>::remove(this);
@@ -238,7 +238,7 @@ namespace dtn
 		/**
 		 * method to receive new events from the EventSwitch
 		 */
-		void BaseRouter::raiseEvent(const dtn::net::TransferCompletedEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::net::TransferCompletedEvent &event) noexcept
 		{
 			// if a transfer is completed, then release the transfer resource of the peer
 			try {
@@ -258,7 +258,7 @@ namespace dtn
 			__eventDataChanged(event.getPeer());
 		}
 
-		void BaseRouter::raiseEvent(const dtn::routing::QueueBundleEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::routing::QueueBundleEvent &event) noexcept
 		{
 			// check Scope Control Block - do not forward bundles with hop limit == 0
 			if (event.bundle.hopcount == 0) return;
@@ -275,7 +275,7 @@ namespace dtn
 			__eventBundleQueued(event.origin, event.bundle);
 		}
 
-		void BaseRouter::raiseEvent(const dtn::net::BundleReceivedEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::net::BundleReceivedEvent &event) noexcept
 		{
 			const dtn::data::MetaBundle m = dtn::data::MetaBundle::create(event.bundle);
 
@@ -353,7 +353,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::raiseEvent(const dtn::net::TransferAbortedEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::net::TransferAbortedEvent &event) noexcept
 		{
 			// if a transfer is aborted, then release the transfer resource of the peer
 			try {
@@ -383,7 +383,7 @@ namespace dtn
 			__eventDataChanged(event.getPeer());
 		}
 
-		void BaseRouter::raiseEvent(const dtn::core::NodeEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::core::NodeEvent &event) noexcept
 		{
 			// If a new neighbor comes available, send him a request for the summary vector
 			// If a neighbor went away we can free the stored database
@@ -422,7 +422,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::raiseEvent(const dtn::net::ConnectionEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::net::ConnectionEvent &event) noexcept
 		{
 			if (event.getState() == dtn::net::ConnectionEvent::CONNECTION_UP)
 			{
@@ -437,7 +437,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::raiseEvent(const dtn::core::BundlePurgeEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::core::BundlePurgeEvent &event) noexcept
 		{
 			if ((event.reason == dtn::core::BundlePurgeEvent::DELIVERED) ||
 				(event.reason == dtn::core::BundlePurgeEvent::ACK_RECIEVED))
@@ -447,7 +447,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::raiseEvent(const dtn::core::TimeEvent &event) throw ()
+		void BaseRouter::raiseEvent(const dtn::core::TimeEvent &event) noexcept
 		{
 			dtn::data::Timestamp expire_time = event.getTimestamp();
 
@@ -495,7 +495,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::__eventDataChanged(const dtn::data::EID &peer) throw ()
+		void BaseRouter::__eventDataChanged(const dtn::data::EID &peer) noexcept
 		{
 			// do not forward the event if the extensions are down
 			if (!_extension_state) return;
@@ -510,7 +510,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::__eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void BaseRouter::__eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// do not forward the event if the extensions are down
 			if (!_extension_state) return;
@@ -525,7 +525,7 @@ namespace dtn
 			}
 		}
 
-		void BaseRouter::__eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void BaseRouter::__eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// do not forward the event if the extensions are down
 			if (!_extension_state) return;

--- a/ibrdtn/daemon/src/routing/BaseRouter.h
+++ b/ibrdtn/daemon/src/routing/BaseRouter.h
@@ -74,7 +74,7 @@ namespace dtn
 			class RoutingException : public ibrcommon::Exception
 			{
 				public:
-					RoutingException(string what = "An error occured during routing.") throw() : Exception(what)
+					RoutingException(string what = "An error occured during routing.") noexcept : Exception(what)
 					{
 					};
 			};
@@ -85,7 +85,7 @@ namespace dtn
 			class NoNeighbourFoundException : public RoutingException
 			{
 				public:
-					NoNeighbourFoundException(string what = "No neighbour was found.") throw() : RoutingException(what)
+					NoNeighbourFoundException(string what = "No neighbour was found.") noexcept : RoutingException(what)
 					{
 					};
 			};
@@ -96,7 +96,7 @@ namespace dtn
 			class NoRouteFoundException : public RoutingException
 			{
 				public:
-					NoRouteFoundException(string what = "No route found.") throw() : RoutingException(what)
+					NoRouteFoundException(string what = "No route found.") noexcept : RoutingException(what)
 					{
 					};
 			};
@@ -126,7 +126,7 @@ namespace dtn
 			/**
 			 * Give access to the mutex for the extension list
 			 */
-			ibrcommon::RWMutex& getExtensionMutex() throw ();
+			ibrcommon::RWMutex& getExtensionMutex() noexcept;
 
 			/**
 			 * Delete all extensions
@@ -136,14 +136,14 @@ namespace dtn
 			/**
 			 * method to receive new events from the EventSwitch
 			 */
-			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) throw ();
-			void raiseEvent(const dtn::net::TransferCompletedEvent &evt) throw ();
-			void raiseEvent(const dtn::net::BundleReceivedEvent &evt) throw ();
-			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) throw ();
-			void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
-			void raiseEvent(const dtn::net::ConnectionEvent &evt) throw ();
-			void raiseEvent(const dtn::core::BundlePurgeEvent &evt) throw ();
+			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::TransferCompletedEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::BundleReceivedEvent &evt) noexcept;
+			void raiseEvent(const dtn::routing::QueueBundleEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
+			void raiseEvent(const dtn::net::ConnectionEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::BundlePurgeEvent &evt) noexcept;
 
 			/**
 			 * provides direct access to the bundle storage
@@ -226,12 +226,12 @@ namespace dtn
 			/**
 			 * enable all extensions
 			 */
-			void extensionsUp() throw ();
+			void extensionsUp() noexcept;
 
 			/**
 			 * disable all extensions
 			 */
-			void extensionsDown() throw ();
+			void extensionsDown() noexcept;
 
 			/**
 			 * Process a completed handshake
@@ -256,13 +256,13 @@ namespace dtn
 
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 		private:
-			void __eventDataChanged(const dtn::data::EID &peer) throw ();
-			void __eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
-			void __eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			void __eventDataChanged(const dtn::data::EID &peer) noexcept;
+			void __eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
+			void __eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
 			ibrcommon::Mutex _known_bundles_lock;
 			dtn::data::BundleSet _known_bundles;

--- a/ibrdtn/daemon/src/routing/NeighborDatabase.cpp
+++ b/ibrdtn/daemon/src/routing/NeighborDatabase.cpp
@@ -145,7 +145,7 @@ namespace dtn
 			}
 		}
 
-		void NeighborDatabase::NeighborEntry::acquireTransfer(const dtn::data::BundleID &id) throw (NoMoreTransfersAvailable, AlreadyInTransitException)
+		void NeighborDatabase::NeighborEntry::acquireTransfer(const dtn::data::BundleID &id) noexcept (false)
 		{
 			// check if enough resources available to transfer the bundle
 			if (_transit_bundles.size() >= dtn::core::BundleCore::max_bundles_in_transit) throw NoMoreTransfersAvailable();
@@ -204,7 +204,7 @@ namespace dtn
 			}
 		}
 
-		NeighborDatabase::NeighborEntry& NeighborDatabase::create(const dtn::data::EID &eid) throw ()
+		NeighborDatabase::NeighborEntry& NeighborDatabase::create(const dtn::data::EID &eid) noexcept
 		{
 			neighbor_map::iterator iter = _entries.find(eid);
 			if (iter == _entries.end())
@@ -220,7 +220,7 @@ namespace dtn
 			return *(*iter).second;
 		}
 
-		NeighborDatabase::NeighborEntry& NeighborDatabase::get(const dtn::data::EID &eid, bool noCached) throw (EntryNotFoundException)
+		NeighborDatabase::NeighborEntry& NeighborDatabase::get(const dtn::data::EID &eid, bool noCached) noexcept (false)
 		{
 			if (noCached && !dtn::core::BundleCore::getInstance().getConnectionManager().isNeighbor(eid))
 				throw NeighborDatabase::EntryNotFoundException();

--- a/ibrdtn/daemon/src/routing/NeighborDatabase.h
+++ b/ibrdtn/daemon/src/routing/NeighborDatabase.h
@@ -51,7 +51,7 @@ namespace dtn
 				BloomfilterNotAvailableException(const dtn::data::EID &host)
 				: ibrcommon::Exception("Bloom filter is not available for this node."), eid(host) { };
 
-				virtual ~BloomfilterNotAvailableException() throw () { };
+				virtual ~BloomfilterNotAvailableException() noexcept { };
 
 				const dtn::data::EID eid;
 			};
@@ -60,35 +60,35 @@ namespace dtn
 			{
 			public:
 				NoRouteKnownException() : ibrcommon::Exception("No route known.") { };
-				virtual ~NoRouteKnownException() throw () { };
+				virtual ~NoRouteKnownException() noexcept { };
 			};
 
 			class NoMoreTransfersAvailable : public ibrcommon::Exception
 			{
 			public:
 				NoMoreTransfersAvailable() : ibrcommon::Exception("No more transfers allowed.") { };
-				virtual ~NoMoreTransfersAvailable() throw () { };
+				virtual ~NoMoreTransfersAvailable() noexcept { };
 			};
 
 			class AlreadyInTransitException : public ibrcommon::Exception
 			{
 			public:
 				AlreadyInTransitException() : ibrcommon::Exception("This bundle is already in transit.") { };
-				virtual ~AlreadyInTransitException() throw () { };
+				virtual ~AlreadyInTransitException() noexcept { };
 			};
 
 			class EntryNotFoundException : public ibrcommon::Exception
 			{
 			public:
 				EntryNotFoundException() : ibrcommon::Exception("Entry for this neighbor not found.") { };
-				virtual ~EntryNotFoundException() throw () { };
+				virtual ~EntryNotFoundException() noexcept { };
 			};
 
 			class DatasetNotAvailableException : public ibrcommon::Exception
 			{
 			public:
 				DatasetNotAvailableException() : ibrcommon::Exception("Dataset not found.") { };
-				virtual ~DatasetNotAvailableException() throw () { };
+				virtual ~DatasetNotAvailableException() noexcept { };
 			};
 
 			class NeighborEntry
@@ -115,7 +115,7 @@ namespace dtn
 				 * Acquire transfer resources. If no resources is left,
 				 * an exception is thrown.
 				 */
-				void acquireTransfer(const dtn::data::BundleID &id) throw (NoMoreTransfersAvailable, AlreadyInTransitException);
+				void acquireTransfer(const dtn::data::BundleID &id) noexcept (false);
 
 				/**
 				 * @return the number of free transfer slots
@@ -167,7 +167,7 @@ namespace dtn
 				 * Retrieve a specific data-set.
 				 */
 				template <class T>
-				const T& getDataset() const throw (DatasetNotAvailableException)
+				const T& getDataset() const noexcept (false)
 				{
 					NeighborDataset item(T::identifier);
 					data_set::const_iterator iter = _datasets.find(item);
@@ -237,7 +237,7 @@ namespace dtn
 			 * @param noCached Only returns an entry if the neighbor is available
 			 * @return The neighbor entry reference.
 			 */
-			NeighborDatabase::NeighborEntry& get(const dtn::data::EID &eid, bool noCached = false) throw (EntryNotFoundException);
+			NeighborDatabase::NeighborEntry& get(const dtn::data::EID &eid, bool noCached = false) noexcept (false);
 
 			/**
 			 * Query a neighbor entry of the database. If the entry does not
@@ -245,7 +245,7 @@ namespace dtn
 			 * @param eid The EID of the neighbor.
 			 * @return The neighbor entry reference.
 			 */
-			NeighborDatabase::NeighborEntry& create(const dtn::data::EID &eid) throw ();
+			NeighborDatabase::NeighborEntry& create(const dtn::data::EID &eid) noexcept;
 
 			/**
 			 * Remove an entry of the database.

--- a/ibrdtn/daemon/src/routing/NeighborRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/NeighborRoutingExtension.cpp
@@ -59,12 +59,12 @@ namespace dtn
 			join();
 		}
 
-		void NeighborRoutingExtension::__cancellation() throw ()
+		void NeighborRoutingExtension::__cancellation() noexcept
 		{
 			_taskqueue.abort();
 		}
 
-		void NeighborRoutingExtension::run() throw ()
+		void NeighborRoutingExtension::run() noexcept
 		{
 #ifdef HAVE_SQLITE
 			class BundleFilter : public dtn::storage::BundleSelector, public dtn::storage::SQLiteDatabase::SQLBundleQuery
@@ -79,9 +79,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return _entry.getFreeTransferSlots(); };
+				virtual dtn::data::Size limit() const noexcept { return _entry.getFreeTransferSlots(); };
 
-				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// check if the considered bundle should get routed
 					std::pair<bool, dtn::core::Node::Protocol> ret = _extension.shouldRouteTo(meta, _entry, _plist);
@@ -94,12 +94,12 @@ namespace dtn
 				};
 
 #ifdef HAVE_SQLITE
-				const std::string getWhere() const throw ()
+				const std::string getWhere() const noexcept
 				{
 					return "destination LIKE ?";
 				};
 
-				int bind(sqlite3_stmt *st, int offset) const throw ()
+				int bind(sqlite3_stmt *st, int offset) const noexcept
 				{
 					const std::string d = _entry.eid.getNode().getString() + "%";
 					sqlite3_bind_text(st, offset, d.c_str(), static_cast<int>(d.size()), SQLITE_TRANSIENT);
@@ -283,13 +283,13 @@ namespace dtn
 			return make_pair(false, dtn::core::Node::CONN_UNDEFINED);
 		}
 
-		void NeighborRoutingExtension::eventDataChanged(const dtn::data::EID &peer) throw ()
+		void NeighborRoutingExtension::eventDataChanged(const dtn::data::EID &peer) noexcept
 		{
 			// transfer the next bundle to this destination
 			_taskqueue.push( new SearchNextBundleTask( peer ) );
 		}
 
-		void NeighborRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void NeighborRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// try to deliver new bundles to all neighbors
 			const std::set<dtn::core::Node> nl = dtn::core::BundleCore::getInstance().getConnectionManager().getNeighbors();
@@ -305,12 +305,12 @@ namespace dtn
 			}
 		}
 
-		void NeighborRoutingExtension::componentUp() throw ()
+		void NeighborRoutingExtension::componentUp() noexcept
 		{
 			// reset the task queue
 			_taskqueue.reset();
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// run the thread
 				start();
@@ -319,9 +319,9 @@ namespace dtn
 			}
 		}
 
-		void NeighborRoutingExtension::componentDown() throw ()
+		void NeighborRoutingExtension::componentDown() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// stop the thread
 				stop();
@@ -331,7 +331,7 @@ namespace dtn
 			}
 		}
 
-		const std::string NeighborRoutingExtension::getTag() const throw ()
+		const std::string NeighborRoutingExtension::getTag() const noexcept
 		{
 			return "neighbor";
 		}

--- a/ibrdtn/daemon/src/routing/NeighborRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/NeighborRoutingExtension.h
@@ -47,18 +47,18 @@ namespace dtn
 			NeighborRoutingExtension();
 			virtual ~NeighborRoutingExtension();
 
-			virtual const std::string getTag() const throw ();
+			virtual const std::string getTag() const noexcept;
 
-			virtual void eventDataChanged(const dtn::data::EID &peer) throw ();
+			virtual void eventDataChanged(const dtn::data::EID &peer) noexcept;
 
-			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 		protected:
-			void run() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			class Task

--- a/ibrdtn/daemon/src/routing/NodeHandshakeExtension.cpp
+++ b/ibrdtn/daemon/src/routing/NodeHandshakeExtension.cpp
@@ -125,9 +125,9 @@ namespace dtn
 
 					virtual ~BundleFilter() {};
 
-					virtual dtn::data::Size limit() const throw () { return 100; };
+					virtual dtn::data::Size limit() const noexcept { return 100; };
 
-					virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+					virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const noexcept (false)
 					{
 						// do not select locally addressed bundles
 						if (meta.destination.getNode() == dtn::core::BundleCore::local)
@@ -184,17 +184,17 @@ namespace dtn
 			_endpoint.push(id);
 		}
 
-		void NodeHandshakeExtension::componentUp() throw ()
+		void NodeHandshakeExtension::componentUp() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::core::NodeEvent>::add(this);
 		}
 
-		void NodeHandshakeExtension::componentDown() throw ()
+		void NodeHandshakeExtension::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::core::NodeEvent>::remove(this);
 		}
 
-		void NodeHandshakeExtension::raiseEvent(const dtn::core::NodeEvent &nodeevent) throw ()
+		void NodeHandshakeExtension::raiseEvent(const dtn::core::NodeEvent &nodeevent) noexcept
 		{
 			// If a new neighbor comes available, send him a request for the summary vector
 			// If a neighbor went away we can free the stored summary vector

--- a/ibrdtn/daemon/src/routing/NodeHandshakeExtension.h
+++ b/ibrdtn/daemon/src/routing/NodeHandshakeExtension.h
@@ -43,9 +43,9 @@ namespace dtn
 			NodeHandshakeExtension();
 			virtual ~NodeHandshakeExtension();
 
-			void raiseEvent(const dtn::core::NodeEvent &evt) throw ();
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void raiseEvent(const dtn::core::NodeEvent &evt) noexcept;
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 			void doHandshake(const dtn::data::EID &eid);
 

--- a/ibrdtn/daemon/src/routing/RetransmissionExtension.cpp
+++ b/ibrdtn/daemon/src/routing/RetransmissionExtension.cpp
@@ -42,7 +42,7 @@ namespace dtn
 		{
 		}
 
-		void RetransmissionExtension::componentUp() throw ()
+		void RetransmissionExtension::componentUp() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::net::TransferAbortedEvent>::add(this);
@@ -50,7 +50,7 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::core::BundleExpiredEvent>::add(this);
 		}
 
-		void RetransmissionExtension::componentDown() throw ()
+		void RetransmissionExtension::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::net::TransferAbortedEvent>::remove(this);
@@ -58,14 +58,14 @@ namespace dtn
 			dtn::core::EventDispatcher<dtn::core::BundleExpiredEvent>::remove(this);
 		}
 
-		void RetransmissionExtension::eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void RetransmissionExtension::eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// remove the bundleid in our list
 			RetransmissionData data(meta, peer);
 			_set.erase(data);
 		}
 
-		void RetransmissionExtension::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void RetransmissionExtension::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			ibrcommon::MutexLock l(_mutex);
 			if (!_queue.empty())
@@ -102,14 +102,14 @@ namespace dtn
 			}
 		}
 
-		void RetransmissionExtension::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) throw ()
+		void RetransmissionExtension::raiseEvent(const dtn::net::TransferAbortedEvent &aborted) noexcept
 		{
 			// remove the bundleid in our list
 			RetransmissionData data(aborted.getBundleID(), aborted.getPeer());
 			_set.erase(data);
 		}
 
-		void RetransmissionExtension::raiseEvent(const dtn::routing::RequeueBundleEvent &requeue) throw ()
+		void RetransmissionExtension::raiseEvent(const dtn::routing::RequeueBundleEvent &requeue) noexcept
 		{
 			const RetransmissionData data(requeue.getBundle(), requeue.getPeer(), requeue.getProtocol());
 
@@ -144,7 +144,7 @@ namespace dtn
 			}
 		}
 
-		void RetransmissionExtension::raiseEvent(const dtn::core::BundleExpiredEvent &expired) throw ()
+		void RetransmissionExtension::raiseEvent(const dtn::core::BundleExpiredEvent &expired) noexcept
 		{
 			// delete all matching elements in the queue
 			ibrcommon::MutexLock l(_mutex);

--- a/ibrdtn/daemon/src/routing/RetransmissionExtension.h
+++ b/ibrdtn/daemon/src/routing/RetransmissionExtension.h
@@ -53,15 +53,15 @@ namespace dtn
 			/**
 			 * This method is called every time a bundle has been completed successfully
 			 */
-			virtual void eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
-			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) throw ();
-			void raiseEvent(const dtn::routing::RequeueBundleEvent &evt) throw ();
-			void raiseEvent(const dtn::core::BundleExpiredEvent &evt) throw ();
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
+			void raiseEvent(const dtn::net::TransferAbortedEvent &evt) noexcept;
+			void raiseEvent(const dtn::routing::RequeueBundleEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::BundleExpiredEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
 
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 		private:
 			class RetransmissionData : public dtn::data::BundleID

--- a/ibrdtn/daemon/src/routing/RoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/RoutingExtension.cpp
@@ -38,12 +38,12 @@ namespace dtn
 		{
 		}
 
-		void RoutingResult::put(const dtn::data::MetaBundle &bundle) throw ()
+		void RoutingResult::put(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			put(bundle, dtn::core::Node::CONN_UNDEFINED);
 		}
 
-		void RoutingResult::put(const dtn::data::MetaBundle &bundle, const dtn::core::Node::Protocol p) throw ()
+		void RoutingResult::put(const dtn::data::MetaBundle &bundle, const dtn::core::Node::Protocol p) noexcept
 		{
 			push_back(make_pair(bundle, p));
 		}

--- a/ibrdtn/daemon/src/routing/RoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/RoutingExtension.h
@@ -43,8 +43,8 @@ namespace dtn
 			RoutingResult();
 			virtual ~RoutingResult();
 
-			virtual void put(const dtn::data::MetaBundle &bundle) throw ();
-			virtual void put(const dtn::data::MetaBundle &bundle, const dtn::core::Node::Protocol p) throw ();
+			virtual void put(const dtn::data::MetaBundle &bundle) noexcept;
+			virtual void put(const dtn::data::MetaBundle &bundle, const dtn::core::Node::Protocol p) noexcept;
 		};
 
 		class RoutingExtension
@@ -55,29 +55,29 @@ namespace dtn
 			RoutingExtension();
 			virtual ~RoutingExtension() = 0;
 
-			virtual void componentUp() throw () = 0;
-			virtual void componentDown() throw () = 0;
+			virtual void componentUp() noexcept = 0;
+			virtual void componentDown() noexcept = 0;
 
 			/**
 			 * Returns a tag used to identify the routing extension in filtering rules
 			 */
-			virtual const std::string getTag() const throw () { return "default"; }
+			virtual const std::string getTag() const noexcept { return "default"; }
 
 			/**
 			 * This method is called every time something has changed. The module
 			 * should search again for bundles to transfer to the given peer.
 			 */
-			virtual void eventDataChanged(const dtn::data::EID &peer) throw () { };
+			virtual void eventDataChanged(const dtn::data::EID &peer) noexcept { };
 
 			/**
 			 * This method is called every time a bundle has been completed successfully
 			 */
-			virtual void eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw () { };
+			virtual void eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept { };
 
 			/**
 			 * This method is called every time a bundle was queued
 			 */
-			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw () { };
+			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept { };
 
 			/**
 			 * If some data of another node is required. These method is called to collect all

--- a/ibrdtn/daemon/src/routing/SchedulingBundleIndex.cpp
+++ b/ibrdtn/daemon/src/routing/SchedulingBundleIndex.cpp
@@ -38,7 +38,7 @@ namespace dtn
 			}
 		}
 
-		void SchedulingBundleIndex::get(const dtn::storage::BundleSelector &cb, dtn::storage::BundleResult &result) throw (dtn::storage::NoBundleFoundException, dtn::storage::BundleSelectorException)
+		void SchedulingBundleIndex::get(const dtn::storage::BundleSelector &cb, dtn::storage::BundleResult &result) noexcept (false)
 		{
 			bool unlimited = (cb.limit() <= 0);
 			size_t added = 0;

--- a/ibrdtn/daemon/src/routing/SchedulingBundleIndex.h
+++ b/ibrdtn/daemon/src/routing/SchedulingBundleIndex.h
@@ -31,7 +31,7 @@ namespace dtn
 			 * @param cb The instance of the callback filter class.
 			 * @return A list of bundles.
 			 */
-			virtual void get(const dtn::storage::BundleSelector &cb, dtn::storage::BundleResult &result) throw (dtn::storage::NoBundleFoundException, dtn::storage::BundleSelectorException);
+			virtual void get(const dtn::storage::BundleSelector &cb, dtn::storage::BundleResult &result) noexcept (false);
 
 			/**
 			 * Return a set of distinct destinations for all bundles in the storage.

--- a/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/StaticRoutingExtension.cpp
@@ -67,12 +67,12 @@ namespace dtn
 			}
 		}
 
-		void StaticRoutingExtension::__cancellation() throw ()
+		void StaticRoutingExtension::__cancellation() noexcept
 		{
 			_taskqueue.abort();
 		}
 
-		void StaticRoutingExtension::run() throw ()
+		void StaticRoutingExtension::run() noexcept
 		{
 			class BundleFilter : public dtn::storage::BundleSelector
 			{
@@ -83,9 +83,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return _entry.getFreeTransferSlots(); };
+				virtual dtn::data::Size limit() const noexcept { return _entry.getFreeTransferSlots(); };
 
-				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// check Scope Control Block - do not forward bundles with hop limit == 0
 					if (meta.hopcount == 0)
@@ -412,17 +412,17 @@ namespace dtn
 			}
 		}
 
-		void StaticRoutingExtension::eventDataChanged(const dtn::data::EID &peer) throw ()
+		void StaticRoutingExtension::eventDataChanged(const dtn::data::EID &peer) noexcept
 		{
 			_taskqueue.push( new SearchNextBundleTask(peer) );
 		}
 
-		void StaticRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void StaticRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			_taskqueue.push( new ProcessBundleTask(meta, peer) );
 		}
 
-		void StaticRoutingExtension::raiseEvent(const dtn::core::TimeEvent&) throw ()
+		void StaticRoutingExtension::raiseEvent(const dtn::core::TimeEvent&) noexcept
 		{
 			// each second, look for expired routes
 			const dtn::data::Timestamp monotonic = dtn::utils::Clock::getMonotonicTimestamp();
@@ -434,7 +434,7 @@ namespace dtn
 			}
 		}
 
-		void StaticRoutingExtension::raiseEvent(const dtn::routing::StaticRouteChangeEvent &route) throw ()
+		void StaticRoutingExtension::raiseEvent(const dtn::routing::StaticRouteChangeEvent &route) noexcept
 		{
 			// on route change, generate a task
 			if (route.type == dtn::routing::StaticRouteChangeEvent::ROUTE_CLEAR)
@@ -475,7 +475,7 @@ namespace dtn
 			}
 		}
 
-		void StaticRoutingExtension::componentUp() throw ()
+		void StaticRoutingExtension::componentUp() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::routing::StaticRouteChangeEvent>::add(this);
@@ -483,7 +483,7 @@ namespace dtn
 			// reset the task queue
 			_taskqueue.reset();
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// run the thread
 				start();
@@ -492,12 +492,12 @@ namespace dtn
 			}
 		}
 
-		void StaticRoutingExtension::componentDown() throw ()
+		void StaticRoutingExtension::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::routing::StaticRouteChangeEvent>::remove(this);
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// stop the thread
 				stop();
@@ -507,7 +507,7 @@ namespace dtn
 			}
 		}
 
-		const std::string StaticRoutingExtension::getTag() const throw ()
+		const std::string StaticRoutingExtension::getTag() const noexcept
 		{
 			return "neighbor";
 		}

--- a/ibrdtn/daemon/src/routing/StaticRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/StaticRoutingExtension.h
@@ -45,27 +45,27 @@ namespace dtn
 			StaticRoutingExtension();
 			virtual ~StaticRoutingExtension();
 
-			virtual const std::string getTag() const throw ();
+			virtual const std::string getTag() const noexcept;
 
 			/**
 			 * This method is called every time something has changed. The module
 			 * should search again for bundles to transfer to the given peer.
 			 */
-			virtual void eventDataChanged(const dtn::data::EID &peer) throw ();
+			virtual void eventDataChanged(const dtn::data::EID &peer) noexcept;
 
 			/**
 			 * This method is called every time a bundle was queued
 			 */
-			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
-			void raiseEvent(const dtn::routing::StaticRouteChangeEvent &evt) throw ();
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
+			void raiseEvent(const dtn::routing::StaticRouteChangeEvent &evt) noexcept;
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 		protected:
-			void run() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			class EIDRoute : public StaticRoute

--- a/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.cpp
@@ -72,13 +72,13 @@ namespace dtn
 			request.addRequest(BloomFilterSummaryVector::identifier);
 		}
 
-		void EpidemicRoutingExtension::eventDataChanged(const dtn::data::EID &peer) throw ()
+		void EpidemicRoutingExtension::eventDataChanged(const dtn::data::EID &peer) noexcept
 		{
 			// transfer the next bundle to this destination
 			_taskqueue.push( new SearchNextBundleTask( peer ) );
 		}
 
-		void EpidemicRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void EpidemicRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// new bundles trigger a recheck for all neighbors
 			const std::set<dtn::core::Node> nl = dtn::core::BundleCore::getInstance().getConnectionManager().getNeighbors();
@@ -95,7 +95,7 @@ namespace dtn
 			}
 		}
 
-		void EpidemicRoutingExtension::raiseEvent(const NodeHandshakeEvent &handshake) throw ()
+		void EpidemicRoutingExtension::raiseEvent(const NodeHandshakeEvent &handshake) noexcept
 		{
 			if (handshake.state == NodeHandshakeEvent::HANDSHAKE_COMPLETED)
 			{
@@ -104,14 +104,14 @@ namespace dtn
 			}
 		}
 
-		void EpidemicRoutingExtension::componentUp() throw ()
+		void EpidemicRoutingExtension::componentUp() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::routing::NodeHandshakeEvent>::add(this);
 
 			// reset the task queue
 			_taskqueue.reset();
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// run the thread
 				start();
@@ -120,7 +120,7 @@ namespace dtn
 			}
 		}
 
-		void EpidemicRoutingExtension::componentDown() throw ()
+		void EpidemicRoutingExtension::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::routing::NodeHandshakeEvent>::remove(this);
 
@@ -133,17 +133,17 @@ namespace dtn
 			}
 		}
 
-		const std::string EpidemicRoutingExtension::getTag() const throw ()
+		const std::string EpidemicRoutingExtension::getTag() const noexcept
 		{
 			return "epidemic";
 		}
 
-		void EpidemicRoutingExtension::__cancellation() throw ()
+		void EpidemicRoutingExtension::__cancellation() noexcept
 		{
 			_taskqueue.abort();
 		}
 
-		void EpidemicRoutingExtension::run() throw ()
+		void EpidemicRoutingExtension::run() noexcept
 		{
 			class BundleFilter : public dtn::storage::BundleSelector
 			{
@@ -154,9 +154,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return _entry.getFreeTransferSlots(); };
+				virtual dtn::data::Size limit() const noexcept { return _entry.getFreeTransferSlots(); };
 
-				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// check Scope Control Block - do not forward bundles with hop limit == 0
 					if (meta.hopcount == 0)

--- a/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/epidemic/EpidemicRoutingExtension.h
@@ -53,15 +53,15 @@ namespace dtn
 			EpidemicRoutingExtension();
 			virtual ~EpidemicRoutingExtension();
 
-			virtual const std::string getTag() const throw ();
+			virtual const std::string getTag() const noexcept;
 
-			virtual void eventDataChanged(const dtn::data::EID &peer) throw ();
+			virtual void eventDataChanged(const dtn::data::EID &peer) noexcept;
 
-			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
-			void raiseEvent(const dtn::routing::NodeHandshakeEvent &evt) throw ();
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void raiseEvent(const dtn::routing::NodeHandshakeEvent &evt) noexcept;
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 			/**
 			 * @see BaseRouter::requestHandshake()
@@ -69,8 +69,8 @@ namespace dtn
 			virtual void requestHandshake(const dtn::data::EID&, NodeHandshake&) const;
 
 		protected:
-			void run() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			class Task

--- a/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.cpp
@@ -62,13 +62,13 @@ namespace dtn
 			join();
 		}
 
-		void FloodRoutingExtension::eventDataChanged(const dtn::data::EID &peer) throw ()
+		void FloodRoutingExtension::eventDataChanged(const dtn::data::EID &peer) noexcept
 		{
 			// transfer the next bundle to this destination
 			_taskqueue.push( new SearchNextBundleTask( peer ) );
 		}
 
-		void FloodRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void FloodRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// new bundles trigger a recheck for all neighbors
 			const std::set<dtn::core::Node> nl = dtn::core::BundleCore::getInstance().getConnectionManager().getNeighbors();
@@ -85,12 +85,12 @@ namespace dtn
 			}
 		}
 
-		void FloodRoutingExtension::componentUp() throw ()
+		void FloodRoutingExtension::componentUp() noexcept
 		{
 			// reset the task queue
 			_taskqueue.reset();
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// run the thread
 				start();
@@ -99,7 +99,7 @@ namespace dtn
 			}
 		}
 
-		void FloodRoutingExtension::componentDown() throw ()
+		void FloodRoutingExtension::componentDown() noexcept
 		{
 			try {
 				// stop the thread
@@ -110,17 +110,17 @@ namespace dtn
 			}
 		}
 
-		const std::string FloodRoutingExtension::getTag() const throw ()
+		const std::string FloodRoutingExtension::getTag() const noexcept
 		{
 			return "flooding";
 		}
 
-		void FloodRoutingExtension::__cancellation() throw ()
+		void FloodRoutingExtension::__cancellation() noexcept
 		{
 			_taskqueue.abort();
 		}
 
-		void FloodRoutingExtension::run() throw ()
+		void FloodRoutingExtension::run() noexcept
 		{
 			class BundleFilter : public dtn::storage::BundleSelector
 			{
@@ -131,9 +131,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return _entry.getFreeTransferSlots(); };
+				virtual dtn::data::Size limit() const noexcept { return _entry.getFreeTransferSlots(); };
 
-				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// check Scope Control Block - do not forward bundles with hop limit == 0
 					if (meta.hopcount == 0)

--- a/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/flooding/FloodRoutingExtension.h
@@ -48,18 +48,18 @@ namespace dtn
 			FloodRoutingExtension();
 			virtual ~FloodRoutingExtension();
 
-			virtual const std::string getTag() const throw ();
+			virtual const std::string getTag() const noexcept;
 
-			virtual void eventDataChanged(const dtn::data::EID &peer) throw ();
+			virtual void eventDataChanged(const dtn::data::EID &peer) noexcept;
 
-			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
-			void componentUp() throw ();
-			void componentDown() throw ();
+			void componentUp() noexcept;
+			void componentDown() noexcept;
 
 		protected:
-			void run() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			class Task

--- a/ibrdtn/daemon/src/routing/prophet/AcknowledgementSet.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/AcknowledgementSet.cpp
@@ -24,7 +24,7 @@ namespace dtn
 		{
 		}
 
-		void AcknowledgementSet::add(const dtn::data::MetaBundle &bundle) throw ()
+		void AcknowledgementSet::add(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			try {
 				// check if the bundle is valid
@@ -37,12 +37,12 @@ namespace dtn
 			}
 		}
 
-		void AcknowledgementSet::expire(const dtn::data::Timestamp &timestamp) throw ()
+		void AcknowledgementSet::expire(const dtn::data::Timestamp &timestamp) noexcept
 		{
 			_bundles.expire(timestamp);
 		}
 
-		void AcknowledgementSet::merge(const AcknowledgementSet &other) throw ()
+		void AcknowledgementSet::merge(const AcknowledgementSet &other) noexcept
 		{
 			for(dtn::data::BundleList::const_iterator it = other._bundles.begin(); it != other._bundles.end(); ++it)
 			{
@@ -51,7 +51,7 @@ namespace dtn
 			}
 		}
 
-		bool AcknowledgementSet::has(const dtn::data::BundleID &id) const throw ()
+		bool AcknowledgementSet::has(const dtn::data::BundleID &id) const noexcept
 		{
 			dtn::data::BundleList::const_iterator iter = _bundles.find(dtn::data::MetaBundle::create(id));
 			return !(iter == _bundles.end());

--- a/ibrdtn/daemon/src/routing/prophet/AcknowledgementSet.h
+++ b/ibrdtn/daemon/src/routing/prophet/AcknowledgementSet.h
@@ -30,22 +30,22 @@ namespace dtn
 			/**
 			 * Add a bundle to the set
 			 */
-			void add(const dtn::data::MetaBundle &bundle) throw ();
+			void add(const dtn::data::MetaBundle &bundle) noexcept;
 
 			/**
 			 * Expire outdated entries
 			 */
-			void expire(const dtn::data::Timestamp &timestamp) throw ();
+			void expire(const dtn::data::Timestamp &timestamp) noexcept;
 
 			/**
 			 * merge the set with a second AcknowledgementSet
 			 */
-			void merge(const AcknowledgementSet&) throw ();
+			void merge(const AcknowledgementSet&) noexcept;
 
 			/**
 			 * Returns true if the given bundleId is in the bundle list
 			 */
-			bool has(const dtn::data::BundleID &id) const throw ();
+			bool has(const dtn::data::BundleID &id) const noexcept;
 
 			/* virtual methods from NodeHandshakeItem */
 			virtual const dtn::data::Number& getIdentifier() const; ///< \see NodeHandshakeItem::getIdentifier

--- a/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.cpp
@@ -135,7 +135,7 @@ namespace dtn
 			return stream;
 		}
 
-		float DeliveryPredictabilityMap::get(const dtn::data::EID &neighbor) const throw (ValueNotFoundException)
+		float DeliveryPredictabilityMap::get(const dtn::data::EID &neighbor) const noexcept (false)
 		{
 			predictmap::const_iterator it;
 			if ((it = _predictmap.find(neighbor)) != _predictmap.end())

--- a/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.h
+++ b/ibrdtn/daemon/src/routing/prophet/DeliveryPredictabilityMap.h
@@ -43,10 +43,10 @@ namespace dtn
 				ValueNotFoundException()
 				: ibrcommon::Exception("The requested value is not available.") { };
 
-				virtual ~ValueNotFoundException() throw () { };
+				virtual ~ValueNotFoundException() noexcept { };
 			};
 
-			float get(const dtn::data::EID &neighbor) const throw (ValueNotFoundException);
+			float get(const dtn::data::EID &neighbor) const noexcept (false);
 			void set(const dtn::data::EID &neighbor, float value);
 			void clear();
 			size_t size() const;

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.cpp
@@ -163,9 +163,9 @@ namespace dtn
 
 					virtual ~BundleFilter() {}
 
-					virtual dtn::data::Size limit() const throw () { return 0; }
+					virtual dtn::data::Size limit() const noexcept { return 0; }
 
-					virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+					virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const noexcept (false)
 					{
 						// do not delete any bundles with
 						if (meta.destination.getNode() == dtn::core::BundleCore::local)
@@ -205,13 +205,13 @@ namespace dtn
 			} catch (std::exception&) { }
 		}
 
-		void ProphetRoutingExtension::eventDataChanged(const dtn::data::EID &peer) throw ()
+		void ProphetRoutingExtension::eventDataChanged(const dtn::data::EID &peer) noexcept
 		{
 			// transfer the next bundle to this destination
 			_taskqueue.push( new SearchNextBundleTask( peer ) );
 		}
 
-		void ProphetRoutingExtension::eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void ProphetRoutingExtension::eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// add forwarded entry to GTMX strategy
 			try {
@@ -220,7 +220,7 @@ namespace dtn
 			} catch (const std::bad_cast &ex) { };
 		}
 
-		void ProphetRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ()
+		void ProphetRoutingExtension::eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept
 		{
 			// new bundles trigger a recheck for all neighbors
 			const std::set<dtn::core::Node> nl = dtn::core::BundleCore::getInstance().getConnectionManager().getNeighbors();
@@ -237,7 +237,7 @@ namespace dtn
 			}
 		}
 
-		void ProphetRoutingExtension::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void ProphetRoutingExtension::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			// expire bundles in the acknowledgment set
 			{
@@ -263,7 +263,7 @@ namespace dtn
 			}
 		}
 
-		void ProphetRoutingExtension::raiseEvent(const NodeHandshakeEvent &handshake) throw ()
+		void ProphetRoutingExtension::raiseEvent(const NodeHandshakeEvent &handshake) noexcept
 		{
 			if (handshake.state == NodeHandshakeEvent::HANDSHAKE_COMPLETED)
 			{
@@ -272,7 +272,7 @@ namespace dtn
 			}
 		}
 
-		void ProphetRoutingExtension::raiseEvent(const dtn::core::BundlePurgeEvent &purge) throw ()
+		void ProphetRoutingExtension::raiseEvent(const dtn::core::BundlePurgeEvent &purge) noexcept
 		{
 			if (purge.reason == dtn::core::BundlePurgeEvent::DELIVERED)
 			{
@@ -282,7 +282,7 @@ namespace dtn
 			}
 		}
 
-		void ProphetRoutingExtension::componentUp() throw ()
+		void ProphetRoutingExtension::componentUp() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::routing::NodeHandshakeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
@@ -294,7 +294,7 @@ namespace dtn
 			// restore persistent routing data
 			if (_persistent_file.exists()) restore(_persistent_file);
 
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			try {
 				// run the thread
 				start();
@@ -303,7 +303,7 @@ namespace dtn
 			}
 		}
 
-		void ProphetRoutingExtension::componentDown() throw ()
+		void ProphetRoutingExtension::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::routing::NodeHandshakeEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
@@ -321,7 +321,7 @@ namespace dtn
 			}
 		}
 
-		const std::string ProphetRoutingExtension::getTag() const throw ()
+		const std::string ProphetRoutingExtension::getTag() const noexcept
 		{
 			return "prophet";
 		}
@@ -345,7 +345,7 @@ namespace dtn
 			return ibrcommon::ThreadsafeReference<const AcknowledgementSet>(_acknowledgementSet, const_cast<AcknowledgementSet&>(_acknowledgementSet));
 		}
 
-		void ProphetRoutingExtension::ProphetRoutingExtension::run() throw ()
+		void ProphetRoutingExtension::ProphetRoutingExtension::run() noexcept
 		{
 			class BundleFilter : public dtn::storage::BundleSelector
 			{
@@ -356,9 +356,9 @@ namespace dtn
 
 				virtual ~BundleFilter() {};
 
-				virtual dtn::data::Size limit() const throw () { return _entry.getFreeTransferSlots(); };
+				virtual dtn::data::Size limit() const noexcept { return _entry.getFreeTransferSlots(); };
 
-				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+				virtual bool addIfSelected(dtn::storage::BundleResult &result, const dtn::data::MetaBundle &meta) const noexcept (false)
 				{
 					// check Scope Control Block - do not forward bundles with hop limit == 0
 					if (meta.hopcount == 0)
@@ -586,7 +586,7 @@ namespace dtn
 			}
 		}
 
-		void ProphetRoutingExtension::__cancellation() throw ()
+		void ProphetRoutingExtension::__cancellation() noexcept
 		{
 			_taskqueue.abort();
 		}

--- a/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.h
+++ b/ibrdtn/daemon/src/routing/prophet/ProphetRoutingExtension.h
@@ -68,24 +68,24 @@ namespace dtn
 						dtn::data::Timestamp next_exchange_timeout);
 			virtual ~ProphetRoutingExtension();
 
-			virtual const std::string getTag() const throw ();
+			virtual const std::string getTag() const noexcept;
 
 			/* virtual methods from BaseRouter::Extension */
 			virtual void requestHandshake(const dtn::data::EID&, NodeHandshake&) const; ///< \see BaseRouter::Extension::requestHandshake
 			virtual void responseHandshake(const dtn::data::EID&, const NodeHandshake&, NodeHandshake&); ///< \see BaseRouter::Extension::responseHandshake
 			virtual void processHandshake(const dtn::data::EID&, NodeHandshake&); ///< \see BaseRouter::Extension::processHandshake
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
-			virtual void raiseEvent(const dtn::routing::NodeHandshakeEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
-			virtual void raiseEvent(const dtn::core::BundlePurgeEvent &evt) throw ();
+			virtual void raiseEvent(const dtn::routing::NodeHandshakeEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
+			virtual void raiseEvent(const dtn::core::BundlePurgeEvent &evt) noexcept;
 
-			virtual void eventDataChanged(const dtn::data::EID &peer) throw ();
+			virtual void eventDataChanged(const dtn::data::EID &peer) noexcept;
 
-			virtual void eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventTransferCompleted(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
-			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) throw ();
+			virtual void eventBundleQueued(const dtn::data::EID &peer, const dtn::data::MetaBundle &meta) noexcept;
 
 			/*!
 			 * Returns a threadsafe reference to the DeliveryPredictabilityMap. I.e. the corresponding
@@ -106,8 +106,8 @@ namespace dtn
 			 */
 			ibrcommon::ThreadsafeReference<const AcknowledgementSet> getAcknowledgementSet() const;
 		protected:
-			virtual void run() throw ();
-			void __cancellation() throw ();
+			virtual void run() noexcept;
+			void __cancellation() noexcept;
 		private:
 			/*!
 			 * Updates the DeliveryPredictabilityMap in the event that a neighbor has been encountered.

--- a/ibrdtn/daemon/src/security/SecurityCertificateManager.cpp
+++ b/ibrdtn/daemon/src/security/SecurityCertificateManager.cpp
@@ -61,7 +61,7 @@ namespace dtn
 			return _trustedCAPath;
 		}
 
-		void SecurityCertificateManager::onConfigurationChanged(const dtn::daemon::Configuration &conf) throw ()
+		void SecurityCertificateManager::onConfigurationChanged(const dtn::daemon::Configuration &conf) noexcept
 		{
 			ibrcommon::File certificate = conf.getSecurity().getCertificate();
 			ibrcommon::File privateKey = conf.getSecurity().getKey();
@@ -109,7 +109,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityCertificateManager::componentUp() throw ()
+		void SecurityCertificateManager::componentUp() noexcept
 		{
 			ibrcommon::MutexLock l(_initialization_lock);
 
@@ -127,7 +127,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityCertificateManager::componentDown() throw ()
+		void SecurityCertificateManager::componentDown() noexcept
 		{
 			/* nothing to do */
 		}
@@ -139,7 +139,7 @@ namespace dtn
 		}
 
 		void
-		SecurityCertificateManager::validateSubject(X509 *certificate, const std::string &cn) throw (SecurityCertificateException)
+		SecurityCertificateManager::validateSubject(X509 *certificate, const std::string &cn) noexcept (false)
 		{
 			if(!certificate || cn.empty()){
 				throw SecurityCertificateException("certificate or common-name is empty");

--- a/ibrdtn/daemon/src/security/SecurityCertificateManager.h
+++ b/ibrdtn/daemon/src/security/SecurityCertificateManager.h
@@ -44,7 +44,7 @@ namespace dtn
 			SecurityCertificateException(std::string what = "verification failed") : ibrcommon::Exception(what)
 			{};
 
-			virtual ~SecurityCertificateException() throw() {};
+			virtual ~SecurityCertificateException() noexcept {};
 		};
 
 		/*!
@@ -61,7 +61,7 @@ namespace dtn
 			/**
 			 * Listen for changes of the configuration
 			 */
-			virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) throw ();
+			virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) noexcept;
 
 			/*!
 			 * \brief Validates if the CommonName in the given X509 certificate corresponds to the given EID
@@ -69,7 +69,7 @@ namespace dtn
 			 * \param eid The EID of the sender.
 			 * \return returns true if the EID fits, false otherwise
 			 */
-			static void validateSubject(X509 *certificate, const std::string &cn) throw (SecurityCertificateException);
+			static void validateSubject(X509 *certificate, const std::string &cn) noexcept (false);
 
 			/*!
 			 * \brief checks if this class has already been initialized with a certificate and private key
@@ -96,8 +96,8 @@ namespace dtn
 			const ibrcommon::File& getTrustedCAPath() const;
 
 			/* functions from IntegratedComponent */
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
 			virtual const std::string getName() const;
 

--- a/ibrdtn/daemon/src/security/SecurityKeyManager.cpp
+++ b/ibrdtn/daemon/src/security/SecurityKeyManager.cpp
@@ -53,7 +53,7 @@ namespace dtn
 		{
 		}
 
-		void SecurityKeyManager::onConfigurationChanged(const dtn::daemon::Configuration &conf) throw ()
+		void SecurityKeyManager::onConfigurationChanged(const dtn::daemon::Configuration &conf) noexcept
 		{
 			const dtn::daemon::Configuration::Security &sec = conf.getSecurity();
 
@@ -149,7 +149,7 @@ namespace dtn
 			store(key);
 		}
 
-		dtn::security::SecurityKey SecurityKeyManager::get(const std::string &prefix, const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type) const throw (SecurityKey::KeyNotFoundException)
+		dtn::security::SecurityKey SecurityKeyManager::get(const std::string &prefix, const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type) const noexcept (false)
 		{
 			dtn::security::SecurityKey keydata;
 			keydata.reference = ref.getNode();
@@ -162,7 +162,7 @@ namespace dtn
 			return keydata;
 		}
 
-		dtn::security::SecurityKey SecurityKeyManager::get(const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type) const throw (SecurityKey::KeyNotFoundException)
+		dtn::security::SecurityKey SecurityKeyManager::get(const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type) const noexcept (false)
 		{
 			dtn::security::SecurityKey keydata;
 			keydata.reference = ref.getNode();

--- a/ibrdtn/daemon/src/security/SecurityKeyManager.h
+++ b/ibrdtn/daemon/src/security/SecurityKeyManager.h
@@ -45,7 +45,7 @@ namespace dtn
 				PathNotFoundException(std::string what = "No security path configured.") : ibrcommon::Exception(what)
 				{};
 
-				virtual ~PathNotFoundException() throw() {};
+				virtual ~PathNotFoundException() noexcept {};
 			};
 
 			static SecurityKeyManager& getInstance();
@@ -55,7 +55,7 @@ namespace dtn
 			/**
 			 * Listen for changes of the configuration
 			 */
-			virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) throw ();
+			virtual void onConfigurationChanged(const dtn::daemon::Configuration &conf) noexcept;
 
 			/**
 			 * Checks if a security key exists
@@ -65,12 +65,12 @@ namespace dtn
 			/**
 			 * Get a security key from the standard key path
 			 */
-			dtn::security::SecurityKey get(const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type = dtn::security::SecurityKey::KEY_UNSPEC) const throw (SecurityKey::KeyNotFoundException);
+			dtn::security::SecurityKey get(const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type = dtn::security::SecurityKey::KEY_UNSPEC) const noexcept (false);
 
 			/**
 			 * Get a security key from the prefixed path
 			 */
-			dtn::security::SecurityKey get(const std::string &prefix, const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type = dtn::security::SecurityKey::KEY_UNSPEC) const throw (SecurityKey::KeyNotFoundException);
+			dtn::security::SecurityKey get(const std::string &prefix, const dtn::data::EID &ref, const dtn::security::SecurityKey::KeyType type = dtn::security::SecurityKey::KEY_UNSPEC) const noexcept (false);
 
 			/**
 			 * Store a security key in the standard key path

--- a/ibrdtn/daemon/src/security/SecurityManager.cpp
+++ b/ibrdtn/daemon/src/security/SecurityManager.cpp
@@ -52,7 +52,7 @@ namespace dtn
 		{
 		}
 
-		void SecurityManager::auth(dtn::data::Bundle &bundle) const throw (KeyMissingException)
+		void SecurityManager::auth(dtn::data::Bundle &bundle) const noexcept (false)
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("SecurityManager", 10) << "auth bundle: " << bundle.toString() << IBRCOMMON_LOGGER_ENDL;
 
@@ -67,7 +67,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityManager::sign(dtn::data::Bundle &bundle) const throw (KeyMissingException)
+		void SecurityManager::sign(dtn::data::Bundle &bundle) const noexcept (false)
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("SecurityManager", 10) << "sign bundle: " << bundle.toString() << IBRCOMMON_LOGGER_ENDL;
 
@@ -82,7 +82,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityManager::verifyIntegrity(dtn::data::Bundle &bundle) const throw (VerificationFailedException)
+		void SecurityManager::verifyIntegrity(dtn::data::Bundle &bundle) const noexcept (false)
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("SecurityManager", 10) << "verify signed bundle: " << bundle.toString() << IBRCOMMON_LOGGER_ENDL;
 
@@ -131,7 +131,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityManager::verifyAuthentication(dtn::data::Bundle &bundle) const throw (VerificationFailedException)
+		void SecurityManager::verifyAuthentication(dtn::data::Bundle &bundle) const noexcept (false)
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("SecurityManager", 10) << "verify authenticated bundle: " << bundle.toString() << IBRCOMMON_LOGGER_ENDL;
 
@@ -165,7 +165,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityManager::decrypt(dtn::data::Bundle &bundle) const throw (DecryptException, KeyMissingException)
+		void SecurityManager::decrypt(dtn::data::Bundle &bundle) const noexcept (false)
 		{
 			// check if the bundle has to be decrypted, return when not
 			if (std::count(bundle.begin(), bundle.end(), dtn::security::PayloadConfidentialBlock::BLOCK_TYPE) <= 0) return;
@@ -186,7 +186,7 @@ namespace dtn
 			}
 		}
 
-		void SecurityManager::encrypt(dtn::data::Bundle &bundle) const throw (EncryptException, KeyMissingException)
+		void SecurityManager::encrypt(dtn::data::Bundle &bundle) const noexcept (false)
 		{
 			try {
 				IBRCOMMON_LOGGER_DEBUG_TAG("SecurityManager", 10) << "encrypt bundle: " << bundle.toString() << IBRCOMMON_LOGGER_ENDL;

--- a/ibrdtn/daemon/src/security/SecurityManager.h
+++ b/ibrdtn/daemon/src/security/SecurityManager.h
@@ -47,7 +47,7 @@ namespace dtn
 					KeyMissingException(std::string what = "Key for this operation is not available.") : SecurityException(what)
 					{};
 
-					virtual ~KeyMissingException() throw() {};
+					virtual ~KeyMissingException() noexcept {};
 				};
 
 				/**
@@ -61,23 +61,23 @@ namespace dtn
 				 * available a KeyMissingException is thrown.
 				 * @param bundle A bundle to sign.
 				 */
-				void sign(dtn::data::Bundle &bundle) const throw (KeyMissingException);
-				void auth(dtn::data::Bundle &bundle) const throw (KeyMissingException);
+				void sign(dtn::data::Bundle &bundle) const noexcept (false);
+				void auth(dtn::data::Bundle &bundle) const noexcept (false);
 
 				/**
 				 * This method verifies the bundle and removes all auth or integrity block
 				 * if they could validated.
 				 * @param bundle The bundle to verify.
 				 */
-				void verifyAuthentication(dtn::data::Bundle &bundle) const throw (VerificationFailedException);
-				void verifyIntegrity(dtn::data::Bundle &bundle) const throw (VerificationFailedException);
+				void verifyAuthentication(dtn::data::Bundle &bundle) const noexcept (false);
+				void verifyIntegrity(dtn::data::Bundle &bundle) const noexcept (false);
 
 				/**
 				 * This method decrypts encrypted payload of a bundle. It is necessary to
 				 * remove all integrity or auth block before the payload can decrypted.
 				 * @param bundle
 				 */
-				void decrypt(dtn::data::Bundle &bundle) const throw (DecryptException, KeyMissingException);
+				void decrypt(dtn::data::Bundle &bundle) const noexcept (false);
 
 				/**
 				 * This method encrypts the payload of a given bundle.
@@ -85,7 +85,7 @@ namespace dtn
 				 * is thrown.
 				 * @param bundle
 				 */
-				void encrypt(dtn::data::Bundle &bundle) const throw (EncryptException, KeyMissingException);
+				void encrypt(dtn::data::Bundle &bundle) const noexcept (false);
 
 			protected:
 				/**

--- a/ibrdtn/daemon/src/security/exchange/KeyExchangeSession.cpp
+++ b/ibrdtn/daemon/src/security/exchange/KeyExchangeSession.cpp
@@ -94,7 +94,7 @@ namespace dtn
 			return _session_key;
 		}
 
-		dtn::security::SecurityKey KeyExchangeSession::getKey(const dtn::security::SecurityKey::KeyType type) const throw (SecurityKey::KeyNotFoundException)
+		dtn::security::SecurityKey KeyExchangeSession::getKey(const dtn::security::SecurityKey::KeyType type) const noexcept (false)
 		{
 			unsigned int id = getUniqueId();
 			std::string prefix((char*)&id, sizeof id);

--- a/ibrdtn/daemon/src/security/exchange/KeyExchangeSession.h
+++ b/ibrdtn/daemon/src/security/exchange/KeyExchangeSession.h
@@ -86,7 +86,7 @@ namespace dtn
 				/**
 				 * Return the key stored within this session
 				 */
-				dtn::security::SecurityKey getKey(const dtn::security::SecurityKey::KeyType type = dtn::security::SecurityKey::KEY_UNSPEC) const throw (SecurityKey::KeyNotFoundException);
+				dtn::security::SecurityKey getKey(const dtn::security::SecurityKey::KeyType type = dtn::security::SecurityKey::KEY_UNSPEC) const noexcept (false);
 
 				/**
 				 * Stores a key in the session

--- a/ibrdtn/daemon/src/security/exchange/KeyExchanger.cpp
+++ b/ibrdtn/daemon/src/security/exchange/KeyExchanger.cpp
@@ -90,12 +90,12 @@ namespace dtn
 			_sessionmap.clear();
 		}
 
-		void KeyExchanger::__cancellation() throw ()
+		void KeyExchanger::__cancellation() noexcept
 		{
 			_queue.abort();
 		}
 
-		void KeyExchanger::componentUp() throw ()
+		void KeyExchanger::componentUp() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::security::KeyExchangeEvent>::add(this);
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
@@ -104,7 +104,7 @@ namespace dtn
 			_queue.reset();
 		}
 
-		void KeyExchanger::componentRun() throw ()
+		void KeyExchanger::componentRun() noexcept
 		{
 			// initialize all protocols
 			for (std::map<int, KeyExchangeProtocol*>::iterator it = _protocols.begin(); it != _protocols.end(); ++it)
@@ -132,7 +132,7 @@ namespace dtn
 			}
 		}
 
-		void KeyExchanger::componentDown() throw ()
+		void KeyExchanger::componentDown() noexcept
 		{
 			dtn::core::EventDispatcher<dtn::security::KeyExchangeEvent>::remove(this);
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
@@ -169,12 +169,12 @@ namespace dtn
 			} catch (const ibrcommon::Exception&) {}
 		}
 
-		void KeyExchanger::raiseEvent(const KeyExchangeEvent &kee) throw ()
+		void KeyExchanger::raiseEvent(const KeyExchangeEvent &kee) noexcept
 		{
 			_queue.push(new ExchangeTask(kee.getEID(), kee.getData()));
 		}
 
-		void KeyExchanger::raiseEvent(const dtn::core::TimeEvent&) throw ()
+		void KeyExchanger::raiseEvent(const dtn::core::TimeEvent&) noexcept
 		{
 			const dtn::data::Timestamp now = dtn::utils::Clock::getMonotonicTimestamp();
 
@@ -311,7 +311,7 @@ namespace dtn
 		 : _peer(peer), _data(data)
 		{}
 
-		void KeyExchanger::ExchangeTask::execute(KeyExchanger &exchanger) throw ()
+		void KeyExchanger::ExchangeTask::execute(KeyExchanger &exchanger) noexcept
 		{
 			try
 			{
@@ -454,7 +454,7 @@ namespace dtn
 		 : _timestamp(timestamp)
 		{}
 
-		void KeyExchanger::ExpireTask::execute(KeyExchanger &exchanger) throw ()
+		void KeyExchanger::ExpireTask::execute(KeyExchanger &exchanger) noexcept
 		{
 			// free expired sessions
 			exchanger.expire(_timestamp);
@@ -519,7 +519,7 @@ namespace dtn
 			return *session;
 		}
 
-		KeyExchangeSession& KeyExchanger::getSession(const dtn::data::EID &peer, const dtn::security::KeyExchangeData &data) throw (ibrcommon::Exception)
+		KeyExchangeSession& KeyExchanger::getSession(const dtn::data::EID &peer, const dtn::security::KeyExchangeData &data) noexcept (false)
 		{
 			const std::string session_key = KeyExchangeSession::getSessionKey(peer, data.getSessionId());
 

--- a/ibrdtn/daemon/src/security/exchange/KeyExchanger.h
+++ b/ibrdtn/daemon/src/security/exchange/KeyExchanger.h
@@ -61,25 +61,25 @@ namespace dtn
 				 * should guarantee that blocking calls in componentRun()
 				 * will unblock.
 				 */
-				virtual void __cancellation() throw ();
+				virtual void __cancellation() noexcept;
 
 				/**
 				 * Is called in preparation of the component.
 				 * Before componentRun() is called.
 				 */
-				virtual void componentUp() throw ();
+				virtual void componentUp() noexcept;
 
 				/**
 				 * This is the run method. The component should loop in there
 				 * until componentDown() or __cancellation() is called.
 				 */
-				virtual void componentRun() throw ();
+				virtual void componentRun() noexcept;
 
 				/**
 				 * This method is called if the component should stop. Clean-up
 				 * code should be inserted here.
 				 */
-				virtual void componentDown() throw ();
+				virtual void componentDown() noexcept;
 
 				/**
 				 * Return an identifier for this component
@@ -95,8 +95,8 @@ namespace dtn
 				/**
 				 * Receives incoming events.
 				 */
-				virtual void raiseEvent(const dtn::security::KeyExchangeEvent &evt) throw ();
-				virtual void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
+				virtual void raiseEvent(const dtn::security::KeyExchangeEvent &evt) noexcept;
+				virtual void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
 
 				/**
 				 * KeyExchangeManager methods
@@ -114,7 +114,7 @@ namespace dtn
 						/**
 						 * Execute the code associated with this task.
 						 */
-						virtual void execute(KeyExchanger &exchanger) throw () = 0;
+						virtual void execute(KeyExchanger &exchanger) noexcept = 0;
 				};
 
 				class ExchangeTask : public Task
@@ -126,7 +126,7 @@ namespace dtn
 						/**
 						 * Execute the code associated with this task.
 						 */
-						virtual void execute(KeyExchanger &exchanger) throw ();
+						virtual void execute(KeyExchanger &exchanger) noexcept;
 
 					private:
 						const dtn::data::EID _peer;
@@ -142,7 +142,7 @@ namespace dtn
 						/**
 						 * Execute the code associated with this task.
 						 */
-						virtual void execute(KeyExchanger &exchanger) throw ();
+						virtual void execute(KeyExchanger &exchanger) noexcept;
 
 					private:
 						const dtn::data::Timestamp _timestamp;
@@ -150,7 +150,7 @@ namespace dtn
 
 				KeyExchangeSession& createSession(KeyExchangeProtocol &p, const dtn::data::EID &peer);
 				KeyExchangeSession& createSession(KeyExchangeProtocol &p, const dtn::data::EID &peer, const dtn::security::KeyExchangeData &data);
-				KeyExchangeSession& getSession(const dtn::data::EID &peer, const dtn::security::KeyExchangeData &data) throw (ibrcommon::Exception);
+				KeyExchangeSession& getSession(const dtn::data::EID &peer, const dtn::security::KeyExchangeData &data) noexcept (false);
 				void freeSession(const dtn::data::EID &peer, const unsigned int uniqueId);
 
 				void expire(const dtn::data::Timestamp timestamp);

--- a/ibrdtn/daemon/src/storage/BundleResult.cpp
+++ b/ibrdtn/daemon/src/storage/BundleResult.cpp
@@ -23,7 +23,7 @@ namespace dtn
 		BundleResultList::~BundleResultList() {
 		}
 
-		void BundleResultList::put(const dtn::data::MetaBundle &bundle) throw () {
+		void BundleResultList::put(const dtn::data::MetaBundle &bundle) noexcept {
 			this->push_back(bundle);
 		}
 
@@ -33,7 +33,7 @@ namespace dtn
 		BundleResultQueue::~BundleResultQueue() {
 		}
 
-		void BundleResultQueue::put(const dtn::data::MetaBundle &bundle) throw () {
+		void BundleResultQueue::put(const dtn::data::MetaBundle &bundle) noexcept {
 			this->push(bundle);
 		}
 	} /* namespace storage */

--- a/ibrdtn/daemon/src/storage/BundleResult.h
+++ b/ibrdtn/daemon/src/storage/BundleResult.h
@@ -20,7 +20,7 @@ namespace dtn
 		public:
 			BundleResult();
 			virtual ~BundleResult() = 0;
-			virtual void put(const dtn::data::MetaBundle &bundle) throw () = 0;
+			virtual void put(const dtn::data::MetaBundle &bundle) noexcept = 0;
 		};
 
 		class BundleResultList : public BundleResult, public std::list<dtn::data::MetaBundle> {
@@ -28,7 +28,7 @@ namespace dtn
 			BundleResultList();
 			virtual ~BundleResultList();
 
-			virtual void put(const dtn::data::MetaBundle &bundle) throw ();
+			virtual void put(const dtn::data::MetaBundle &bundle) noexcept;
 		};
 
 		class BundleResultQueue : public BundleResult, public ibrcommon::Queue<dtn::data::MetaBundle> {
@@ -36,7 +36,7 @@ namespace dtn
 			BundleResultQueue();
 			virtual ~BundleResultQueue();
 
-			virtual void put(const dtn::data::MetaBundle &bundle) throw ();
+			virtual void put(const dtn::data::MetaBundle &bundle) noexcept;
 		};
 	} /* namespace storage */
 } /* namespace dtn */

--- a/ibrdtn/daemon/src/storage/BundleSeeker.h
+++ b/ibrdtn/daemon/src/storage/BundleSeeker.h
@@ -30,7 +30,7 @@ namespace dtn
 			 * @param cb The instance of the BundleSelector class.
 			 * @return A list of bundles.
 			 */
-			virtual void get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException) = 0;
+			virtual void get(const BundleSelector &cb, BundleResult &result) noexcept (false) = 0;
 
 			/**
 			 * Return a set of distinct destinations for all bundles in the storage.

--- a/ibrdtn/daemon/src/storage/BundleSelector.h
+++ b/ibrdtn/daemon/src/storage/BundleSelector.h
@@ -21,7 +21,7 @@ namespace dtn
 		class BundleSelectorException : public ibrcommon::Exception
 		{
 		public:
-			BundleSelectorException(std::string what = "Bundle query aborted.") throw() : ibrcommon::Exception(what)
+			BundleSelectorException(std::string what = "Bundle query aborted.") noexcept : ibrcommon::Exception(what)
 			{
 			}
 		};
@@ -29,7 +29,7 @@ namespace dtn
 		class NoBundleFoundException : public dtn::MissingObjectException
 		{
 		public:
-			NoBundleFoundException(std::string what = "No bundle match the specified criteria.") throw() : dtn::MissingObjectException(what)
+			NoBundleFoundException(std::string what = "No bundle match the specified criteria.") noexcept : dtn::MissingObjectException(what)
 			{
 			};
 		};
@@ -43,7 +43,7 @@ namespace dtn
 			 * Limit the number of selected items.
 			 * @return The limit as number of items.
 			 */
-			virtual dtn::data::Size limit() const throw () { return 1; };
+			virtual dtn::data::Size limit() const noexcept { return 1; };
 
 			/**
 			 * This method is called by addIfSelected() to determine if one bundle
@@ -51,13 +51,13 @@ namespace dtn
 			 * @param id The bundle id of the bundle to select.
 			 * @return True, if the bundle should be added to the set.
 			 */
-			virtual bool shouldAdd(const dtn::data::MetaBundle&) const throw (BundleSelectorException) { return false; };
+			virtual bool shouldAdd(const dtn::data::MetaBundle&) const noexcept (false) { return false; };
 
 			/**
 			 * This method is called by the storage to add a bundle to the result
 			 * if it has been selected by the shouldAdd method
 			 */
-			virtual bool addIfSelected(BundleResult &result, const dtn::data::MetaBundle &bundle) const throw (BundleSelectorException) {
+			virtual bool addIfSelected(BundleResult &result, const dtn::data::MetaBundle &bundle) const noexcept (false) {
 				if (shouldAdd(bundle)) {
 					result.put(bundle);
 					return true;

--- a/ibrdtn/daemon/src/storage/BundleStorage.cpp
+++ b/ibrdtn/daemon/src/storage/BundleStorage.cpp
@@ -133,7 +133,7 @@ namespace dtn
 			return _currentsize;
 		}
 
-		void BundleStorage::allocSpace(const dtn::data::Length &size) throw (StorageSizeExeededException)
+		void BundleStorage::allocSpace(const dtn::data::Length &size) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_sizelock);
 
@@ -147,7 +147,7 @@ namespace dtn
 			_currentsize += size;
 		}
 
-		void BundleStorage::freeSpace(const dtn::data::Length &size) throw ()
+		void BundleStorage::freeSpace(const dtn::data::Length &size) noexcept
 		{
 			ibrcommon::MutexLock l(_sizelock);
 			if (size > _currentsize)
@@ -161,13 +161,13 @@ namespace dtn
 			}
 		}
 
-		void BundleStorage::clearSpace() throw ()
+		void BundleStorage::clearSpace() noexcept
 		{
 			ibrcommon::MutexLock l(_sizelock);
 			_currentsize = 0;
 		}
 
-		void BundleStorage::eventBundleAdded(const dtn::data::MetaBundle &b) throw ()
+		void BundleStorage::eventBundleAdded(const dtn::data::MetaBundle &b) noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("BundleStorage", 2) << "add bundle to index: " << b.toString() << IBRCOMMON_LOGGER_ENDL;
 
@@ -177,7 +177,7 @@ namespace dtn
 			}
 		}
 
-		void BundleStorage::eventBundleRemoved(const dtn::data::BundleID &id) throw ()
+		void BundleStorage::eventBundleRemoved(const dtn::data::BundleID &id) noexcept
 		{
 			IBRCOMMON_LOGGER_DEBUG_TAG("BundleStorage", 2) << "remove bundle from index: " << id.toString() << IBRCOMMON_LOGGER_ENDL;
 

--- a/ibrdtn/daemon/src/storage/BundleStorage.h
+++ b/ibrdtn/daemon/src/storage/BundleStorage.h
@@ -47,7 +47,7 @@ namespace dtn
 			class BundleLoadException : public NoBundleFoundException
 			{
 			public:
-				BundleLoadException(string what = "Error while loading bundle data.") throw() : NoBundleFoundException(what)
+				BundleLoadException(string what = "Error while loading bundle data.") noexcept : NoBundleFoundException(what)
 				{
 				};
 			};
@@ -55,7 +55,7 @@ namespace dtn
 			class StorageSizeExeededException : public ibrcommon::Exception
 			{
 			public:
-				StorageSizeExeededException(string what = "No space left in the storage.") throw() : ibrcommon::Exception(what)
+				StorageSizeExeededException(string what = "No space left in the storage.") noexcept : ibrcommon::Exception(what)
 				{
 				};
 			};
@@ -92,7 +92,7 @@ namespace dtn
 			/**
 			 * @see BundleSeeker::get(BundleSelector &cb, BundleResult &result)
 			 */
-			virtual void get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException) = 0;
+			virtual void get(const BundleSelector &cb, BundleResult &result) noexcept (false) = 0;
 
 			/**
 			 * @see BundleSeeker::getDistinctDestinations()
@@ -186,12 +186,12 @@ namespace dtn
 			 */
 			BundleStorage(const dtn::data::Length &maxsize);
 
-			void allocSpace(const dtn::data::Length &size) throw (StorageSizeExeededException);
-			void freeSpace(const dtn::data::Length &size) throw ();
-			void clearSpace() throw ();
+			void allocSpace(const dtn::data::Length &size) noexcept (false);
+			void freeSpace(const dtn::data::Length &size) noexcept;
+			void clearSpace() noexcept;
 
-			void eventBundleAdded(const dtn::data::MetaBundle &b) throw ();
-			void eventBundleRemoved(const dtn::data::BundleID &id) throw ();
+			void eventBundleAdded(const dtn::data::MetaBundle &b) noexcept;
+			void eventBundleRemoved(const dtn::data::BundleID &id) noexcept;
 
 			bool _faulty;
 

--- a/ibrdtn/daemon/src/storage/DataStorage.cpp
+++ b/ibrdtn/daemon/src/storage/DataStorage.cpp
@@ -173,7 +173,7 @@ namespace dtn
 			return hash;
 		}
 
-		DataStorage::istream DataStorage::retrieve(const DataStorage::Hash &hash) throw (DataNotAvailableException)
+		DataStorage::istream DataStorage::retrieve(const DataStorage::Hash &hash) noexcept (false)
 		{
 			ibrcommon::File file = _path.get(hash.value);
 
@@ -195,12 +195,12 @@ namespace dtn
 			_tasks.wait(ibrcommon::Queue< Task* >::QUEUE_EMPTY);
 		}
 
-		void DataStorage::__cancellation() throw ()
+		void DataStorage::__cancellation() noexcept
 		{
 			_tasks.abort();
 		}
 
-		void DataStorage::run() throw ()
+		void DataStorage::run() noexcept
 		{
 			try {
 				while (true)

--- a/ibrdtn/daemon/src/storage/DataStorage.h
+++ b/ibrdtn/daemon/src/storage/DataStorage.h
@@ -44,7 +44,7 @@ namespace dtn
 			class DataNotAvailableException : public ibrcommon::Exception
 			{
 			public:
-				DataNotAvailableException(string what = "Requested data is not available.") throw() : Exception(what)
+				DataNotAvailableException(string what = "Requested data is not available.") noexcept : Exception(what)
 				{ };
 			};
 
@@ -100,7 +100,7 @@ namespace dtn
 			const Hash store(Container *data);
 			void store(const Hash &hash, Container *data);
 
-			DataStorage::istream retrieve(const Hash &hash) throw (DataNotAvailableException);
+			DataStorage::istream retrieve(const Hash &hash) noexcept (false);
 			void remove(const Hash &hash);
 
 			/**
@@ -129,8 +129,8 @@ namespace dtn
 			/*** END: methods for unit-testing ***/
 
 		protected:
-			void run() throw ();
-			void __cancellation() throw ();
+			void run() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 			class Task

--- a/ibrdtn/daemon/src/storage/MemoryBundleStorage.cpp
+++ b/ibrdtn/daemon/src/storage/MemoryBundleStorage.cpp
@@ -44,19 +44,19 @@ namespace dtn
 		{
 		}
 
-		void MemoryBundleStorage::componentUp() throw ()
+		void MemoryBundleStorage::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
 		}
 
-		void MemoryBundleStorage::componentDown() throw ()
+		void MemoryBundleStorage::componentDown() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
 		}
 
-		void MemoryBundleStorage::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void MemoryBundleStorage::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			if (time.getAction() == dtn::core::TIME_SECOND_TICK)
 			{
@@ -89,7 +89,7 @@ namespace dtn
 			return _bundles.size();
 		}
 
-		void MemoryBundleStorage::get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException)
+		void MemoryBundleStorage::get(const BundleSelector &cb, BundleResult &result) noexcept (false)
 		{
 			size_t items_added = 0;
 
@@ -254,7 +254,7 @@ namespace dtn
 			clearSpace();
 		}
 
-		void MemoryBundleStorage::eventBundleExpired(const dtn::data::MetaBundle &b) throw ()
+		void MemoryBundleStorage::eventBundleExpired(const dtn::data::MetaBundle &b) noexcept
 		{
 			// search for the bundle in the bundle list
 			const bundle_list::iterator iter = find(_bundles.begin(), _bundles.end(), b);

--- a/ibrdtn/daemon/src/storage/MemoryBundleStorage.h
+++ b/ibrdtn/daemon/src/storage/MemoryBundleStorage.h
@@ -72,7 +72,7 @@ namespace dtn
 			/**
 			 * @see BundleSeeker::get(BundleSelector &cb, BundleResult &result)
 			 */
-			virtual void get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException);
+			virtual void get(const BundleSelector &cb, BundleResult &result) noexcept (false);
 
 			/**
 			 * @see BundleSeeker::getDistinctDestinations()
@@ -110,7 +110,7 @@ namespace dtn
 			 * This method is used to receive events.
 			 * @param evt
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
 
 			/**
 			 * @see Component::getName()
@@ -118,10 +118,10 @@ namespace dtn
 			virtual const std::string getName() const;
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
 
-			virtual void eventBundleExpired(const dtn::data::MetaBundle &b) throw ();
+			virtual void eventBundleExpired(const dtn::data::MetaBundle &b) noexcept;
 
 		private:
 			ibrcommon::Mutex _bundleslock;

--- a/ibrdtn/daemon/src/storage/MetaStorage.cpp
+++ b/ibrdtn/daemon/src/storage/MetaStorage.cpp
@@ -34,17 +34,17 @@ namespace dtn
 		{
 		}
 
-		bool MetaStorage::contains(const dtn::data::BundleID &id) const throw ()
+		bool MetaStorage::contains(const dtn::data::BundleID &id) const noexcept
 		{
 			return (_bundle_lengths.find(id) != _bundle_lengths.end());
 		}
 
-		void MetaStorage::expire(const dtn::data::Timestamp &timestamp) throw ()
+		void MetaStorage::expire(const dtn::data::Timestamp &timestamp) noexcept
 		{
 			_list.expire(timestamp);
 		}
 
-		const dtn::data::MetaBundle& MetaStorage::find(const ibrcommon::BloomFilter &filter) const throw (NoBundleFoundException)
+		const dtn::data::MetaBundle& MetaStorage::find(const ibrcommon::BloomFilter &filter) const noexcept (false)
 		{
 			for (const_iterator iter = begin(); iter != end(); ++iter)
 			{
@@ -62,7 +62,7 @@ namespace dtn
 			throw NoBundleFoundException();
 		}
 
-		std::set<dtn::data::EID> MetaStorage::getDistinctDestinations() const throw ()
+		std::set<dtn::data::EID> MetaStorage::getDistinctDestinations() const noexcept
 		{
 			std::set<dtn::data::EID> ret;
 
@@ -79,7 +79,7 @@ namespace dtn
 			return ret;
 		}
 
-		void MetaStorage::store(const dtn::data::MetaBundle &meta, const dtn::data::Length &space) throw ()
+		void MetaStorage::store(const dtn::data::MetaBundle &meta, const dtn::data::Length &space) noexcept
 		{
 			// increment the storage size
 			_bundle_lengths[meta] = space;
@@ -91,7 +91,7 @@ namespace dtn
 			_priority_index.insert(meta);
 		}
 
-		dtn::data::Length MetaStorage::remove(const dtn::data::MetaBundle &meta) throw ()
+		dtn::data::Length MetaStorage::remove(const dtn::data::MetaBundle &meta) noexcept
 		{
 			// get length of the stored bundle
 			size_map::iterator it = _bundle_lengths.find(meta);
@@ -118,19 +118,19 @@ namespace dtn
 			return ret;
 		}
 
-		void MetaStorage::markRemoved(const dtn::data::MetaBundle &meta) throw ()
+		void MetaStorage::markRemoved(const dtn::data::MetaBundle &meta) noexcept
 		{
 			if (contains(meta)) {
 				_removal_set.insert(meta);
 			}
 		}
 
-		bool MetaStorage::isRemoved(const dtn::data::MetaBundle &meta) const throw ()
+		bool MetaStorage::isRemoved(const dtn::data::MetaBundle &meta) const noexcept
 		{
 			return (_removal_set.find(meta) != _removal_set.end());
 		}
 
-		bool MetaStorage::empty() throw ()
+		bool MetaStorage::empty() noexcept
 		{
 			if ( _priority_index.empty() )
 			{
@@ -140,12 +140,12 @@ namespace dtn
 			return size() == 0;
 		}
 
-		dtn::data::Size MetaStorage::size() throw ()
+		dtn::data::Size MetaStorage::size() noexcept
 		{
 			return _priority_index.size() - _removal_set.size();
 		}
 
-		void MetaStorage::clear() throw ()
+		void MetaStorage::clear() noexcept
 		{
 			_priority_index.clear();
 			_list.clear();

--- a/ibrdtn/daemon/src/storage/MetaStorage.h
+++ b/ibrdtn/daemon/src/storage/MetaStorage.h
@@ -76,14 +76,14 @@ namespace dtn
 			const_iterator begin() const { return _priority_index.begin(); }
 			const_iterator end() const { return _priority_index.end(); }
 
-			bool empty() throw ();
-			size_t size() throw ();
+			bool empty() noexcept;
+			size_t size() noexcept;
 
-			bool contains(const dtn::data::BundleID &id) const throw ();
-			void expire(const dtn::data::Timestamp &timestamp) throw ();
+			bool contains(const dtn::data::BundleID &id) const noexcept;
+			void expire(const dtn::data::Timestamp &timestamp) noexcept;
 
 			template<class T>
-			const dtn::data::MetaBundle& find(const T &id) const throw (NoBundleFoundException)
+			const dtn::data::MetaBundle& find(const T &id) const noexcept (false)
 			{
 				dtn::data::BundleList::const_iterator it = _list.find(id);
 				if (it == _list.end())
@@ -92,33 +92,33 @@ namespace dtn
 				return (*it);
 			}
 
-			const dtn::data::MetaBundle& find(const ibrcommon::BloomFilter &filter) const throw (NoBundleFoundException);
+			const dtn::data::MetaBundle& find(const ibrcommon::BloomFilter &filter) const noexcept (false);
 
-			std::set<dtn::data::EID> getDistinctDestinations() const throw ();
+			std::set<dtn::data::EID> getDistinctDestinations() const noexcept;
 
-			void store(const dtn::data::MetaBundle &meta, const dtn::data::Length &space) throw ();
+			void store(const dtn::data::MetaBundle &meta, const dtn::data::Length &space) noexcept;
 
 			/**
 			 * Remove a data entry completely and returns the number of
 			 * released bytes.
 			 */
-			dtn::data::Length remove(const dtn::data::MetaBundle &meta) throw ();
+			dtn::data::Length remove(const dtn::data::MetaBundle &meta) noexcept;
 
 			/**
 			 * Mark a bundle as removed. Such a bundle is still reachable
 			 * using find(id) and getSize()
 			 */
-			void markRemoved(const dtn::data::MetaBundle &meta) throw ();
+			void markRemoved(const dtn::data::MetaBundle &meta) noexcept;
 
 			/**
 			 * Return true, if the bundle is already marked as removed
 			 */
-			bool isRemoved(const dtn::data::MetaBundle &meta) const throw ();
+			bool isRemoved(const dtn::data::MetaBundle &meta) const noexcept;
 
 			/**
 			 * Delete all bundles
 			 */
-			void clear() throw ();
+			void clear() noexcept;
 		};
 	} /* namespace storage */
 } /* namespace dtn */

--- a/ibrdtn/daemon/src/storage/SQLiteBundleSet.cpp
+++ b/ibrdtn/daemon/src/storage/SQLiteBundleSet.cpp
@@ -58,7 +58,7 @@ namespace dtn
 			}
 		}
 
-		size_t SQLiteBundleSet::Factory::create(SQLiteDatabase &db) throw (SQLiteDatabase::SQLiteQueryException)
+		size_t SQLiteBundleSet::Factory::create(SQLiteDatabase &db) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_create_lock);
 
@@ -70,13 +70,13 @@ namespace dtn
 			return __create(db, name, false);
 		}
 
-		size_t SQLiteBundleSet::Factory::create(SQLiteDatabase &db, const std::string &name) throw (SQLiteDatabase::SQLiteQueryException)
+		size_t SQLiteBundleSet::Factory::create(SQLiteDatabase &db, const std::string &name) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_create_lock);
 			return __create(db, name, true);
 		}
 
-		size_t SQLiteBundleSet::Factory::__create(SQLiteDatabase &db, const std::string &name, bool persistent) throw (SQLiteDatabase::SQLiteQueryException)
+		size_t SQLiteBundleSet::Factory::__create(SQLiteDatabase &db, const std::string &name, bool persistent) noexcept (false)
 		{
 			// create a new name (fails, if the name already exists)
 			SQLiteDatabase::Statement st1(db._database, SQLiteDatabase::_sql_queries[SQLiteDatabase::BUNDLE_SET_NAME_ADD]);
@@ -96,7 +96,7 @@ namespace dtn
 			throw SQLiteDatabase::SQLiteQueryException("could not create the bundle-set name");
 		}
 
-		bool SQLiteBundleSet::Factory::__exists(SQLiteDatabase &db, const std::string &name, bool persistent) throw (SQLiteDatabase::SQLiteQueryException)
+		bool SQLiteBundleSet::Factory::__exists(SQLiteDatabase &db, const std::string &name, bool persistent) noexcept (false)
 		{
 			SQLiteDatabase::Statement st(db._database, SQLiteDatabase::_sql_queries[SQLiteDatabase::BUNDLE_SET_NAME_GET_ID]);
 			sqlite3_bind_text(*st, 1, name.c_str(), static_cast<int>(name.length()), SQLITE_TRANSIENT);
@@ -205,7 +205,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleSet::add(const dtn::data::MetaBundle &bundle) throw ()
+		void SQLiteBundleSet::add(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			try {
 				// insert bundle id into database
@@ -238,7 +238,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleSet::clear() throw ()
+		void SQLiteBundleSet::clear() noexcept
 		{
 			try {
 				SQLiteDatabase::Statement st(_sqldb._database, SQLiteDatabase::_sql_queries[SQLiteDatabase::BUNDLE_SET_CLEAR]);
@@ -253,7 +253,7 @@ namespace dtn
 			_bf.clear();
 		}
 
-		bool SQLiteBundleSet::has(const dtn::data::BundleID &id) const throw ()
+		bool SQLiteBundleSet::has(const dtn::data::BundleID &id) const noexcept
 		{
 			// check bloom-filter first
 			if (!id.isIn(_bf)) return false;
@@ -287,7 +287,7 @@ namespace dtn
 			return false;
 		}
 
-		void SQLiteBundleSet::expire(const dtn::data::Timestamp timestamp) throw ()
+		void SQLiteBundleSet::expire(const dtn::data::Timestamp timestamp) noexcept
 		{
 			// we can not expire bundles if we have no idea of time
 			if (timestamp == 0) return;
@@ -336,7 +336,7 @@ namespace dtn
 			rebuild_bloom_filter();
 		}
 
-		dtn::data::Size SQLiteBundleSet::size() const throw ()
+		dtn::data::Size SQLiteBundleSet::size() const noexcept
 		{
 			int rows = 0;
 
@@ -355,17 +355,17 @@ namespace dtn
 			return rows;
 		}
 
-		dtn::data::Length SQLiteBundleSet::getLength() const throw ()
+		dtn::data::Length SQLiteBundleSet::getLength() const noexcept
 		{
 			return dtn::data::Number(_bf.size()).getLength() + _bf.size();
 		}
 
-		const ibrcommon::BloomFilter& SQLiteBundleSet::getBloomFilter() const throw ()
+		const ibrcommon::BloomFilter& SQLiteBundleSet::getBloomFilter() const noexcept
 		{
 			return _bf;
 		}
 
-		std::set<dtn::data::MetaBundle> SQLiteBundleSet::getNotIn(const ibrcommon::BloomFilter &filter) const throw ()
+		std::set<dtn::data::MetaBundle> SQLiteBundleSet::getNotIn(const ibrcommon::BloomFilter &filter) const noexcept
 		{
 			std::set<dtn::data::MetaBundle> ret;
 
@@ -423,7 +423,7 @@ namespace dtn
 			return stream;
 		}
 
-		void SQLiteBundleSet::new_expire_time(const dtn::data::Timestamp &ttl) throw ()
+		void SQLiteBundleSet::new_expire_time(const dtn::data::Timestamp &ttl) noexcept
 		{
 			if (_next_expiration == 0 || ttl < _next_expiration)
 			{
@@ -456,7 +456,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleSet::get_bundleid(SQLiteDatabase::Statement &st, dtn::data::BundleID &id, int offset) const throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteBundleSet::get_bundleid(SQLiteDatabase::Statement &st, dtn::data::BundleID &id, int offset) const noexcept (false)
 		{
 			id.source = dtn::data::EID((const char*)sqlite3_column_text(*st, offset + 0));
 			id.timestamp = sqlite3_column_int64(*st, offset + 1);

--- a/ibrdtn/daemon/src/storage/SQLiteBundleSet.h
+++ b/ibrdtn/daemon/src/storage/SQLiteBundleSet.h
@@ -49,18 +49,18 @@ namespace dtn
 					/**
 					 * creates an anonymous bundle-set and returns its ID
 					 */
-					static size_t create(SQLiteDatabase &db) throw (SQLiteDatabase::SQLiteQueryException);
+					static size_t create(SQLiteDatabase &db) noexcept (false);
 
 					/**
 					 * creates a named bundle-set or returns the ID of an existing bundle-set
 					 */
-					static size_t create(SQLiteDatabase &db, const std::string &name) throw (SQLiteDatabase::SQLiteQueryException);
-					static size_t __create(SQLiteDatabase &db, const std::string &name, bool persistent) throw (SQLiteDatabase::SQLiteQueryException);
+					static size_t create(SQLiteDatabase &db, const std::string &name) noexcept (false);
+					static size_t __create(SQLiteDatabase &db, const std::string &name, bool persistent) noexcept (false);
 
 					/*
 					 * returns true, if a specific bundle-set name exists
 					 */
-					static bool __exists(SQLiteDatabase &db, const std::string &name, bool persistent) throw (SQLiteDatabase::SQLiteQueryException);
+					static bool __exists(SQLiteDatabase &db, const std::string &name, bool persistent) noexcept (false);
 
 				private:
 					static ibrcommon::Mutex _create_lock;
@@ -86,33 +86,33 @@ namespace dtn
 			 */
 			virtual void assign(const refcnt_ptr<BundleSetImpl>&);
 
-			virtual void add(const dtn::data::MetaBundle &bundle) throw ();
+			virtual void add(const dtn::data::MetaBundle &bundle) noexcept;
 
-			virtual void clear() throw ();
+			virtual void clear() noexcept;
 
-			virtual bool has(const dtn::data::BundleID &bundle) const throw ();
+			virtual bool has(const dtn::data::BundleID &bundle) const noexcept;
 
-			virtual void expire(const dtn::data::Timestamp timestamp) throw ();
+			virtual void expire(const dtn::data::Timestamp timestamp) noexcept;
 
 			/**
 			 * Returns the number of elements in this set
 			 */
-			virtual dtn::data::Size size() const throw();
+			virtual dtn::data::Size size() const noexcept;
 
 			/**
 			 * Returns the data length of the serialized BundleSet
 			 */
-			dtn::data::Length getLength() const throw();
+			dtn::data::Length getLength() const noexcept;
 
-			const ibrcommon::BloomFilter& getBloomFilter() const throw();
+			const ibrcommon::BloomFilter& getBloomFilter() const noexcept;
 
-			std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const throw();
+			std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const noexcept;
 
 			virtual std::ostream &serialize(std::ostream &stream) const;
 			virtual std::istream &deserialize(std::istream &stream);
 
 		private:
-			void get_bundleid(SQLiteDatabase::Statement &st, dtn::data::BundleID &id, int offset = 0) const throw (SQLiteDatabase::SQLiteQueryException);
+			void get_bundleid(SQLiteDatabase::Statement &st, dtn::data::BundleID &id, int offset = 0) const noexcept (false);
 
 			// remove this bundle-set from the database
 			void destroy();
@@ -135,7 +135,7 @@ namespace dtn
 
 			dtn::data::Timestamp _next_expiration;
 
-			void new_expire_time(const dtn::data::Timestamp &ttl) throw();
+			void new_expire_time(const dtn::data::Timestamp &ttl) noexcept;
 
 			void rebuild_bloom_filter();
 

--- a/ibrdtn/daemon/src/storage/SQLiteBundleStorage.cpp
+++ b/ibrdtn/daemon/src/storage/SQLiteBundleStorage.cpp
@@ -158,7 +158,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleStorage::componentRun() throw ()
+		void SQLiteBundleStorage::componentRun() noexcept
 		{
 			// loop until aborted
 			try {
@@ -188,9 +188,9 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleStorage::componentUp() throw ()
+		void SQLiteBundleStorage::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 
 			//register Events
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::add(this);
@@ -204,9 +204,9 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleStorage::componentDown() throw ()
+		void SQLiteBundleStorage::componentDown() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 
 			//unregister Events
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
@@ -216,7 +216,7 @@ namespace dtn
 			join();
 		}
 
-		void SQLiteBundleStorage::__cancellation() throw ()
+		void SQLiteBundleStorage::__cancellation() noexcept
 		{
 			_tasks.abort();
 		}
@@ -232,7 +232,7 @@ namespace dtn
 			return SQLiteBundleStorage::eid_set();
 		}
 
-		void SQLiteBundleStorage::get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException)
+		void SQLiteBundleStorage::get(const BundleSelector &cb, BundleResult &result) noexcept (false)
 		{
 			ibrcommon::MutexLock l(_global_lock);
 			_database.get(cb, result);
@@ -538,7 +538,7 @@ namespace dtn
 			return 0;
 		}
 
-		void SQLiteBundleStorage::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void SQLiteBundleStorage::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			if (time.getAction() == dtn::core::TIME_SECOND_TICK)
 			{
@@ -546,7 +546,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteBundleStorage::raiseEvent(const dtn::core::GlobalEvent &global) throw ()
+		void SQLiteBundleStorage::raiseEvent(const dtn::core::GlobalEvent &global) noexcept
 		{
 			if (global.getAction() == dtn::core::GlobalEvent::GLOBAL_IDLE)
 			{
@@ -632,7 +632,7 @@ namespace dtn
 			allocSpace(size);
 		}
 
-		void SQLiteBundleStorage::eventBundleExpired(const dtn::data::BundleID &id, const dtn::data::Length size) throw ()
+		void SQLiteBundleStorage::eventBundleExpired(const dtn::data::BundleID &id, const dtn::data::Length size) noexcept
 		{
 			// raise bundle removed event
 			eventBundleRemoved(id);

--- a/ibrdtn/daemon/src/storage/SQLiteBundleStorage.h
+++ b/ibrdtn/daemon/src/storage/SQLiteBundleStorage.h
@@ -101,7 +101,7 @@ namespace dtn
 			/**
 			 * @see BundleSeeker::get(BundleSelector &cb, BundleResult &result)
 			 */
-			virtual void get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException);
+			virtual void get(const BundleSelector &cb, BundleResult &result) noexcept (false);
 
 			/**
 			 * @see BundleSeeker::getDistinctDestinations()
@@ -139,13 +139,13 @@ namespace dtn
 			 * This method is used to receive events.
 			 * @param evt
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
-			void raiseEvent(const dtn::core::GlobalEvent &evt) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
+			void raiseEvent(const dtn::core::GlobalEvent &evt) noexcept;
 
 			/**
 			 * callbacks for the sqlite database
 			 */
-			void eventBundleExpired(const dtn::data::BundleID &id, const dtn::data::Length size) throw ();
+			void eventBundleExpired(const dtn::data::BundleID &id, const dtn::data::Length size) noexcept;
 			void iterateDatabase(const dtn::data::MetaBundle &bundle, const dtn::data::Length size);
 
 
@@ -166,10 +166,10 @@ namespace dtn
 
 
 		protected:
-			virtual void componentRun() throw ();
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
-			void __cancellation() throw ();
+			virtual void componentRun() noexcept;
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
+			void __cancellation() noexcept;
 
 		private:
 //			enum Position

--- a/ibrdtn/daemon/src/storage/SQLiteDatabase.cpp
+++ b/ibrdtn/daemon/src/storage/SQLiteDatabase.cpp
@@ -153,7 +153,7 @@ namespace dtn
 			return _st;
 		}
 
-		void SQLiteDatabase::Statement::reset() throw ()
+		void SQLiteDatabase::Statement::reset() noexcept
 		{
 			if (_st != NULL) {
 				sqlite3_reset(_st);
@@ -161,7 +161,7 @@ namespace dtn
 			}
 		}
 
-		int SQLiteDatabase::Statement::step() throw (SQLiteDatabase::SQLiteQueryException)
+		int SQLiteDatabase::Statement::step() noexcept (false)
 		{
 			if (_st == NULL)
 				throw SQLiteQueryException("statement not prepared");
@@ -188,7 +188,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::Statement::prepare() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::Statement::prepare() noexcept (false)
 		{
 			if (_st != NULL)
 				throw SQLiteQueryException("already prepared");
@@ -210,7 +210,7 @@ namespace dtn
 		{
 		}
 
-		int SQLiteDatabase::getVersion() throw (SQLiteDatabase::SQLiteQueryException)
+		int SQLiteDatabase::getVersion() noexcept (false)
 		{
 			// Check version of SQLiteDB
 			int version = 0;
@@ -232,7 +232,7 @@ namespace dtn
 			return version;
 		}
 
-		void SQLiteDatabase::setVersion(int version) throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::setVersion(int version) noexcept (false)
 		{
 			std::stringstream ss; ss << version;
 			Statement st(_database, SET_SCHEMAVERSION);
@@ -247,7 +247,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::doUpgrade(int oldVersion, int newVersion) throw (ibrcommon::Exception)
+		void SQLiteDatabase::doUpgrade(int oldVersion, int newVersion) noexcept (false)
 		{
 			if (oldVersion > newVersion)
 			{
@@ -302,7 +302,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::open() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::open() noexcept (false)
 		{
 			//Configure SQLite Library
 			SQLiteConfigure::configure();
@@ -361,7 +361,7 @@ namespace dtn
 			SQLiteConfigure::shutdown();
 		}
 
-		void SQLiteDatabase::get(const dtn::data::BundleID &id, dtn::data::MetaBundle &meta) const throw (SQLiteDatabase::SQLiteQueryException, NoBundleFoundException)
+		void SQLiteDatabase::get(const dtn::data::BundleID &id, dtn::data::MetaBundle &meta) const noexcept (false)
 		{
 			// lock the prepared statement
 			Statement st(_database, _sql_queries[BUNDLE_GET_ID]);
@@ -382,7 +382,7 @@ namespace dtn
 			get(st, meta);
 		}
 
-		void SQLiteDatabase::get(Statement &st, dtn::data::MetaBundle &bundle, int offset) const throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::get(Statement &st, dtn::data::MetaBundle &bundle, int offset) const noexcept (false)
 		{
 			try {
 				bundle.source = dtn::data::EID( (const char*) sqlite3_column_text(*st, offset) );
@@ -429,7 +429,7 @@ namespace dtn
 			bundle.setPayloadLength(sqlite3_column_int64(*st, offset + 13));
 		}
 
-		void SQLiteDatabase::get(Statement &st, dtn::data::Bundle &bundle, const int offset) const throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::get(Statement &st, dtn::data::Bundle &bundle, const int offset) const noexcept (false)
 		{
 			try {
 				bundle.source = dtn::data::EID( (const char*) sqlite3_column_text(*st, offset + 0) );
@@ -454,7 +454,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::iterateAll() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::iterateAll() noexcept (false)
 		{
 			Statement st(_database, _sql_queries[BUNDLE_GET_ITERATOR]);
 			// abort if enough bundles are found
@@ -472,7 +472,7 @@ namespace dtn
 			st.reset();
 		}
 
-		void SQLiteDatabase::get(const BundleSelector &cb, BundleResult &ret) throw (NoBundleFoundException, BundleSelectorException)
+		void SQLiteDatabase::get(const BundleSelector &cb, BundleResult &ret) noexcept (false)
 		{
 			size_t items_added = 0;
 
@@ -523,7 +523,7 @@ namespace dtn
 			if (items_added == 0) throw dtn::storage::NoBundleFoundException();
 		}
 
-		void SQLiteDatabase::__get(const BundleSelector &cb, Statement &st, BundleResult &ret, size_t &items_added, const int bind_offset, const size_t offset, const size_t query_limit) const throw (SQLiteDatabase::SQLiteQueryException, NoBundleFoundException, BundleSelectorException)
+		void SQLiteDatabase::__get(const BundleSelector &cb, Statement &st, BundleResult &ret, size_t &items_added, const int bind_offset, const size_t offset, const size_t query_limit) const noexcept (false)
 		{
 			const bool unlimited = (cb.limit() <= 0);
 
@@ -562,7 +562,7 @@ namespace dtn
 			st.reset();
 		}
 
-		void SQLiteDatabase::get(const dtn::data::BundleID &id, dtn::data::Bundle &bundle, blocklist &blocks) const throw (SQLiteDatabase::SQLiteQueryException, NoBundleFoundException)
+		void SQLiteDatabase::get(const dtn::data::BundleID &id, dtn::data::Bundle &bundle, blocklist &blocks) const noexcept (false)
 		{
 			int err = 0;
 
@@ -623,7 +623,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::store(const dtn::data::Bundle &bundle, const dtn::data::Length &size) throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::store(const dtn::data::Bundle &bundle, const dtn::data::Length &size) noexcept (false)
 		{
 			int err;
 
@@ -694,7 +694,7 @@ namespace dtn
 			new_expire_time(expire_time);
 		}
 
-		void SQLiteDatabase::store(const dtn::data::BundleID &id, int index, const dtn::data::Block &block, const ibrcommon::File &file) throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::store(const dtn::data::BundleID &id, int index, const dtn::data::Block &block, const ibrcommon::File &file) noexcept (false)
 		{
 			int blocktyp = (int)block.getType();
 
@@ -720,7 +720,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::transaction() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::transaction() noexcept (false)
 		{
 			char *zErrMsg = 0;
 
@@ -735,7 +735,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::rollback() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::rollback() noexcept (false)
 		{
 			char *zErrMsg = 0;
 
@@ -750,7 +750,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::commit() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::commit() noexcept (false)
 		{
 			char *zErrMsg = 0;
 
@@ -765,7 +765,7 @@ namespace dtn
 			}
 		}
 
-		dtn::data::Length SQLiteDatabase::remove(const dtn::data::BundleID &id) throw (SQLiteDatabase::SQLiteQueryException)
+		dtn::data::Length SQLiteDatabase::remove(const dtn::data::BundleID &id) noexcept (false)
 		{
 			// return value (size of the bundle in bytes)
 			dtn::data::Length ret = 0;
@@ -823,7 +823,7 @@ namespace dtn
 			return ret;
 		}
 
-		void SQLiteDatabase::clear() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::clear() noexcept (false)
 		{
 			Statement vacuum(_database, _sql_queries[VACUUM]);
 			Statement bundle_clear(_database, _sql_queries[BUNDLE_CLEAR]);
@@ -840,7 +840,7 @@ namespace dtn
 			reset_expire_time();
 		}
 
-		bool SQLiteDatabase::contains(const dtn::data::BundleID &id) throw (SQLiteDatabase::SQLiteQueryException)
+		bool SQLiteDatabase::contains(const dtn::data::BundleID &id) noexcept (false)
 		{
 			// lock the prepared statement
 			Statement st(_database, _sql_queries[BUNDLE_GET_ID]);
@@ -852,7 +852,7 @@ namespace dtn
 			return !((st.step() != SQLITE_ROW) || _faulty);
 		}
 
-		bool SQLiteDatabase::empty() const throw (SQLiteDatabase::SQLiteQueryException)
+		bool SQLiteDatabase::empty() const noexcept (false)
 		{
 			Statement st(_database, _sql_queries[EMPTY_CHECK]);
 
@@ -866,7 +866,7 @@ namespace dtn
 			}
 		}
 
-		size_t SQLiteDatabase::count() const throw (SQLiteDatabase::SQLiteQueryException)
+		size_t SQLiteDatabase::count() const noexcept (false)
 		{
 			size_t rows = 0;
 			int err = 0;
@@ -887,7 +887,7 @@ namespace dtn
 			return rows;
 		}
 
-		const std::set<dtn::data::EID> SQLiteDatabase::getDistinctDestinations() throw (SQLiteDatabase::SQLiteQueryException)
+		const std::set<dtn::data::EID> SQLiteDatabase::getDistinctDestinations() noexcept (false)
 		{
 			std::set<dtn::data::EID> ret;
 
@@ -904,7 +904,7 @@ namespace dtn
 			return ret;
 		}
 
-		void SQLiteDatabase::update_expire_time() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::update_expire_time() noexcept (false)
 		{
 			Statement st(_database, _sql_queries[EXPIRE_NEXT_TIMESTAMP]);
 
@@ -920,7 +920,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::expire(const dtn::data::Timestamp &timestamp) throw ()
+		void SQLiteDatabase::expire(const dtn::data::Timestamp &timestamp) noexcept
 		{
 			/*
 			 * Only if the actual time is bigger or equal than the time when the next bundle expires, deleteexpired is called.
@@ -998,13 +998,13 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::vacuum() throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::vacuum() noexcept (false)
 		{
 			Statement st(_database, _sql_queries[VACUUM]);
 			st.step();
 		}
 
-		void SQLiteDatabase::update(UPDATE_VALUES mode, const dtn::data::BundleID &id, const dtn::data::EID &eid) throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::update(UPDATE_VALUES mode, const dtn::data::BundleID &id, const dtn::data::EID &eid) noexcept (false)
 		{
 			if (mode == UPDATE_CUSTODIAN)
 			{
@@ -1026,7 +1026,7 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::new_expire_time(const dtn::data::Timestamp &ttl) throw ()
+		void SQLiteDatabase::new_expire_time(const dtn::data::Timestamp &ttl) noexcept
 		{
 			if (_next_expiration == 0 || ttl < _next_expiration)
 			{
@@ -1034,17 +1034,17 @@ namespace dtn
 			}
 		}
 
-		void SQLiteDatabase::reset_expire_time() throw ()
+		void SQLiteDatabase::reset_expire_time() noexcept
 		{
 			_next_expiration = 0;
 		}
 
-		const dtn::data::Timestamp& SQLiteDatabase::get_expire_time() const throw ()
+		const dtn::data::Timestamp& SQLiteDatabase::get_expire_time() const noexcept
 		{
 			return _next_expiration;
 		}
 
-		void SQLiteDatabase::set_bundleid(Statement &st, const dtn::data::BundleID &id, int offset) const throw (SQLiteDatabase::SQLiteQueryException)
+		void SQLiteDatabase::set_bundleid(Statement &st, const dtn::data::BundleID &id, int offset) const noexcept (false)
 		{
 			sqlite3_bind_text(*st, offset + 1, id.source.getString().c_str(), static_cast<int>(id.source.getString().length()), SQLITE_TRANSIENT);
 			sqlite3_bind_int64(*st, offset + 2, id.timestamp.get<uint64_t>());

--- a/ibrdtn/daemon/src/storage/SQLiteDatabase.h
+++ b/ibrdtn/daemon/src/storage/SQLiteDatabase.h
@@ -131,7 +131,7 @@ namespace dtn
 			{
 			public:
 				virtual ~DatabaseListener() = 0;
-				virtual void eventBundleExpired(const dtn::data::BundleID&, const dtn::data::Length) throw () = 0;
+				virtual void eventBundleExpired(const dtn::data::BundleID&, const dtn::data::Length) noexcept = 0;
 				virtual void iterateDatabase(const dtn::data::MetaBundle&, const dtn::data::Length) = 0;
 			};
 
@@ -145,7 +145,7 @@ namespace dtn
 				 * returns the user-defined sql query
 				 * @return
 				 */
-				virtual const std::string getWhere() const throw () = 0;
+				virtual const std::string getWhere() const noexcept = 0;
 
 				/**
 				 * bind all custom values to the statement
@@ -153,7 +153,7 @@ namespace dtn
 				 * @param offset
 				 * @return
 				 */
-				virtual int bind(sqlite3_stmt*, int offset) const throw ()
+				virtual int bind(sqlite3_stmt*, int offset) const noexcept
 				{
 					return offset;
 				}
@@ -162,7 +162,7 @@ namespace dtn
 			class SQLiteQueryException : public ibrcommon::Exception
 			{
 			public:
-				SQLiteQueryException(string what = "Unable to execute Querry.") throw() : Exception(what)
+				SQLiteQueryException(string what = "Unable to execute Querry.") noexcept : Exception(what)
 				{
 				}
 			};
@@ -174,9 +174,9 @@ namespace dtn
 				~Statement();
 
 				sqlite3_stmt* operator*();
-				void prepare() throw (SQLiteQueryException);
-				void reset() throw ();
-				int step() throw (SQLiteQueryException);
+				void prepare() noexcept (false);
+				void reset() noexcept;
+				int step() noexcept (false);
 
 			private:
 				sqlite3 *_database;
@@ -193,7 +193,7 @@ namespace dtn
 			/**
 			 * open the database
 			 */
-			void open() throw (SQLiteQueryException);
+			void open() noexcept (false);
 
 			/**
 			 * close the database
@@ -205,76 +205,76 @@ namespace dtn
 			 * Expire all bundles with a lifetime lower than the given timestamp.
 			 * @param timestamp
 			 */
-			void expire(const dtn::data::Timestamp &timestamp) throw ();
+			void expire(const dtn::data::Timestamp &timestamp) noexcept;
 
 			/**
 			 * Shrink down the database.
 			 */
-			void vacuum() throw (SQLiteQueryException);
+			void vacuum() noexcept (false);
 
 			/**
 			 * Update
 			 * @param id
 			 * @param
 			 */
-			void update(UPDATE_VALUES, const dtn::data::BundleID &id, const dtn::data::EID&) throw (SQLiteQueryException);
+			void update(UPDATE_VALUES, const dtn::data::BundleID &id, const dtn::data::EID&) noexcept (false);
 
 			/**
 			 * Delete an entry in the database.
 			 * @param id
 			 * @return The number of released bytes
 			 */
-			dtn::data::Length remove(const dtn::data::BundleID &id) throw (SQLiteQueryException);
+			dtn::data::Length remove(const dtn::data::BundleID &id) noexcept (false);
 
 			/**
 			 * @see BundleSeeker::get(BundleSelector &cb, BundleResult &result)
 			 */
-			virtual void get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException);
+			virtual void get(const BundleSelector &cb, BundleResult &result) noexcept (false);
 
 			/**
 			 * Retrieve the meta data of a given bundle
 			 * @param id
 			 * @return
 			 */
-			void get(const dtn::data::BundleID &id, dtn::data::MetaBundle &meta) const throw (SQLiteQueryException, NoBundleFoundException);
+			void get(const dtn::data::BundleID &id, dtn::data::MetaBundle &meta) const noexcept (false);
 
 			/**
 			 * Retrieve the data of a given bundle
 			 * @param id
 			 * @return
 			 */
-			void get(const dtn::data::BundleID &id, dtn::data::Bundle &bundle, blocklist &blocks) const throw (SQLiteQueryException, NoBundleFoundException);
+			void get(const dtn::data::BundleID &id, dtn::data::Bundle &bundle, blocklist &blocks) const noexcept (false);
 
 			/**
 			 *
 			 * @param bundle
 			 */
-			void store(const dtn::data::Bundle &bundle, const dtn::data::Length &size) throw (SQLiteQueryException);
-			void store(const dtn::data::BundleID &id, int index, const dtn::data::Block &block, const ibrcommon::File &file) throw (SQLiteQueryException);
-			void transaction() throw (SQLiteQueryException);
-			void rollback() throw (SQLiteQueryException);
-			void commit() throw (SQLiteQueryException);
+			void store(const dtn::data::Bundle &bundle, const dtn::data::Length &size) noexcept (false);
+			void store(const dtn::data::BundleID &id, int index, const dtn::data::Block &block, const ibrcommon::File &file) noexcept (false);
+			void transaction() noexcept (false);
+			void rollback() noexcept (false);
+			void commit() noexcept (false);
 
-			bool empty() const throw (SQLiteQueryException);
+			bool empty() const noexcept (false);
 
-			dtn::data::Size count() const throw (SQLiteQueryException);
+			dtn::data::Size count() const noexcept (false);
 
-			void clear() throw (SQLiteQueryException);
+			void clear() noexcept (false);
 
 			/**
 			 * Returns true, if the bundle ID is stored in the database
 			 */
-			bool contains(const dtn::data::BundleID &id) throw (SQLiteDatabase::SQLiteQueryException);
+			bool contains(const dtn::data::BundleID &id) noexcept (false);
 
 			/**
 			 * @see BundleSeeker::getDistinctDestinations()
 			 */
-			virtual const eid_set getDistinctDestinations() throw (SQLiteQueryException);
+			virtual const eid_set getDistinctDestinations() noexcept (false);
 
 			/**
 			 * iterate through all the bundles and call the iterateDatabase() on each bundle
 			 */
-			void iterateAll() throw (SQLiteQueryException);
+			void iterateAll() noexcept (false);
 
 			/*** BEGIN: methods for unit-testing ***/
 
@@ -293,7 +293,7 @@ namespace dtn
 			 * @param bundle
 			 * @param offset
 			 */
-			void get(Statement &st, dtn::data::MetaBundle &bundle, int offset = 0) const throw (SQLiteQueryException);
+			void get(Statement &st, dtn::data::MetaBundle &bundle, int offset = 0) const noexcept (false);
 
 			/**
 			 * Retrieve meta data from the database and put them into a bundle structure.
@@ -301,7 +301,7 @@ namespace dtn
 			 * @param bundle
 			 * @param offset
 			 */
-			void get(Statement &st, dtn::data::Bundle &bundle, const int offset = 0) const throw (SQLiteQueryException);
+			void get(Statement &st, dtn::data::Bundle &bundle, const int offset = 0) const noexcept (false);
 
 			/**
 			 *
@@ -310,40 +310,40 @@ namespace dtn
 			 * @param bind_offset
 			 * @param limit
 			 */
-			void __get(const BundleSelector &cb, Statement &st, BundleResult &ret, size_t &items_added, const int bind_offset, const size_t offset, const size_t query_limit) const throw (SQLiteQueryException, NoBundleFoundException, BundleSelectorException);
+			void __get(const BundleSelector &cb, Statement &st, BundleResult &ret, size_t &items_added, const int bind_offset, const size_t offset, const size_t query_limit) const noexcept (false);
 
 			/**
 			 * updates the nextExpiredTime. The calling function has to have the databaselock.
 			 */
-			void update_expire_time() throw (SQLiteQueryException);
+			void update_expire_time() noexcept (false);
 
 			/**
 			 * lower the next expire time if the ttl is lower than the current expire time
 			 * @param ttl
 			 */
-			void new_expire_time(const dtn::data::Timestamp &ttl) throw ();
-			void reset_expire_time() throw ();
-			const dtn::data::Timestamp& get_expire_time() const throw ();
+			void new_expire_time(const dtn::data::Timestamp &ttl) noexcept;
+			void reset_expire_time() noexcept;
+			const dtn::data::Timestamp& get_expire_time() const noexcept;
 
-			void set_bundleid(Statement &st, const dtn::data::BundleID &id, int offset = 0) const throw (SQLiteQueryException);
+			void set_bundleid(Statement &st, const dtn::data::BundleID &id, int offset = 0) const noexcept (false);
 
 			/**
 			 * get database version
 			 */
-			int getVersion() throw (SQLiteQueryException);
+			int getVersion() noexcept (false);
 
 			/**
 			 * set database version
 			 * @param version
 			 */
-			void setVersion(int version) throw (SQLiteQueryException);
+			void setVersion(int version) noexcept (false);
 
 			/**
 			 * upgrade the database to new version
 			 * @param oldVersion Current version of the database.
 			 * @param newVersion Required version.
 			 */
-			void doUpgrade(int oldVersion, int newVersion) throw (ibrcommon::Exception);
+			void doUpgrade(int oldVersion, int newVersion) noexcept (false);
 
 			ibrcommon::File _file;
 

--- a/ibrdtn/daemon/src/storage/SimpleBundleStorage.cpp
+++ b/ibrdtn/daemon/src/storage/SimpleBundleStorage.cpp
@@ -166,9 +166,9 @@ namespace dtn
 			}
 		}
 
-		void SimpleBundleStorage::componentUp() throw ()
+		void SimpleBundleStorage::componentUp() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 
 			// load persistent bundles
 			_datastore.iterateAll();
@@ -188,9 +188,9 @@ namespace dtn
 			}
 		}
 
-		void SimpleBundleStorage::componentDown() throw ()
+		void SimpleBundleStorage::componentDown() noexcept
 		{
-			// routine checked for throw() on 15.02.2013
+			// routine checked for noexcept on 15.02.2013
 
 			dtn::core::EventDispatcher<dtn::core::TimeEvent>::remove(this);
 			try {
@@ -210,7 +210,7 @@ namespace dtn
 			}
 		}
 
-		void SimpleBundleStorage::raiseEvent(const dtn::core::TimeEvent &time) throw ()
+		void SimpleBundleStorage::raiseEvent(const dtn::core::TimeEvent &time) noexcept
 		{
 			if (time.getAction() == dtn::core::TIME_SECOND_TICK)
 			{
@@ -253,7 +253,7 @@ namespace dtn
 			_datastore.setFaulty(mode);
 		}
 
-		void SimpleBundleStorage::get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException)
+		void SimpleBundleStorage::get(const BundleSelector &cb, BundleResult &result) noexcept (false)
 		{
 			size_t items_added = 0;
 
@@ -465,7 +465,7 @@ namespace dtn
 			}
 		}
 
-		void SimpleBundleStorage::eventBundleExpired(const dtn::data::MetaBundle &b) throw ()
+		void SimpleBundleStorage::eventBundleExpired(const dtn::data::MetaBundle &b) noexcept
 		{
 			DataStorage::Hash hash(BundleContainer::createId(b));
 

--- a/ibrdtn/daemon/src/storage/SimpleBundleStorage.h
+++ b/ibrdtn/daemon/src/storage/SimpleBundleStorage.h
@@ -94,7 +94,7 @@ namespace dtn
 			/**
 			 * @see BundleSeeker::get(BundleSelector &cb, BundleResult &result)
 			 */
-			virtual void get(const BundleSelector &cb, BundleResult &result) throw (NoBundleFoundException, BundleSelectorException);
+			virtual void get(const BundleSelector &cb, BundleResult &result) noexcept (false);
 
 			/**
 			 * @see BundleSeeker::getDistinctDestinations()
@@ -132,7 +132,7 @@ namespace dtn
 			 * This method is used to receive events.
 			 * @param evt
 			 */
-			void raiseEvent(const dtn::core::TimeEvent &evt) throw ();
+			void raiseEvent(const dtn::core::TimeEvent &evt) noexcept;
 
 			/**
 			 * @see Component::getName()
@@ -161,9 +161,9 @@ namespace dtn
 			/*** END: methods for unit-testing ***/
 
 		protected:
-			virtual void componentUp() throw ();
-			virtual void componentDown() throw ();
-			virtual void eventBundleExpired(const dtn::data::MetaBundle &b) throw ();
+			virtual void componentUp() noexcept;
+			virtual void componentDown() noexcept;
+			virtual void eventBundleExpired(const dtn::data::MetaBundle &b) noexcept;
 
 		private:
 			class BundleContainer : public DataStorage::Container

--- a/ibrdtn/daemon/tests/tools/EventSwitchLoop.h
+++ b/ibrdtn/daemon/tests/tools/EventSwitchLoop.h
@@ -46,13 +46,13 @@ namespace ibrtest
 		};
 
 	protected:
-		virtual void run() throw ()
+		virtual void run() noexcept
 		{
 			dtn::core::EventSwitch &es = dtn::core::EventSwitch::getInstance();
 			es.loop(0);
 		}
 
-		virtual void __cancellation() throw ()
+		virtual void __cancellation() noexcept
 		{
 			dtn::core::EventSwitch &es = dtn::core::EventSwitch::getInstance();
 			es.shutdown();

--- a/ibrdtn/daemon/tests/tools/TestEventListener.h
+++ b/ibrdtn/daemon/tests/tools/TestEventListener.h
@@ -37,7 +37,7 @@ public:
 		dtn::core::EventDispatcher<EVENT>::remove(this);
 	}
 
-	void raiseEvent(const EVENT&) throw () {
+	void raiseEvent(const EVENT&) noexcept {
 		ibrcommon::MutexLock l(event_cond);
 		event_counter++;
 		event_cond.signal(true);

--- a/ibrdtn/daemon/tests/unittests/BaseRouterTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/BaseRouterTest.cpp
@@ -57,8 +57,8 @@ void BaseRouterTest::testGetRouter()
 		ExtensionTest() {};
 		~ExtensionTest() {};
 
-		void componentUp() throw () {};
-		void componentDown() throw () {};
+		void componentUp() noexcept {};
+		void componentDown() noexcept {};
 
 
 		dtn::routing::BaseRouter& testGetRouter()
@@ -83,8 +83,8 @@ void BaseRouterTest::testAddExtension()
 		ExtensionTest() {};
 		~ExtensionTest() {};
 
-		void componentUp() throw () {};
-		void componentDown() throw () {};
+		void componentUp() noexcept {};
+		void componentDown() noexcept {};
 
 		dtn::routing::BaseRouter& testGetRouter()
 		{
@@ -106,8 +106,8 @@ void BaseRouterTest::testTransferTo()
 		ExtensionTest() {};
 		~ExtensionTest() {};
 
-		void componentUp() throw () {};
-		void componentDown() throw () {};
+		void componentUp() noexcept {};
+		void componentDown() noexcept {};
 
 		void testTransfer(const dtn::data::EID &destination, const dtn::data::MetaBundle &meta)
 		{

--- a/ibrdtn/daemon/tests/unittests/BundleSetTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/BundleSetTest.cpp
@@ -338,7 +338,7 @@ BundleSetTest::ExpiredBundleCounter::~ExpiredBundleCounter()
 {
 }
 
-void BundleSetTest::ExpiredBundleCounter::eventBundleExpired(const dtn::data::MetaBundle&) throw ()
+void BundleSetTest::ExpiredBundleCounter::eventBundleExpired(const dtn::data::MetaBundle&) noexcept
 {
 	counter++;
 }

--- a/ibrdtn/daemon/tests/unittests/BundleSetTest.hh
+++ b/ibrdtn/daemon/tests/unittests/BundleSetTest.hh
@@ -45,7 +45,7 @@ class BundleSetTest : public CppUnit::TestFixture {
 			ExpiredBundleCounter();
 			virtual ~ExpiredBundleCounter();
 
-			void eventBundleExpired(const dtn::data::MetaBundle &b) throw ();
+			void eventBundleExpired(const dtn::data::MetaBundle &b) noexcept;
 			int counter;
 		};
 		void genbundles(dtn::data::BundleSet &l, int number, int offset, int max);

--- a/ibrdtn/daemon/tests/unittests/BundleStorageTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/BundleStorageTest.cpp
@@ -484,12 +484,12 @@ void BundleStorageTest::testConcurrentStoreGet(dtn::storage::BundleStorage &stor
 			join();
 		};
 
-		void __cancellation() throw ()
+		void __cancellation() noexcept
 		{
 		}
 
 	protected:
-		void run() throw ()
+		void run() noexcept
 		{
 			for (std::list<dtn::data::Bundle>::const_iterator iter = _list.begin(); iter != _list.end(); ++iter)
 			{
@@ -704,9 +704,9 @@ void BundleStorageTest::testSelector(dtn::storage::BundleStorage &storage)
 
 		virtual ~BundleFilter() {};
 
-		virtual dtn::data::Size limit() const throw () { return 5; };
+		virtual dtn::data::Size limit() const noexcept { return 5; };
 
-		virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+		virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const noexcept (false)
 		{
 			// select every second bundle
 			return (meta.destination == dtn::data::EID("dtn://node-two/6"));
@@ -992,9 +992,9 @@ void BundleStorageTest::testQueryBloomFilter(dtn::storage::BundleStorage &storag
 
 		virtual ~BundleFilter() {};
 
-		virtual dtn::data::Size limit() const throw () { return 1; };
+		virtual dtn::data::Size limit() const noexcept { return 1; };
 
-		virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const throw (dtn::storage::BundleSelectorException)
+		virtual bool shouldAdd(const dtn::data::MetaBundle &meta) const noexcept (false)
 		{
 			// select the bundle if it is in the filter
 			return meta.isIn(_filter);

--- a/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
+++ b/ibrdtn/daemon/tests/unittests/FakeDatagramService.cpp
@@ -72,7 +72,7 @@ void FakeDatagramService::genAck(const unsigned int seqno, const std::string &ad
 	_recv_queue.push(msg);
 }
 
-void FakeDatagramService::bind() throw (dtn::net::DatagramException) {
+void FakeDatagramService::bind() noexcept (false) {
 	_recv_queue.reset();
 }
 
@@ -80,7 +80,7 @@ void FakeDatagramService::shutdown() {
 	_recv_queue.abort();
 }
 
-void FakeDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) throw (dtn::net::DatagramException) {
+void FakeDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) noexcept (false) {
 	if (type == dtn::net::DatagramConvergenceLayer::HEADER_SEGMENT) {
 		// wait 50ms and queue an ack
 		ibrcommon::Thread::sleep(50);
@@ -89,11 +89,11 @@ void FakeDatagramService::send(const char &type, const char &flags, const unsign
 	}
 }
 
-void FakeDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (dtn::net::DatagramException) {
+void FakeDatagramService::send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false) {
 	// no ack here!
 }
 
-size_t FakeDatagramService::recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (dtn::net::DatagramException) {
+size_t FakeDatagramService::recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false) {
 	size_t ret = 0;
 
 	msg_queue::Locked lq = _recv_queue.exclusive();

--- a/ibrdtn/daemon/tests/unittests/FakeDatagramService.h
+++ b/ibrdtn/daemon/tests/unittests/FakeDatagramService.h
@@ -41,15 +41,15 @@ public:
 	FakeDatagramService();
 	virtual ~FakeDatagramService();
 
-	void bind() throw (dtn::net::DatagramException);
+	void bind() noexcept (false);
 
 	void shutdown();
 
-	void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) throw (dtn::net::DatagramException);
+	void send(const char &type, const char &flags, const unsigned int &seqno, const std::string &address, const char *buf, size_t length) noexcept (false);
 
-	void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) throw (dtn::net::DatagramException);
+	void send(const char &type, const char &flags, const unsigned int &seqno, const char *buf, size_t length) noexcept (false);
 
-	size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) throw (dtn::net::DatagramException);
+	size_t recvfrom(char *buf, size_t length, char &type, char &flags, unsigned int &seqno, std::string &address) noexcept (false);
 
 	const std::string getServiceDescription() const;
 

--- a/ibrdtn/daemon/tests/unittests/NativeSerializerTest.cpp
+++ b/ibrdtn/daemon/tests/unittests/NativeSerializerTest.cpp
@@ -29,23 +29,23 @@ void NativeSerializerTest::callbackStreamTest() {
 		virtual ~Callback() {
 		}
 
-		virtual void beginBundle(const dtn::data::PrimaryBlock &block) throw () {
+		virtual void beginBundle(const dtn::data::PrimaryBlock &block) noexcept {
 			bundle_count++;
 		}
 
-		virtual void endBundle() throw () {
+		virtual void endBundle() noexcept {
 			bundle_count++;
 		}
 
-		virtual void beginBlock(const dtn::data::Block &block, const size_t payload_length) throw () {
+		virtual void beginBlock(const dtn::data::Block &block, const size_t payload_length) noexcept {
 			block_count++;
 		}
 
-		virtual void endBlock() throw () {
+		virtual void endBlock() noexcept {
 			block_count++;
 		}
 
-		virtual void payload(const char *data, const size_t len) throw () {
+		virtual void payload(const char *data, const size_t len) noexcept {
 			payload_count += len;
 		}
 	} _callback;
@@ -73,23 +73,23 @@ void NativeSerializerTest::serializeBundle() {
 		virtual ~Callback() {
 		}
 
-		virtual void beginBundle(const dtn::data::PrimaryBlock &block) throw () {
+		virtual void beginBundle(const dtn::data::PrimaryBlock &block) noexcept {
 			bundle_count++;
 		}
 
-		virtual void endBundle() throw () {
+		virtual void endBundle() noexcept {
 			bundle_count++;
 		}
 
-		virtual void beginBlock(const dtn::data::Block &block, const size_t payload_length) throw () {
+		virtual void beginBlock(const dtn::data::Block &block, const size_t payload_length) noexcept {
 			block_count++;
 		}
 
-		virtual void endBlock() throw () {
+		virtual void endBlock() noexcept {
 			block_count++;
 		}
 
-		virtual void payload(const char *data, const size_t len) throw () {
+		virtual void payload(const char *data, const size_t len) noexcept {
 			payload_count += len;
 		}
 	} _callback;

--- a/ibrdtn/ibrdtn/ibrdtn/api/Client.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/api/Client.cpp
@@ -44,12 +44,12 @@ namespace dtn
 		{
 		}
 
-		void Client::AsyncReceiver::__cancellation() throw ()
+		void Client::AsyncReceiver::__cancellation() noexcept
 		{
 			_running = false;
 		}
 
-		void Client::AsyncReceiver::run() throw ()
+		void Client::AsyncReceiver::run() noexcept
 		{
 			try {
 				while (!_client.eof() && _running)
@@ -167,7 +167,7 @@ namespace dtn
 			shutdown(StreamConnection::CONNECTION_SHUTDOWN_ERROR);
 		}
 
-		void Client::eventConnectionDown() throw ()
+		void Client::eventConnectionDown() noexcept
 		{
 			_inqueue.abort();
 
@@ -178,7 +178,7 @@ namespace dtn
 			}
 		}
 
-		void Client::eventBundleAck(const dtn::data::Length &ack) throw ()
+		void Client::eventBundleAck(const dtn::data::Length &ack) noexcept
 		{
 			lastack = ack;
 		}
@@ -206,7 +206,7 @@ namespace dtn
 			flush();
 		}
 
-		dtn::data::Bundle Client::getBundle(const dtn::data::Timeout timeout) throw (ConnectionException)
+		dtn::data::Bundle Client::getBundle(const dtn::data::Timeout timeout) noexcept (false)
 		{
 			try {
 				return _inqueue.poll(timeout * 1000);

--- a/ibrdtn/ibrdtn/ibrdtn/api/Client.h
+++ b/ibrdtn/ibrdtn/ibrdtn/api/Client.h
@@ -41,7 +41,7 @@ namespace dtn
 		class ConnectionException : public ibrcommon::Exception
 		{
 		public:
-			ConnectionException(string what = "A connection error occurred.") throw() : ibrcommon::Exception(what)
+			ConnectionException(string what = "A connection error occurred.") noexcept : ibrcommon::Exception(what)
 			{
 			};
 		};
@@ -52,7 +52,7 @@ namespace dtn
 		class ConnectionTimeoutException : public ConnectionException
 		{
 		public:
-			ConnectionTimeoutException(string what = "Timeout.") throw() : ConnectionException(what)
+			ConnectionTimeoutException(string what = "Timeout.") noexcept : ConnectionException(what)
 			{
 			};
 		};
@@ -63,7 +63,7 @@ namespace dtn
 		class ConnectionAbortedException : public ConnectionException
 		{
 		public:
-			ConnectionAbortedException(string what = "Aborted.") throw() : ConnectionException(what)
+			ConnectionAbortedException(string what = "Aborted.") noexcept : ConnectionException(what)
 			{
 			};
 		};
@@ -109,13 +109,13 @@ namespace dtn
 				 * It aborts if the stream of the client went bad or an error occurred during
 				 * the deserialization.
 				 */
-				void run() throw ();
+				void run() noexcept;
 
 				/**
 				 * Aborts the receiver thread
 				 * @return
 				 */
-				void __cancellation() throw ();
+				void __cancellation() noexcept;
 
 			private:
 				// member variable for the reference to the client object
@@ -174,51 +174,51 @@ namespace dtn
 			 * aborts the blocking getBundle() method. If a client is working synchonous
 			 * this method should not be overloaded!
 			 */
-			virtual void eventConnectionDown() throw ();
+			virtual void eventConnectionDown() noexcept;
 
 			/**
 			 * The bundle ack event is called by the StreamConnection object and stores
 			 * the last ACK'd bundle size in the lastack variable.
 			 * @param ack ACK'd bundle size
 			 */
-			virtual void eventBundleAck(const dtn::data::Length &ack) throw ();
+			virtual void eventBundleAck(const dtn::data::Length &ack) noexcept;
 
 			/**
 			 * The shutdown event callback method can overloaded to handle shutdown
 			 * events.
 			 */
-			virtual void eventShutdown(StreamConnection::ConnectionShutdownCases) throw () {};
+			virtual void eventShutdown(StreamConnection::ConnectionShutdownCases) noexcept {};
 
 			/**
 			 * The timeout event callback method can overloaded to handle timeouts
 			 * occurring in the API protocol.
 			 */
-			virtual void eventTimeout() throw () {};
+			virtual void eventTimeout() noexcept {};
 
 			/**
 			 * The error event callback method can overloaded to handle errors
 			 * occurring in the API protocol.
 			 */
-			virtual void eventError() throw () {};
+			virtual void eventError() noexcept {};
 
 			/**
 			 * The connection up event callback method can overloaded to handle
 			 * a successful connection handshake. In this call the header of the
 			 * corresponding daemon is available.
 			 */
-			virtual void eventConnectionUp(const dtn::streams::StreamContactHeader&) throw () {};
+			virtual void eventConnectionUp(const dtn::streams::StreamContactHeader&) noexcept {};
 
 			/**
 			 * The bundle refused event callback method can overloaded to handle
 			 * a bundle refused by the porresponding daemon.
 			 */
-			virtual void eventBundleRefused() throw () {};
+			virtual void eventBundleRefused() noexcept {};
 
 			/**
 			 * The bundle forwarded event callback method can overloaded to determine
 			 * when a bundle is forwarded to the daemon.
 			 */
-			virtual void eventBundleForwarded() throw () {};
+			virtual void eventBundleForwarded() noexcept {};
 
 			/**
 			 * Send a bundle to the daemon
@@ -232,7 +232,7 @@ namespace dtn
 			 * @param timeout
 			 * @return
 			 */
-			dtn::data::Bundle getBundle(const dtn::data::Timeout timeout = 0) throw (ConnectionException);
+			dtn::data::Bundle getBundle(const dtn::data::Timeout timeout = 0) noexcept (false);
 
 			// public variable
 			dtn::data::Length lastack;

--- a/ibrdtn/ibrdtn/ibrdtn/api/PlainSerializer.h
+++ b/ibrdtn/ibrdtn/ibrdtn/api/PlainSerializer.h
@@ -97,7 +97,7 @@ namespace dtn
 			class PlainDeserializerException : public ibrcommon::Exception
 			{
 				public:
-					PlainDeserializerException(string what = "") throw() : Exception(what)
+					PlainDeserializerException(string what = "") noexcept : Exception(what)
 					{
 					}
 			};
@@ -105,7 +105,7 @@ namespace dtn
 			class UnknownBlockException : public PlainDeserializerException
 			{
 				public:
-					UnknownBlockException(string what = "unknown block") throw() : PlainDeserializerException(what)
+					UnknownBlockException(string what = "unknown block") noexcept : PlainDeserializerException(what)
 					{
 					}
 			};
@@ -113,7 +113,7 @@ namespace dtn
 			class BlockNotProcessableException : public PlainDeserializerException
 			{
 				public:
-					BlockNotProcessableException(string what = "block not processable") throw() : PlainDeserializerException(what)
+					BlockNotProcessableException(string what = "block not processable") noexcept : PlainDeserializerException(what)
 					{
 					}
 			};

--- a/ibrdtn/ibrdtn/ibrdtn/data/AdministrativeBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/AdministrativeBlock.h
@@ -19,7 +19,7 @@ namespace dtn
 			class WrongRecordException : public ibrcommon::Exception
 			{
 			public:
-				WrongRecordException(string what = "This administrative block is not of the expected type.") throw() : ibrcommon::Exception(what)
+				WrongRecordException(string what = "This administrative block is not of the expected type.") noexcept : ibrcommon::Exception(what)
 				{
 				};
 			};
@@ -27,7 +27,7 @@ namespace dtn
 			AdministrativeBlock();
 			virtual ~AdministrativeBlock() = 0;
 
-			virtual void read(const dtn::data::PayloadBlock &p) throw (WrongRecordException) = 0;
+			virtual void read(const dtn::data::PayloadBlock &p) noexcept (false) = 0;
 			virtual void write(dtn::data::PayloadBlock &p) const = 0;
 		};
 	} /* namespace data */

--- a/ibrdtn/ibrdtn/ibrdtn/data/BundleBuilder.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BundleBuilder.h
@@ -23,7 +23,7 @@ namespace dtn
 			class DiscardBlockException : public dtn::SerializationFailedException
 			{
 			public:
-				DiscardBlockException(string what = "Block has been discarded.") throw() : dtn::SerializationFailedException(what)
+				DiscardBlockException(string what = "Block has been discarded.") noexcept : dtn::SerializationFailedException(what)
 				{
 				};
 			};

--- a/ibrdtn/ibrdtn/ibrdtn/data/BundleList.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BundleList.cpp
@@ -35,7 +35,7 @@ namespace dtn
 		BundleList::~BundleList()
 		{ }
 
-		void BundleList::add(const dtn::data::MetaBundle &bundle) throw ()
+		void BundleList::add(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			// insert the bundle to the public list
 			pair<iterator,bool> ret = _meta_bundles.insert(bundle);
@@ -46,7 +46,7 @@ namespace dtn
 			}
 		}
 
-		void BundleList::remove(const dtn::data::MetaBundle &bundle) throw ()
+		void BundleList::remove(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			// search for the bundle in the public list
 			const std::set<dtn::data::MetaBundle>::iterator it = _meta_bundles.find(bundle);
@@ -62,13 +62,13 @@ namespace dtn
 			}
 		}
 
-		void BundleList::clear() throw ()
+		void BundleList::clear() noexcept
 		{
 			_bundles.clear();
 			_meta_bundles.clear();
 		}
 
-		void BundleList::expire(const Timestamp &timestamp) throw ()
+		void BundleList::expire(const Timestamp &timestamp) noexcept
 		{
 			// we can not expire bundles if we have no idea of time
 			if (timestamp == 0) return;

--- a/ibrdtn/ibrdtn/ibrdtn/data/BundleList.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BundleList.h
@@ -36,17 +36,17 @@ namespace dtn
 			class Listener {
 			public:
 				virtual ~Listener() = 0;
-				virtual void eventBundleExpired(const dtn::data::MetaBundle&) throw () = 0;
+				virtual void eventBundleExpired(const dtn::data::MetaBundle&) noexcept = 0;
 			};
 
 			BundleList(BundleList::Listener *listener = NULL);
 			virtual ~BundleList();
 
-			virtual void add(const dtn::data::MetaBundle &bundle) throw ();
-			virtual void remove(const dtn::data::MetaBundle &bundle) throw ();
-			virtual void clear() throw ();
+			virtual void add(const dtn::data::MetaBundle &bundle) noexcept;
+			virtual void remove(const dtn::data::MetaBundle &bundle) noexcept;
+			virtual void clear() noexcept;
 
-			virtual void expire(const Timestamp &timestamp) throw ();
+			virtual void expire(const Timestamp &timestamp) noexcept;
 
 			typedef std::set<dtn::data::MetaBundle> meta_set;
 			typedef meta_set::iterator iterator;

--- a/ibrdtn/ibrdtn/ibrdtn/data/BundleSet.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BundleSet.cpp
@@ -92,47 +92,47 @@ namespace dtn
 			return (*this);
 		}
 
-		void BundleSet::add(const dtn::data::MetaBundle &bundle) throw ()
+		void BundleSet::add(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			_set_impl->add(bundle);
 		}
 
-		void BundleSet::clear() throw ()
+		void BundleSet::clear() noexcept
 		{
 			_set_impl->clear();
 		}
 
-		bool BundleSet::has(const dtn::data::BundleID &bundle) const throw ()
+		bool BundleSet::has(const dtn::data::BundleID &bundle) const noexcept
 		{
 			return _set_impl->has(bundle);
 		}
 
-		Size BundleSet::size() const throw ()
+		Size BundleSet::size() const noexcept
 		{
 			return _set_impl->size();
 		}
 
-		void BundleSet::expire(const Timestamp timestamp) throw ()
+		void BundleSet::expire(const Timestamp timestamp) noexcept
 		{
 			_set_impl->expire(timestamp);
 		}
 
-		const ibrcommon::BloomFilter& BundleSet::getBloomFilter() const throw ()
+		const ibrcommon::BloomFilter& BundleSet::getBloomFilter() const noexcept
 		{
 			return _set_impl->getBloomFilter();
 		}
 
-		std::set<dtn::data::MetaBundle> BundleSet::getNotIn(const ibrcommon::BloomFilter &filter) const throw ()
+		std::set<dtn::data::MetaBundle> BundleSet::getNotIn(const ibrcommon::BloomFilter &filter) const noexcept
 		{
 			return _set_impl->getNotIn(filter);
 		}
 
-		void BundleSet::sync() throw ()
+		void BundleSet::sync() noexcept
 		{
 			return _set_impl->sync();
 		}
 
-		Length BundleSet::getLength() const throw ()
+		Length BundleSet::getLength() const noexcept
 		{
 			return _set_impl->getLength();
 		}

--- a/ibrdtn/ibrdtn/ibrdtn/data/BundleSet.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BundleSet.h
@@ -79,47 +79,47 @@ namespace dtn
 			/**
 			 * Add a bundle to this bundle-set
 			 */
-			virtual void add(const dtn::data::MetaBundle &bundle) throw ();
+			virtual void add(const dtn::data::MetaBundle &bundle) noexcept;
 
 			/**
 			 * Clear all entries
 			 */
-			virtual void clear() throw ();
+			virtual void clear() noexcept;
 
 			/**
 			 * Check if a specific bundle is in this bundle-set
 			 */
-			virtual bool has(const dtn::data::BundleID &bundle) const throw ();
+			virtual bool has(const dtn::data::BundleID &bundle) const noexcept;
 
 			/**
 			 * Remove expired bundles in this bundle-set
 			 */
-			virtual void expire(const Timestamp timestamp) throw ();
+			virtual void expire(const Timestamp timestamp) noexcept;
 
 			/**
 			 * Returns the number of elements in this set
 			 */
-			virtual Size size() const throw ();
+			virtual Size size() const noexcept;
 
 			/**
 			 * Returns the data length of the serialized BundleSet
 			 */
-			Length getLength() const throw ();
+			Length getLength() const noexcept;
 
 			/**
 			 * Return the bloom-filter object of this bundle-set
 			 */
-			const ibrcommon::BloomFilter& getBloomFilter() const throw ();
+			const ibrcommon::BloomFilter& getBloomFilter() const noexcept;
 
 			/**
 			 * Return bundles not in the given bloom-filter
 			 */
-			std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const throw ();
+			std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const noexcept;
 
 			/**
 			 * Synchronize the bundle-set with the persistent set on the disk.
 			 */
-			void sync() throw ();
+			void sync() noexcept;
 
 			std::ostream& serialize(std::ostream &stream) const;
 			std::istream& deserialize(std::istream &stream);

--- a/ibrdtn/ibrdtn/ibrdtn/data/BundleSetImpl.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/BundleSetImpl.h
@@ -51,30 +51,30 @@ namespace dtn
 			 */
 			virtual void assign(const refcnt_ptr<BundleSetImpl>&) = 0;
 
-			virtual void add(const dtn::data::MetaBundle &bundle) throw () = 0;
-			virtual void clear() throw () = 0;
-			virtual bool has(const dtn::data::BundleID &bundle) const throw () = 0;
+			virtual void add(const dtn::data::MetaBundle &bundle) noexcept = 0;
+			virtual void clear() noexcept = 0;
+			virtual bool has(const dtn::data::BundleID &bundle) const noexcept = 0;
 
 			virtual void expire(const Timestamp timestamp) = 0;
 
 			/**
 			 * Returns the number of elements in this set
 			 */
-			virtual Size size() const throw() = 0;
+			virtual Size size() const noexcept = 0;
 
 			/**
 			 * Returns the data length of the serialized BundleSet
 			 */
-			virtual Length getLength() const throw () = 0;
+			virtual Length getLength() const noexcept = 0;
 
-			virtual const ibrcommon::BloomFilter& getBloomFilter() const throw() = 0;
+			virtual const ibrcommon::BloomFilter& getBloomFilter() const noexcept = 0;
 
-			virtual std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const throw () = 0;
+			virtual std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const noexcept = 0;
 
 			/**
 			 * Synchronize the bundle-set with the persistent set on the disk.
 			 */
-			virtual void sync() throw () { };
+			virtual void sync() noexcept { };
 
 			virtual std::ostream& serialize(std::ostream &stream) const = 0;
 			virtual std::istream& deserialize(std::istream &stream) = 0;

--- a/ibrdtn/ibrdtn/ibrdtn/data/CustodySignalBlock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/CustodySignalBlock.cpp
@@ -38,7 +38,7 @@ namespace dtn
 		{
 		}
 
-		void CustodySignalBlock::read(const dtn::data::PayloadBlock &p) throw (WrongRecordException)
+		void CustodySignalBlock::read(const dtn::data::PayloadBlock &p) noexcept (false)
 		{
 			ibrcommon::BLOB::Reference r = p.getBLOB();
 			ibrcommon::BLOB::iostream stream = r.iostream();

--- a/ibrdtn/ibrdtn/ibrdtn/data/CustodySignalBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/CustodySignalBlock.h
@@ -58,7 +58,7 @@ namespace dtn
 			void setMatch(const dtn::data::Bundle& other);
 			bool match(const dtn::data::Bundle& other) const;
 
-			virtual void read(const dtn::data::PayloadBlock &p) throw (WrongRecordException);
+			virtual void read(const dtn::data::PayloadBlock &p) noexcept (false);
 			virtual void write(dtn::data::PayloadBlock &p) const;
 
 			bool custody_accepted;

--- a/ibrdtn/ibrdtn/ibrdtn/data/Dictionary.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/Dictionary.cpp
@@ -62,7 +62,7 @@ namespace dtn
 		{
 		}
 
-		Number Dictionary::get(const std::string &value) const throw (EntryNotFoundException)
+		Number Dictionary::get(const std::string &value) const noexcept (false)
 		{
 			std::string bytes = _bytestream.str();
 			const char *bytebegin = bytes.c_str();

--- a/ibrdtn/ibrdtn/ibrdtn/data/Dictionary.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/Dictionary.h
@@ -43,7 +43,7 @@ namespace dtn
 			class EntryNotFoundException : public dtn::InvalidDataException
 			{
 			public:
-				EntryNotFoundException(string what = "The requested dictionary entry is not available.") throw() : dtn::InvalidDataException(what)
+				EntryNotFoundException(string what = "The requested dictionary entry is not available.") noexcept : dtn::InvalidDataException(what)
 				{
 				};
 			};
@@ -115,7 +115,7 @@ namespace dtn
 		private:
 			bool exists(const std::string&) const;
 			void add(const std::string&);
-			Number get(const std::string&) const throw (EntryNotFoundException);
+			Number get(const std::string&) const noexcept (false);
 
 			std::stringstream _bytestream;
 		};

--- a/ibrdtn/ibrdtn/ibrdtn/data/EID.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/EID.cpp
@@ -400,7 +400,7 @@ namespace dtn
 			return ss.str();
 		}
 
-		void EID::setApplication(const Number &app) throw ()
+		void EID::setApplication(const Number &app) noexcept
 		{
 			switch (_scheme_type) {
 			case SCHEME_CBHE:
@@ -417,7 +417,7 @@ namespace dtn
 			}
 		}
 
-		void EID::setApplication(const std::string &app) throw ()
+		void EID::setApplication(const std::string &app) noexcept
 		{
 			switch (_scheme_type) {
 			case SCHEME_CBHE:
@@ -435,7 +435,7 @@ namespace dtn
 			}
 		}
 
-		std::string EID::getApplication() const throw ()
+		std::string EID::getApplication() const noexcept
 		{
 			switch (_scheme_type) {
 			case SCHEME_CBHE:
@@ -452,13 +452,13 @@ namespace dtn
 			}
 		}
 
-		bool EID::isApplication(const dtn::data::Number &app) const throw ()
+		bool EID::isApplication(const dtn::data::Number &app) const noexcept
 		{
 			if (_scheme_type != SCHEME_CBHE) return false;
 			return (_cbhe_application == app);
 		}
 
-		bool EID::isApplication(const std::string &app) const throw ()
+		bool EID::isApplication(const std::string &app) const noexcept
 		{
 			switch (_scheme_type) {
 			case SCHEME_CBHE:
@@ -472,7 +472,7 @@ namespace dtn
 			}
 		}
 
-		std::string EID::getHost() const throw ()
+		std::string EID::getHost() const noexcept
 		{
 			switch (_scheme_type) {
 			case SCHEME_CBHE:
@@ -525,7 +525,7 @@ namespace dtn
 			}
 		}
 
-		EID EID::getNode() const throw ()
+		EID EID::getNode() const noexcept
 		{
 			switch (_scheme_type) {
 			case SCHEME_CBHE:

--- a/ibrdtn/ibrdtn/ibrdtn/data/EID.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/EID.h
@@ -82,14 +82,14 @@ namespace dtn
 
 			std::string getString() const;
 
-			void setApplication(const dtn::data::Number &app) throw ();
-			void setApplication(const std::string &app) throw ();
-			std::string getApplication() const throw ();
+			void setApplication(const dtn::data::Number &app) noexcept;
+			void setApplication(const std::string &app) noexcept;
+			std::string getApplication() const noexcept;
 
-			bool isApplication(const dtn::data::Number &app) const throw ();
-			bool isApplication(const std::string &app) const throw ();
+			bool isApplication(const dtn::data::Number &app) const noexcept;
+			bool isApplication(const std::string &app) const noexcept;
 
-			std::string getHost() const throw ();
+			std::string getHost() const noexcept;
 			const std::string getScheme() const;
 			const std::string getSSP() const;
 
@@ -99,7 +99,7 @@ namespace dtn
 			 * Return the EID with stripped application part
 			 * @return The EID without any application specific part
 			 */
-			EID getNode() const throw ();
+			EID getNode() const noexcept;
 
 			bool hasApplication() const;
 

--- a/ibrdtn/ibrdtn/ibrdtn/data/Exceptions.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/Exceptions.h
@@ -38,7 +38,7 @@ namespace dtn
 		class InvalidDataException : public ibrcommon::Exception
 		{
 			public:
-				InvalidDataException(string what = "Invalid input data.") throw() : Exception(what)
+				InvalidDataException(string what = "Invalid input data.") noexcept : Exception(what)
 				{
 				};
 		};
@@ -46,7 +46,7 @@ namespace dtn
 		class InvalidProtocolException : public dtn::InvalidDataException
 		{
 		public:
-			InvalidProtocolException(string what = "The received data does not match the protocol.") throw() : dtn::InvalidDataException(what)
+			InvalidProtocolException(string what = "The received data does not match the protocol.") noexcept : dtn::InvalidDataException(what)
 			{
 			};
 		};
@@ -54,7 +54,7 @@ namespace dtn
 		class SerializationFailedException : public dtn::InvalidDataException
 		{
 		public:
-			SerializationFailedException(string what = "The serialization failed.") throw() : dtn::InvalidDataException(what)
+			SerializationFailedException(string what = "The serialization failed.") noexcept : dtn::InvalidDataException(what)
 			{
 			};
 		};
@@ -63,7 +63,7 @@ namespace dtn
 		{
 		public:
 			const size_t length;
-			PayloadReceptionInterrupted(const size_t l, string what = "The payload reception has been interrupted.") throw() : dtn::SerializationFailedException(what), length(l)
+			PayloadReceptionInterrupted(const size_t l, string what = "The payload reception has been interrupted.") noexcept : dtn::SerializationFailedException(what), length(l)
 			{
 			};
 		};
@@ -71,7 +71,7 @@ namespace dtn
 		class MissingObjectException : public ibrcommon::Exception
 		{
 		public:
-			MissingObjectException(string what = "Object not available.") throw() : Exception(what)
+			MissingObjectException(string what = "Object not available.") noexcept : Exception(what)
 			{
 			};
 		};

--- a/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.cpp
@@ -47,7 +47,7 @@ namespace dtn
 			}
 		}
 
-		ExtensionBlock::Factory& ExtensionBlock::FactoryList::get(const block_t type) throw (ibrcommon::Exception)
+		ExtensionBlock::Factory& ExtensionBlock::FactoryList::get(const block_t type) noexcept (false)
 		{
 			std::map<block_t, ExtensionBlock::Factory*>::iterator iter = fmap.find(type);
 
@@ -59,7 +59,7 @@ namespace dtn
 			throw ibrcommon::Exception("Factory not available");
 		}
 
-		void ExtensionBlock::FactoryList::add(const block_t type, Factory *f) throw (ibrcommon::Exception)
+		void ExtensionBlock::FactoryList::add(const block_t type, Factory *f) noexcept (false)
 		{
 			try {
 				get(type);
@@ -86,7 +86,7 @@ namespace dtn
 			ExtensionBlock::factories->remove(_type);
 		}
 
-		ExtensionBlock::Factory& ExtensionBlock::Factory::get(block_t type) throw (ibrcommon::Exception)
+		ExtensionBlock::Factory& ExtensionBlock::Factory::get(block_t type) noexcept (false)
 		{
 			ExtensionBlock::FactoryList::initialize();
 			return ExtensionBlock::factories->get(type);

--- a/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/ExtensionBlock.h
@@ -39,7 +39,7 @@ namespace dtn
 			public:
 				virtual dtn::data::Block* create() = 0;
 
-				static Factory& get(block_t type) throw (ibrcommon::Exception);
+				static Factory& get(block_t type) noexcept (false);
 
 			protected:
 				Factory(block_t type);
@@ -68,8 +68,8 @@ namespace dtn
 				FactoryList();
 				virtual ~FactoryList();
 
-				Factory& get(block_t type) throw (ibrcommon::Exception);
-				void add(block_t type, Factory *f) throw (ibrcommon::Exception);
+				Factory& get(block_t type) noexcept (false);
+				void add(block_t type, Factory *f) noexcept (false);
 				void remove(block_t type);
 
 				static void initialize();

--- a/ibrdtn/ibrdtn/ibrdtn/data/MemoryBundleSet.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/MemoryBundleSet.cpp
@@ -106,7 +106,7 @@ namespace dtn
 			}
 		}
 
-		void MemoryBundleSet::add(const dtn::data::MetaBundle &bundle) throw ()
+		void MemoryBundleSet::add(const dtn::data::MetaBundle &bundle) noexcept
 		{
 			// insert bundle id to the private list
 			pair<bundle_set::iterator,bool> ret = _bundles.insert(bundle);
@@ -118,7 +118,7 @@ namespace dtn
 			bundle.addTo(_bf);
 		}
 
-		void MemoryBundleSet::clear() throw ()
+		void MemoryBundleSet::clear() noexcept
 		{
 			_consistent = true;
 			_bundles.clear();
@@ -126,7 +126,7 @@ namespace dtn
 			_bf.clear();
 		}
 
-		bool MemoryBundleSet::has(const dtn::data::BundleID &bundle) const throw ()
+		bool MemoryBundleSet::has(const dtn::data::BundleID &bundle) const noexcept
 		{
 			// check bloom-filter first
 			if (bundle.isIn(_bf)) {
@@ -141,12 +141,12 @@ namespace dtn
 			return false;
 		}
 
-		Size MemoryBundleSet::size() const throw ()
+		Size MemoryBundleSet::size() const noexcept
 		{
 			return _bundles.size();
 		}
 
-		void MemoryBundleSet::expire(const Timestamp timestamp) throw ()
+		void MemoryBundleSet::expire(const Timestamp timestamp) noexcept
 		{
 			bool commit = false;
 
@@ -186,12 +186,12 @@ namespace dtn
 			}
 		}
 
-		const ibrcommon::BloomFilter& MemoryBundleSet::getBloomFilter() const throw ()
+		const ibrcommon::BloomFilter& MemoryBundleSet::getBloomFilter() const noexcept
 		{
 			return _bf;
 		}
 
-		MemoryBundleSet::bundle_set MemoryBundleSet::getNotIn(const ibrcommon::BloomFilter &filter) const throw ()
+		MemoryBundleSet::bundle_set MemoryBundleSet::getNotIn(const ibrcommon::BloomFilter &filter) const noexcept
 		{
 			bundle_set ret;
 
@@ -210,7 +210,7 @@ namespace dtn
 			return ret;
 		}
 
-		Length MemoryBundleSet::getLength() const throw ()
+		Length MemoryBundleSet::getLength() const noexcept
 		{
 			return dtn::data::Number(_bf.size()).getLength() + _bf.size();
 		}
@@ -258,7 +258,7 @@ namespace dtn
 			}
 		}
 
-		void MemoryBundleSet::sync() throw ()
+		void MemoryBundleSet::sync() noexcept
 		{
 			// store the bundle set to disk
 			store();

--- a/ibrdtn/ibrdtn/ibrdtn/data/MemoryBundleSet.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/MemoryBundleSet.h
@@ -72,42 +72,42 @@ namespace dtn
 			/**
 			 * Add a bundle to the bundle-set
 			 */
-			virtual void add(const dtn::data::MetaBundle &bundle) throw ();
+			virtual void add(const dtn::data::MetaBundle &bundle) noexcept;
 
 			/**
 			 * Clear the whole bundle-set
 			 */
-			virtual void clear() throw ();
+			virtual void clear() noexcept;
 
 			/**
 			 * Check if a bundle id is in this bundle-set
 			 */
-			virtual bool has(const dtn::data::BundleID &bundle) const throw ();
+			virtual bool has(const dtn::data::BundleID &bundle) const noexcept;
 
 			/**
 			 * Check for expired entries in this bundle-set and remove them
 			 */
-			virtual void expire(const Timestamp timestamp) throw ();
+			virtual void expire(const Timestamp timestamp) noexcept;
 
 			/**
 			 * Returns the number of elements in this set
 			 */
-			virtual Size size() const throw ();
+			virtual Size size() const noexcept;
 
 			/**
 			 * Returns the data length of the serialized BundleSet
 			 */
-			Length getLength() const throw ();
+			Length getLength() const noexcept;
 
 			/**
 			 * Get the bloom-filter of this bundle-set
 			 */
-			const ibrcommon::BloomFilter& getBloomFilter() const throw ();
+			const ibrcommon::BloomFilter& getBloomFilter() const noexcept;
 
 			/**
 			 * Return bundles not in the given bloom-filter
 			 */
-			std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const throw ();
+			std::set<dtn::data::MetaBundle> getNotIn(const ibrcommon::BloomFilter &filter) const noexcept;
 
 			/**
 			 * Serialize the bloom-filter of this bundle-set into a stream
@@ -127,7 +127,7 @@ namespace dtn
 			/**
 			 * Synchronize the bundle-set with the persistent set on the disk.
 			 */
-			virtual void sync() throw ();
+			virtual void sync() noexcept;
 
 		private:
             /**

--- a/ibrdtn/ibrdtn/ibrdtn/data/SDNV.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/SDNV.h
@@ -60,7 +60,7 @@ namespace dtn
 		class ValueOutOfRangeException : public dtn::InvalidDataException
 		{
 		public:
-			ValueOutOfRangeException(const std::string &what = "The value is out of range.") throw() : dtn::InvalidDataException(what)
+			ValueOutOfRangeException(const std::string &what = "The value is out of range.") noexcept : dtn::InvalidDataException(what)
 			{
 			};
 		};

--- a/ibrdtn/ibrdtn/ibrdtn/data/Serializer.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/Serializer.cpp
@@ -804,21 +804,21 @@ namespace dtn
 		{
 		}
 
-		void AcceptValidator::validate(const dtn::data::PrimaryBlock&) const throw (RejectedException)
+		void AcceptValidator::validate(const dtn::data::PrimaryBlock&) const noexcept (false)
 		{
 		}
 
-		void AcceptValidator::validate(const dtn::data::Block&, const dtn::data::Number&) const throw (RejectedException)
-		{
-
-		}
-
-		void AcceptValidator::validate(const dtn::data::PrimaryBlock&, const dtn::data::Block&, const dtn::data::Number&) const throw (RejectedException)
+		void AcceptValidator::validate(const dtn::data::Block&, const dtn::data::Number&) const noexcept (false)
 		{
 
 		}
 
-		void AcceptValidator::validate(const dtn::data::Bundle&) const throw (RejectedException)
+		void AcceptValidator::validate(const dtn::data::PrimaryBlock&, const dtn::data::Block&, const dtn::data::Number&) const noexcept (false)
+		{
+
+		}
+
+		void AcceptValidator::validate(const dtn::data::Bundle&) const noexcept (false)
 		{
 
 		}

--- a/ibrdtn/ibrdtn/ibrdtn/data/Serializer.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/Serializer.h
@@ -67,17 +67,17 @@ namespace dtn
 			class RejectedException : public dtn::SerializationFailedException
 			{
 			public:
-				RejectedException(string what = "A validate method has the bundle rejected.") throw() : dtn::SerializationFailedException(what)
+				RejectedException(string what = "A validate method has the bundle rejected.") noexcept : dtn::SerializationFailedException(what)
 				{
 				};
 			};
 
 			virtual ~Validator() {};
 
-			virtual void validate(const dtn::data::PrimaryBlock&) const throw (RejectedException) = 0;
-			virtual void validate(const dtn::data::Block&, const dtn::data::Number&) const throw (RejectedException) = 0;
-			virtual void validate(const dtn::data::PrimaryBlock&, const dtn::data::Block&, const dtn::data::Number&) const throw (RejectedException) = 0;
-			virtual void validate(const dtn::data::Bundle&) const throw (RejectedException) = 0;
+			virtual void validate(const dtn::data::PrimaryBlock&) const noexcept (false) = 0;
+			virtual void validate(const dtn::data::Block&, const dtn::data::Number&) const noexcept (false) = 0;
+			virtual void validate(const dtn::data::PrimaryBlock&, const dtn::data::Block&, const dtn::data::Number&) const noexcept (false) = 0;
+			virtual void validate(const dtn::data::Bundle&) const noexcept (false) = 0;
 		};
 
 		class AcceptValidator : public Validator
@@ -86,10 +86,10 @@ namespace dtn
 			AcceptValidator();
 			virtual ~AcceptValidator();
 
-			virtual void validate(const dtn::data::PrimaryBlock&) const throw (RejectedException);
-			virtual void validate(const dtn::data::Block&, const dtn::data::Number&) const throw (RejectedException);
-			virtual void validate(const dtn::data::PrimaryBlock&, const dtn::data::Block&, const dtn::data::Number&) const throw (RejectedException);
-			virtual void validate(const dtn::data::Bundle&) const throw (RejectedException);
+			virtual void validate(const dtn::data::PrimaryBlock&) const noexcept (false);
+			virtual void validate(const dtn::data::Block&, const dtn::data::Number&) const noexcept (false);
+			virtual void validate(const dtn::data::PrimaryBlock&, const dtn::data::Block&, const dtn::data::Number&) const noexcept (false);
+			virtual void validate(const dtn::data::Bundle&) const noexcept (false);
 		};
 
 		class DefaultSerializer : public Serializer

--- a/ibrdtn/ibrdtn/ibrdtn/data/StatusReportBlock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/data/StatusReportBlock.cpp
@@ -81,7 +81,7 @@ namespace dtn
 			(*stream) << BundleString(bundleid.source.getString());
 		}
 
-		void StatusReportBlock::read(const dtn::data::PayloadBlock &p) throw (WrongRecordException)
+		void StatusReportBlock::read(const dtn::data::PayloadBlock &p) noexcept (false)
 		{
 			ibrcommon::BLOB::Reference r = p.getBLOB();
 			ibrcommon::BLOB::iostream stream = r.iostream();

--- a/ibrdtn/ibrdtn/ibrdtn/data/StatusReportBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/data/StatusReportBlock.h
@@ -61,7 +61,7 @@ namespace dtn
 			StatusReportBlock();
 			virtual ~StatusReportBlock();
 
-			virtual void read(const dtn::data::PayloadBlock &p) throw (WrongRecordException);
+			virtual void read(const dtn::data::PayloadBlock &p) noexcept (false);
 			virtual void write(dtn::data::PayloadBlock &p) const;
 
 			char status;

--- a/ibrdtn/ibrdtn/ibrdtn/security/BundleAuthenticationBlock.cpp
+++ b/ibrdtn/ibrdtn/ibrdtn/security/BundleAuthenticationBlock.cpp
@@ -74,7 +74,7 @@ namespace dtn
 			bab_end._security_result.set(SecurityBlock::integrity_signature, sizehash_hash);
 		}
 
-		void BundleAuthenticationBlock::verify(const dtn::data::Bundle &bundle, const dtn::security::SecurityKey &key) throw (SecurityException)
+		void BundleAuthenticationBlock::verify(const dtn::data::Bundle &bundle, const dtn::security::SecurityKey &key) noexcept (false)
 		{
 			// store the correlator of the verified BABs
 			dtn::data::Number correlator;
@@ -110,7 +110,7 @@ namespace dtn
 			bundle.erase(std::remove(bundle.begin(), bundle.end(), BundleAuthenticationBlock::BLOCK_TYPE), bundle.end());
 		}
 
-		void BundleAuthenticationBlock::verify(const dtn::data::Bundle& bundle, const dtn::security::SecurityKey &key, dtn::data::Number &correlator) throw (SecurityException)
+		void BundleAuthenticationBlock::verify(const dtn::data::Bundle& bundle, const dtn::security::SecurityKey &key, dtn::data::Number &correlator) noexcept (false)
 		{
 			// get the blocks, with which the key should match
 			std::set<dtn::data::Number> correlators;

--- a/ibrdtn/ibrdtn/ibrdtn/security/BundleAuthenticationBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/security/BundleAuthenticationBlock.h
@@ -78,7 +78,7 @@ namespace dtn
 				 * @param bundle
 				 * @param key
 				 */
-				static void verify(const dtn::data::Bundle &bundle, const dtn::security::SecurityKey &key) throw (SecurityException);
+				static void verify(const dtn::data::Bundle &bundle, const dtn::security::SecurityKey &key) noexcept (false);
 
 				/**
 				 * strips verified BABs off the bundle
@@ -126,7 +126,7 @@ namespace dtn
 				the matching pair. otherwise the first is false, if there was no
 				matching
 				*/
-				static void verify(const dtn::data::Bundle& bundle, const dtn::security::SecurityKey &key, dtn::data::Number &correlator) throw (SecurityException);
+				static void verify(const dtn::data::Bundle& bundle, const dtn::security::SecurityKey &key, dtn::data::Number &correlator) noexcept (false);
 
 				/**
 				Returns the size of the security result field. This is used for strict 

--- a/ibrdtn/ibrdtn/ibrdtn/security/SecurityBlock.h
+++ b/ibrdtn/ibrdtn/ibrdtn/security/SecurityBlock.h
@@ -46,7 +46,7 @@ namespace dtn
 			SecurityException(std::string what = "security has been violated") : ibrcommon::Exception(what)
 			{};
 
-			virtual ~SecurityException() throw() {};
+			virtual ~SecurityException() noexcept {};
 		};
 
 		class EncryptException : public SecurityException
@@ -55,7 +55,7 @@ namespace dtn
 			EncryptException(std::string what = "Encryption failed.") : SecurityException(what)
 			{};
 
-			virtual ~EncryptException() throw() {};
+			virtual ~EncryptException() noexcept {};
 		};
 
 		class DecryptException : public SecurityException
@@ -64,7 +64,7 @@ namespace dtn
 			DecryptException(std::string what = "Decryption failed.") : SecurityException(what)
 			{};
 
-			virtual ~DecryptException() throw() {};
+			virtual ~DecryptException() noexcept {};
 		};
 
 		class VerificationSkippedException : public SecurityException
@@ -73,7 +73,7 @@ namespace dtn
 			VerificationSkippedException(std::string what = "Verification skipped.") : SecurityException(what)
 			{};
 
-			virtual ~VerificationSkippedException() throw() {};
+			virtual ~VerificationSkippedException() noexcept {};
 		};
 
 		class VerificationFailedException : public SecurityException
@@ -82,7 +82,7 @@ namespace dtn
 			VerificationFailedException(std::string what = "Verification failed.") : SecurityException(what)
 			{};
 
-			virtual ~VerificationFailedException() throw() {};
+			virtual ~VerificationFailedException() noexcept {};
 		};
 
 		class ElementMissingException : public ibrcommon::Exception
@@ -91,7 +91,7 @@ namespace dtn
 			ElementMissingException(std::string what = "Requested element is missing.") : ibrcommon::Exception(what)
 			{};
 
-			virtual ~ElementMissingException() throw() {};
+			virtual ~ElementMissingException() noexcept {};
 		};
 
 		class MutableSerializer;

--- a/ibrdtn/ibrdtn/ibrdtn/security/SecurityKey.h
+++ b/ibrdtn/ibrdtn/ibrdtn/security/SecurityKey.h
@@ -61,7 +61,7 @@ namespace dtn
 				KeyNotFoundException(std::string what = "Requested key not found.") : ibrcommon::Exception(what)
 				{};
 
-				virtual ~KeyNotFoundException() throw() {};
+				virtual ~KeyNotFoundException() noexcept {};
 			};
 
 			SecurityKey();

--- a/ibrdtn/ibrdtn/ibrdtn/streams/StreamConnection.h
+++ b/ibrdtn/ibrdtn/ibrdtn/streams/StreamConnection.h
@@ -56,12 +56,12 @@ namespace dtn
 			class TransmissionInterruptedException : public ibrcommon::IOException
 			{
 				public:
-					TransmissionInterruptedException(const dtn::data::Bundle &bundle, const dtn::data::Length &position) throw()
+					TransmissionInterruptedException(const dtn::data::Bundle &bundle, const dtn::data::Length &position) noexcept
 					 : ibrcommon::IOException("Transmission was interrupted."), _bundle(bundle), _position(position)
 					{
 					};
 
-					virtual ~TransmissionInterruptedException() throw ()
+					virtual ~TransmissionInterruptedException() noexcept
 					{
 					};
 
@@ -72,7 +72,7 @@ namespace dtn
 			class StreamClosedException : public ibrcommon::IOException
 			{
 			public:
-				StreamClosedException(string what = "The stream has been closed.") throw() : IOException(what)
+				StreamClosedException(string what = "The stream has been closed.") noexcept : IOException(what)
 				{
 				};
 			};
@@ -80,7 +80,7 @@ namespace dtn
 			class StreamErrorException : public ibrcommon::IOException
 			{
 			public:
-				StreamErrorException(string what = "StreamError") throw() : IOException(what)
+				StreamErrorException(string what = "StreamError") noexcept : IOException(what)
 				{
 				};
 			};
@@ -88,7 +88,7 @@ namespace dtn
 			class StreamShutdownException : public ibrcommon::IOException
 			{
 			public:
-				StreamShutdownException(string what = "Shutdown message received.") throw() : IOException(what)
+				StreamShutdownException(string what = "Shutdown message received.") noexcept : IOException(what)
 				{
 				};
 			};
@@ -100,52 +100,52 @@ namespace dtn
 				 * This method is called if a SHUTDOWN message is
 				 * received.
 				 */
-				virtual void eventShutdown(StreamConnection::ConnectionShutdownCases csc) throw () = 0;
+				virtual void eventShutdown(StreamConnection::ConnectionShutdownCases csc) noexcept = 0;
 
 				/**
 				 * This method is called if the stream is closed
 				 * by a TIMEOUT.
 				 */
-				virtual void eventTimeout() throw () = 0;
+				virtual void eventTimeout() noexcept = 0;
 
 				/**
 				 * This method is called if a error occured in the stream.
 				 */
-				virtual void eventError() throw () = 0;
+				virtual void eventError() noexcept = 0;
 
 				/**
 				 * This method is called if a bundle is refused by the peer.
 				 */
-				virtual void eventBundleRefused() throw () = 0;
+				virtual void eventBundleRefused() noexcept = 0;
 				/**
 				 * This method is called if a bundle is refused by the peer.
 				 */
-				virtual void eventBundleForwarded() throw () = 0;
+				virtual void eventBundleForwarded() noexcept = 0;
 				/**
 				 * This method is called if a ACK is received.
 				 */
-				virtual void eventBundleAck(const dtn::data::Length &ack) throw () = 0;
+				virtual void eventBundleAck(const dtn::data::Length &ack) noexcept = 0;
 
 				/**
 				 * This method is called if a handshake was successful.
 				 * @param header
 				 */
-				virtual void eventConnectionUp(const StreamContactHeader &header) throw () = 0;
+				virtual void eventConnectionUp(const StreamContactHeader &header) noexcept = 0;
 
 				/**
 				 * This method is called if a connection went down.
 				 */
-				virtual void eventConnectionDown() throw () = 0;
+				virtual void eventConnectionDown() noexcept = 0;
 
 				/**
 				 * Reports inbound traffic amount
 				 */
-				virtual void addTrafficIn(size_t) throw () { };
+				virtual void addTrafficIn(size_t) noexcept { };
 
 				/**
 				 * Reports outbound traffic amount
 				 */
-				virtual void addTrafficOut(size_t) throw () { };
+				virtual void addTrafficOut(size_t) noexcept { };
 			};
 
 			/**

--- a/ibrdtn/ibrdtn/tests/data/TestBundleList.cpp
+++ b/ibrdtn/ibrdtn/tests/data/TestBundleList.cpp
@@ -46,7 +46,7 @@ TestBundleList::ExpiredBundleCounter::~ExpiredBundleCounter()
 {
 }
 
-void TestBundleList::ExpiredBundleCounter::eventBundleExpired(const dtn::data::MetaBundle&) throw ()
+void TestBundleList::ExpiredBundleCounter::eventBundleExpired(const dtn::data::MetaBundle&) noexcept
 {
 	//std::cout << "Bundle expired " << b.bundle.toString() << std::endl;
 	counter++;

--- a/ibrdtn/ibrdtn/tests/data/TestBundleList.h
+++ b/ibrdtn/ibrdtn/tests/data/TestBundleList.h
@@ -49,7 +49,7 @@ private:
 		ExpiredBundleCounter();
 		virtual ~ExpiredBundleCounter();
 
-		void eventBundleExpired(const dtn::data::MetaBundle &b) throw ();
+		void eventBundleExpired(const dtn::data::MetaBundle &b) noexcept;
 		int counter;
 	};
 

--- a/ibrdtn/ibrdtn/tests/data/TestBundleSet.cpp
+++ b/ibrdtn/ibrdtn/tests/data/TestBundleSet.cpp
@@ -47,7 +47,7 @@ TestBundleSet::ExpiredBundleCounter::~ExpiredBundleCounter()
 {
 }
 
-void TestBundleSet::ExpiredBundleCounter::eventBundleExpired(const dtn::data::MetaBundle&) throw ()
+void TestBundleSet::ExpiredBundleCounter::eventBundleExpired(const dtn::data::MetaBundle&) noexcept
 {
 	//std::cout << "Bundle expired " << b.bundle.toString() << std::endl;
 	counter++;

--- a/ibrdtn/ibrdtn/tests/data/TestBundleSet.h
+++ b/ibrdtn/ibrdtn/tests/data/TestBundleSet.h
@@ -50,7 +50,7 @@ private:
 		ExpiredBundleCounter();
 		virtual ~ExpiredBundleCounter();
 
-		void eventBundleExpired(const dtn::data::MetaBundle &b) throw ();
+		void eventBundleExpired(const dtn::data::MetaBundle &b) noexcept;
 		int counter;
 	};
 

--- a/ibrdtn/ibrdtn/tests/net/TestStreamConnection.cpp
+++ b/ibrdtn/ibrdtn/tests/net/TestStreamConnection.cpp
@@ -64,27 +64,27 @@ void TestStreamConnection::connectionUpDown()
 			_sockets.destroy();
 		};
 
-		void __cancellation() throw () {
+		void __cancellation() noexcept {
 			_running = false;
 			_sockets.down();
 		}
 
-		void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) throw () {};
-		void eventTimeout() throw () {};
-		void eventError() throw () {};
-		void eventBundleRefused() throw () {};
-		void eventBundleForwarded() throw () {};
-		void eventBundleAck(const dtn::data::Length &ack) throw ()
+		void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) noexcept {};
+		void eventTimeout() noexcept {};
+		void eventError() noexcept {};
+		void eventBundleRefused() noexcept {};
+		void eventBundleForwarded() noexcept {};
+		void eventBundleAck(const dtn::data::Length &ack) noexcept
 		{
 			std::cout << "server: ack received, value: " << ack << std::endl;
 		};
-		void eventConnectionUp(const dtn::streams::StreamContactHeader&) throw () {};
-		void eventConnectionDown() throw () {};
+		void eventConnectionUp(const dtn::streams::StreamContactHeader&) noexcept {};
+		void eventConnectionDown() noexcept {};
 
 		unsigned int recv_bundles;
 
 	protected:
-		void run() throw ()
+		void run() noexcept
 		{
 			ibrcommon::vaddress peeraddr;
 
@@ -142,23 +142,23 @@ void TestStreamConnection::connectionUpDown()
 			join();
 		};
 
-		void __cancellation() throw () {
+		void __cancellation() noexcept {
 			_stream.shutdown(dtn::streams::StreamConnection::CONNECTION_SHUTDOWN_ERROR);
 			_client.close();
 		}
 
-		void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) throw () {};
-		void eventTimeout() throw () {};
-		void eventError() throw () {};
-		void eventBundleRefused() throw () {};
-		void eventBundleForwarded() throw () {};
-		void eventBundleAck(const dtn::data::Length &ack) throw ()
+		void eventShutdown(dtn::streams::StreamConnection::ConnectionShutdownCases) noexcept {};
+		void eventTimeout() noexcept {};
+		void eventError() noexcept {};
+		void eventBundleRefused() noexcept {};
+		void eventBundleForwarded() noexcept {};
+		void eventBundleAck(const dtn::data::Length &ack) noexcept
 		{
 			// std::cout << "client: ack received, value: " << ack << std::endl;
 		};
 
-		void eventConnectionUp(const dtn::streams::StreamContactHeader&) throw () {};
-		void eventConnectionDown() throw () {};
+		void eventConnectionUp(const dtn::streams::StreamContactHeader&) noexcept {};
+		void eventConnectionDown() noexcept {};
 
 		void handshake()
 		{
@@ -202,7 +202,7 @@ void TestStreamConnection::connectionUpDown()
 		}
 
 	protected:
-		void run() throw ()
+		void run() noexcept
 		{
 			try {
 				while (_client.good())

--- a/ibrdtn/tools/src/io/FatImageReader.cpp
+++ b/ibrdtn/tools/src/io/FatImageReader.cpp
@@ -33,7 +33,7 @@ namespace io
 	{
 	}
 
-	FatImageReader::FatImageException::~FatImageException() throw ()
+	FatImageReader::FatImageException::~FatImageException() noexcept
 	{
 	}
 
@@ -58,7 +58,7 @@ namespace io
 	{
 	}
 
-	bool FatImageReader::isDirectory(const FATFile &file) const throw ()
+	bool FatImageReader::isDirectory(const FATFile &file) const noexcept
 	{
 		try {
 			if (file.isRoot()) return true;
@@ -71,7 +71,7 @@ namespace io
 		}
 	}
 
-	size_t FatImageReader::size(const FATFile &file) const throw ()
+	size_t FatImageReader::size(const FATFile &file) const noexcept
 	{
 		try {
 			if (file.isRoot()) return 0;
@@ -84,7 +84,7 @@ namespace io
 		}
 	}
 
-	time_t FatImageReader::lastaccess(const FATFile &file) const throw ()
+	time_t FatImageReader::lastaccess(const FATFile &file) const noexcept
 	{
 		try {
 			if (file.isRoot()) return 0;
@@ -105,7 +105,7 @@ namespace io
 		}
 	}
 
-	bool FatImageReader::exists(const FATFile &file) const throw ()
+	bool FatImageReader::exists(const FATFile &file) const noexcept
 	{
 		try {
 			dirent_t d;
@@ -116,7 +116,7 @@ namespace io
 		}
 	}
 
-	void FatImageReader::update(const FATFile &path, dirent_t &d) const throw (ibrcommon::IOException)
+	void FatImageReader::update(const FATFile &path, dirent_t &d) const noexcept (false)
 	{
 		int ret = 0;
 		tdir_handle_t hdir;
@@ -173,13 +173,13 @@ namespace io
 		}
 	}
 
-	void FatImageReader::list(filelist &files) const throw (FatImageException)
+	void FatImageReader::list(filelist &files) const noexcept (false)
 	{
 		FATFile root(*this, "/");
 		list(root, files);
 	}
 
-	void FatImageReader::list(const FATFile &directory, filelist &files) const throw (FatImageException)
+	void FatImageReader::list(const FATFile &directory, filelist &files) const noexcept (false)
 	{
 		int ret = 0;
 		tdir_handle_t hdir;

--- a/ibrdtn/tools/src/io/FatImageReader.h
+++ b/ibrdtn/tools/src/io/FatImageReader.h
@@ -41,7 +41,7 @@ namespace io
 		{
 		public:
 			FatImageException(int errcode, const std::string &operation, const ibrcommon::File &file);
-			virtual ~FatImageException() throw ();
+			virtual ~FatImageException() noexcept;
 
 			int getErrorCode() const;
 
@@ -72,21 +72,21 @@ namespace io
 
 		typedef std::list<FATFile> filelist;
 
-		void list(filelist &files) const throw (FatImageException);
-		void list(const FATFile &directory, filelist &files) const throw (FatImageException);
+		void list(filelist &files) const noexcept (false);
+		void list(const FATFile &directory, filelist &files) const noexcept (false);
 
-		bool exists(const FATFile &file) const throw ();
+		bool exists(const FATFile &file) const noexcept;
 
-		time_t lastaccess(const FATFile &file) const throw ();
+		time_t lastaccess(const FATFile &file) const noexcept;
 
-		size_t size(const FATFile &file) const throw ();
+		size_t size(const FATFile &file) const noexcept;
 
-		bool isDirectory(const FATFile &file) const throw ();
+		bool isDirectory(const FATFile &file) const noexcept;
 
 		FileHandle open(const FATFile &file) const;
 
 	private:
-		void update(const FATFile &path, dirent_t &d) const throw (ibrcommon::IOException);
+		void update(const FATFile &path, dirent_t &d) const noexcept (false);
 
 		const static std::string TAG;
 


### PR DESCRIPTION
Preparation for future versions of c++ (c++17 and higher, deprecated since c++11)
See: https://en.cppreference.com/w/cpp/language/noexcept_spec and https://en.cppreference.com/w/cpp/language/except_spec

Most of the work was done by regex: throw\s\(.{2,85}\) replace by noexcept (false) and throw?\(\) replace by noexcept. Checked all occurrences by hand and build passes on linux (20 LTS)